### PR TITLE
apply clang-format to all source files

### DIFF
--- a/examples/common/golioth_basics.c
+++ b/examples/common/golioth_basics.c
@@ -51,7 +51,7 @@ static golioth_settings_status_t on_setting(
         }
 
         // Setting has passed all checks, so apply it to the loop delay
-        GLTH_LOGI(TAG, "Setting loop delay to %"PRId32" s", value->i32);
+        GLTH_LOGI(TAG, "Setting loop delay to %" PRId32 " s", value->i32);
         _loop_delay_s = value->i32;
         return GOLIOTH_SETTINGS_SUCCESS;
     }
@@ -90,7 +90,7 @@ static void on_get_my_int(
 
     // Now we can use a helper function to convert the binary payload to an integer.
     int32_t value = golioth_payload_as_int(payload, payload_size);
-    GLTH_LOGI(TAG, "Callback got my_int = %"PRId32, value);
+    GLTH_LOGI(TAG, "Callback got my_int = %" PRId32, value);
 }
 
 // Callback function for asynchronous observation of LightDB path "desired/my_config"
@@ -111,7 +111,7 @@ static void on_my_config(
     }
 
     int32_t desired_value = golioth_payload_as_int(payload, payload_size);
-    GLTH_LOGI(TAG, "Cloud desires %s = %"PRId32". Setting now.", path, desired_value);
+    GLTH_LOGI(TAG, "Cloud desires %s = %" PRId32 ". Setting now.", path, desired_value);
     _my_config = desired_value;
     golioth_lightdb_delete_async(client, path, NULL, NULL);
 }
@@ -178,7 +178,7 @@ void golioth_basics(golioth_client_t client) {
     int32_t readback_int = 0;
     status = golioth_lightdb_get_int_sync(client, "my_int", &readback_int, 5);
     if (status == GOLIOTH_OK) {
-        GLTH_LOGI(TAG, "Synchronously got my_int = %"PRId32, readback_int);
+        GLTH_LOGI(TAG, "Synchronously got my_int = %" PRId32, readback_int);
     } else {
         GLTH_LOGE(TAG, "Synchronous get my_int failed: %s", golioth_status_to_str(status));
     }
@@ -227,7 +227,7 @@ void golioth_basics(golioth_client_t client) {
     char sbuf[32];
     while (1) {
         golioth_lightdb_set_int_async(client, "counter", counter, NULL, NULL);
-        snprintf(sbuf, sizeof(sbuf), "Sending hello! %"PRId32, counter);
+        snprintf(sbuf, sizeof(sbuf), "Sending hello! %" PRId32, counter);
         golioth_log_info_async(client, "app_main", sbuf, NULL, NULL);
         counter++;
         vTaskDelay(_loop_delay_s * 1000 / portTICK_PERIOD_MS);

--- a/examples/esp_idf/common/wifi.c
+++ b/examples/esp_idf/common/wifi.c
@@ -29,8 +29,11 @@ static int s_retry_num = 0;
 const char* _ssid;
 const char* _password;
 
-static void
-event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data) {
+static void event_handler(
+        void* arg,
+        esp_event_base_t event_base,
+        int32_t event_id,
+        void* event_data) {
     if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
         esp_wifi_connect();
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {

--- a/examples/modus_toolbox/golioth_basics/golioth_app/source/cy_flash_map.h
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/source/cy_flash_map.h
@@ -2,29 +2,17 @@
 /* Platform: PSOC_062_2M */
 
 static struct flash_area flash_areas[] = {
-    {
-        .fa_id        = FLASH_AREA_BOOTLOADER,
-        .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH,
-        .fa_off       = 0x0U,
-        .fa_size      = 0x18000U
-    },
-    {
-        .fa_id        = FLASH_AREA_IMG_1_PRIMARY,
-        .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH,
-        .fa_off       = 0x18000U,
-        .fa_size      = 0x1c0000U
-    },
-    {
-        .fa_id        = FLASH_AREA_IMG_1_SECONDARY,
-        .fa_device_id = FLASH_DEVICE_EXTERNAL_FLASH(CY_BOOT_EXTERNAL_DEVICE_INDEX),
-        .fa_off       = 0x0U,
-        .fa_size      = 0x1c0000U
-    }
-};
+        {.fa_id = FLASH_AREA_BOOTLOADER,
+         .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH,
+         .fa_off = 0x0U,
+         .fa_size = 0x18000U},
+        {.fa_id = FLASH_AREA_IMG_1_PRIMARY,
+         .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH,
+         .fa_off = 0x18000U,
+         .fa_size = 0x1c0000U},
+        {.fa_id = FLASH_AREA_IMG_1_SECONDARY,
+         .fa_device_id = FLASH_DEVICE_EXTERNAL_FLASH(CY_BOOT_EXTERNAL_DEVICE_INDEX),
+         .fa_off = 0x0U,
+         .fa_size = 0x1c0000U}};
 
-struct flash_area *boot_area_descs[] = {
-    &flash_areas[0U],
-    &flash_areas[1U],
-    &flash_areas[2U],
-    NULL
-};
+struct flash_area* boot_area_descs[] = {&flash_areas[0U], &flash_areas[1U], &flash_areas[2U], NULL};

--- a/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.c
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.c
@@ -1,41 +1,41 @@
 /******************************************************************************
-* File Name:   golioth_main.c
-*
-* Description: This file contains task and functions related to Golioth main
-*              operation.
-*
-********************************************************************************
-* Copyright 2020-2021, Cypress Semiconductor Corporation (an Infineon company) or
-* an affiliate of Cypress Semiconductor Corporation.  All rights reserved.
-*
-* This software, including source code, documentation and related
-* materials ("Software") is owned by Cypress Semiconductor Corporation
-* or one of its affiliates ("Cypress") and is protected by and subject to
-* worldwide patent protection (United States and foreign),
-* United States copyright laws and international treaty provisions.
-* Therefore, you may use this Software only as provided in the license
-* agreement accompanying the software package from which you
-* obtained this Software ("EULA").
-* If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
-* non-transferable license to copy, modify, and compile the Software
-* source code solely for use in connection with Cypress's
-* integrated circuit products.  Any reproduction, modification, translation,
-* compilation, or representation of this Software except as specified
-* above is prohibited without the express written permission of Cypress.
-*
-* Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
-* EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
-* reserves the right to make changes to the Software without notice. Cypress
-* does not assume any liability arising out of the application or use of the
-* Software or any product or circuit described in the Software. Cypress does
-* not authorize its products for use in any products where a malfunction or
-* failure of the Cypress product may reasonably be expected to result in
-* significant property damage, injury or death ("High Risk Product"). By
-* including Cypress's product in a High Risk Product, the manufacturer
-* of such system or application assumes all risk of such use and in doing
-* so agrees to indemnify Cypress against all liability.
-*******************************************************************************/
+ * File Name:   golioth_main.c
+ *
+ * Description: This file contains task and functions related to Golioth main
+ *              operation.
+ *
+ ********************************************************************************
+ * Copyright 2020-2021, Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation.  All rights reserved.
+ *
+ * This software, including source code, documentation and related
+ * materials ("Software") is owned by Cypress Semiconductor Corporation
+ * or one of its affiliates ("Cypress") and is protected by and subject to
+ * worldwide patent protection (United States and foreign),
+ * United States copyright laws and international treaty provisions.
+ * Therefore, you may use this Software only as provided in the license
+ * agreement accompanying the software package from which you
+ * obtained this Software ("EULA").
+ * If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
+ * non-transferable license to copy, modify, and compile the Software
+ * source code solely for use in connection with Cypress's
+ * integrated circuit products.  Any reproduction, modification, translation,
+ * compilation, or representation of this Software except as specified
+ * above is prohibited without the express written permission of Cypress.
+ *
+ * Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
+ * reserves the right to make changes to the Software without notice. Cypress
+ * does not assume any liability arising out of the application or use of the
+ * Software or any product or circuit described in the Software. Cypress does
+ * not authorize its products for use in any products where a malfunction or
+ * failure of the Cypress product may reasonably be expected to result in
+ * significant property damage, injury or death ("High Risk Product"). By
+ * including Cypress's product in a High Risk Product, the manufacturer
+ * of such system or application assumes all risk of such use and in doing
+ * so agrees to indemnify Cypress against all liability.
+ *******************************************************************************/
 
 /* Header file includes. */
 #include "cyhal.h"
@@ -69,50 +69,50 @@
  *  configured number of times until the connection succeeds.
  *
  *******************************************************************************/
-cy_rslt_t connect_to_wifi_ap(void)
-{
+cy_rslt_t connect_to_wifi_ap(void) {
     cy_rslt_t result;
 
     /* Variables used by Wi-Fi connection manager.*/
     cy_wcm_connect_params_t wifi_conn_param;
 
-    cy_wcm_config_t wifi_config = { .interface = CY_WCM_INTERFACE_TYPE_STA };
+    cy_wcm_config_t wifi_config = {.interface = CY_WCM_INTERFACE_TYPE_STA};
 
     cy_wcm_ip_address_t ip_address;
 
-     /* Initialize Wi-Fi connection manager. */
+    /* Initialize Wi-Fi connection manager. */
     result = cy_wcm_init(&wifi_config);
 
-    if (result != CY_RSLT_SUCCESS)
-    {
+    if (result != CY_RSLT_SUCCESS) {
         printf("Wi-Fi Connection Manager initialization failed!\n");
         return result;
     }
     printf("Wi-Fi Connection Manager initialized.\r\n");
 
-     /* Set the Wi-Fi SSID, password and security type. */
+    /* Set the Wi-Fi SSID, password and security type. */
     memset(&wifi_conn_param, 0, sizeof(cy_wcm_connect_params_t));
     memcpy(wifi_conn_param.ap_credentials.SSID, WIFI_SSID, sizeof(WIFI_SSID));
     memcpy(wifi_conn_param.ap_credentials.password, WIFI_PASSWORD, sizeof(WIFI_PASSWORD));
     wifi_conn_param.ap_credentials.security = WIFI_SECURITY_TYPE;
 
     /* Join the Wi-Fi AP. */
-    for(uint32_t conn_retries = 0; conn_retries < MAX_WIFI_CONN_RETRIES; conn_retries++ )
-    {
+    for (uint32_t conn_retries = 0; conn_retries < MAX_WIFI_CONN_RETRIES; conn_retries++) {
         result = cy_wcm_connect_ap(&wifi_conn_param, &ip_address);
 
-        if(result == CY_RSLT_SUCCESS)
-        {
+        if (result == CY_RSLT_SUCCESS) {
             printf("Successfully connected to Wi-Fi network '%s'.\n",
-                                wifi_conn_param.ap_credentials.SSID);
-            printf("IP Address Assigned: %d.%d.%d.%d\n", (uint8)ip_address.ip.v4,
-                    (uint8)(ip_address.ip.v4 >> 8), (uint8)(ip_address.ip.v4 >> 16),
-                    (uint8)(ip_address.ip.v4 >> 24));
+                   wifi_conn_param.ap_credentials.SSID);
+            printf("IP Address Assigned: %d.%d.%d.%d\n",
+                   (uint8)ip_address.ip.v4,
+                   (uint8)(ip_address.ip.v4 >> 8),
+                   (uint8)(ip_address.ip.v4 >> 16),
+                   (uint8)(ip_address.ip.v4 >> 24));
             return result;
         }
 
         printf("Connection to Wi-Fi network failed with error code %d."
-               "Retrying in %d ms...\n", (int)result, WIFI_CONN_RETRY_INTERVAL_MSEC);
+               "Retrying in %d ms...\n",
+               (int)result,
+               WIFI_CONN_RETRY_INTERVAL_MSEC);
 
         vTaskDelay(pdMS_TO_TICKS(WIFI_CONN_RETRY_INTERVAL_MSEC));
     }
@@ -123,9 +123,9 @@ cy_rslt_t connect_to_wifi_ap(void)
     return result;
 }
 
-void golioth_main_task(void *arg) {
+void golioth_main_task(void* arg) {
     /* Connect to Wi-Fi AP */
-    if(connect_to_wifi_ap() != CY_RSLT_SUCCESS) {
+    if (connect_to_wifi_ap() != CY_RSLT_SUCCESS) {
         printf("\n Failed to connect to Wi-FI AP.\n");
         CY_ASSERT(0);
     }

--- a/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.h
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.h
@@ -1,48 +1,48 @@
 /******************************************************************************
-* File Name:   golioth_main.h
-*
-* Description: This file contains declaration of task related to Golioth main
-*              operation.
-*
-********************************************************************************
-* Copyright 2020-2021, Cypress Semiconductor Corporation (an Infineon company) or
-* an affiliate of Cypress Semiconductor Corporation.  All rights reserved.
-*
-* This software, including source code, documentation and related
-* materials ("Software") is owned by Cypress Semiconductor Corporation
-* or one of its affiliates ("Cypress") and is protected by and subject to
-* worldwide patent protection (United States and foreign),
-* United States copyright laws and international treaty provisions.
-* Therefore, you may use this Software only as provided in the license
-* agreement accompanying the software package from which you
-* obtained this Software ("EULA").
-* If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
-* non-transferable license to copy, modify, and compile the Software
-* source code solely for use in connection with Cypress's
-* integrated circuit products.  Any reproduction, modification, translation,
-* compilation, or representation of this Software except as specified
-* above is prohibited without the express written permission of Cypress.
-*
-* Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
-* EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
-* reserves the right to make changes to the Software without notice. Cypress
-* does not assume any liability arising out of the application or use of the
-* Software or any product or circuit described in the Software. Cypress does
-* not authorize its products for use in any products where a malfunction or
-* failure of the Cypress product may reasonably be expected to result in
-* significant property damage, injury or death ("High Risk Product"). By
-* including Cypress's product in a High Risk Product, the manufacturer
-* of such system or application assumes all risk of such use and in doing
-* so agrees to indemnify Cypress against all liability.
-*******************************************************************************/
+ * File Name:   golioth_main.h
+ *
+ * Description: This file contains declaration of task related to Golioth main
+ *              operation.
+ *
+ ********************************************************************************
+ * Copyright 2020-2021, Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation.  All rights reserved.
+ *
+ * This software, including source code, documentation and related
+ * materials ("Software") is owned by Cypress Semiconductor Corporation
+ * or one of its affiliates ("Cypress") and is protected by and subject to
+ * worldwide patent protection (United States and foreign),
+ * United States copyright laws and international treaty provisions.
+ * Therefore, you may use this Software only as provided in the license
+ * agreement accompanying the software package from which you
+ * obtained this Software ("EULA").
+ * If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
+ * non-transferable license to copy, modify, and compile the Software
+ * source code solely for use in connection with Cypress's
+ * integrated circuit products.  Any reproduction, modification, translation,
+ * compilation, or representation of this Software except as specified
+ * above is prohibited without the express written permission of Cypress.
+ *
+ * Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
+ * reserves the right to make changes to the Software without notice. Cypress
+ * does not assume any liability arising out of the application or use of the
+ * Software or any product or circuit described in the Software. Cypress does
+ * not authorize its products for use in any products where a malfunction or
+ * failure of the Cypress product may reasonably be expected to result in
+ * significant property damage, injury or death ("High Risk Product"). By
+ * including Cypress's product in a High Risk Product, the manufacturer
+ * of such system or application assumes all risk of such use and in doing
+ * so agrees to indemnify Cypress against all liability.
+ *******************************************************************************/
 
 #ifndef GOLIOTH_MAIN_H_
 #define GOLIOTH_MAIN_H_
 
 /*******************************************************************************
-* Macros
-********************************************************************************/
+ * Macros
+ ********************************************************************************/
 /* Wi-Fi Credentials: Modify WIFI_SSID, WIFI_PASSWORD and WIFI_SECURITY_TYPE
  * to match your Wi-Fi network credentials.
  * Note: Maximum length of the Wi-Fi SSID and password is set to
@@ -63,18 +63,18 @@
 /* Security type of the Wi-Fi access point. See 'cy_wcm_security_t' structure
  * in "cy_wcm.h" for more details.
  */
-#define WIFI_SECURITY_TYPE                 CY_WCM_SECURITY_WPA2_AES_PSK
+#define WIFI_SECURITY_TYPE CY_WCM_SECURITY_WPA2_AES_PSK
 
 /* Maximum number of connection retries to the Wi-Fi network. */
-#define MAX_WIFI_CONN_RETRIES             (10u)
+#define MAX_WIFI_CONN_RETRIES (10u)
 
 /* Wi-Fi re-connection time interval in milliseconds */
-#define WIFI_CONN_RETRY_INTERVAL_MSEC     (1000)
+#define WIFI_CONN_RETRY_INTERVAL_MSEC (1000)
 
 /*******************************************************************************
-* Function Prototype
-********************************************************************************/
-void golioth_main_task(void *arg);
+ * Function Prototype
+ ********************************************************************************/
+void golioth_main_task(void* arg);
 
 #endif /* GOLIOTH_MAIN_H_ */
 

--- a/examples/modus_toolbox/golioth_basics/golioth_app/source/main.c
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/source/main.c
@@ -1,43 +1,43 @@
 /******************************************************************************
-* File Name:   main.c
-*
-* Description: This is the source code for the CE230650 - PSoC 6 MCU: MCUboot-
-*              Based Basic Bootloader code example for ModusToolbox.
-*
-* Related Document: See README.md
-*
-*******************************************************************************
-* Copyright 2020-2022, Cypress Semiconductor Corporation (an Infineon company) or
-* an affiliate of Cypress Semiconductor Corporation.  All rights reserved.
-*
-* This software, including source code, documentation and related
-* materials ("Software") is owned by Cypress Semiconductor Corporation
-* or one of its affiliates ("Cypress") and is protected by and subject to
-* worldwide patent protection (United States and foreign),
-* United States copyright laws and international treaty provisions.
-* Therefore, you may use this Software only as provided in the license
-* agreement accompanying the software package from which you
-* obtained this Software ("EULA").
-* If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
-* non-transferable license to copy, modify, and compile the Software
-* source code solely for use in connection with Cypress's
-* integrated circuit products.  Any reproduction, modification, translation,
-* compilation, or representation of this Software except as specified
-* above is prohibited without the express written permission of Cypress.
-*
-* Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
-* EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
-* reserves the right to make changes to the Software without notice. Cypress
-* does not assume any liability arising out of the application or use of the
-* Software or any product or circuit described in the Software. Cypress does
-* not authorize its products for use in any products where a malfunction or
-* failure of the Cypress product may reasonably be expected to result in
-* significant property damage, injury or death ("High Risk Product"). By
-* including Cypress's product in a High Risk Product, the manufacturer
-* of such system or application assumes all risk of such use and in doing
-* so agrees to indemnify Cypress against all liability.
-*******************************************************************************/
+ * File Name:   main.c
+ *
+ * Description: This is the source code for the CE230650 - PSoC 6 MCU: MCUboot-
+ *              Based Basic Bootloader code example for ModusToolbox.
+ *
+ * Related Document: See README.md
+ *
+ *******************************************************************************
+ * Copyright 2020-2022, Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation.  All rights reserved.
+ *
+ * This software, including source code, documentation and related
+ * materials ("Software") is owned by Cypress Semiconductor Corporation
+ * or one of its affiliates ("Cypress") and is protected by and subject to
+ * worldwide patent protection (United States and foreign),
+ * United States copyright laws and international treaty provisions.
+ * Therefore, you may use this Software only as provided in the license
+ * agreement accompanying the software package from which you
+ * obtained this Software ("EULA").
+ * If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
+ * non-transferable license to copy, modify, and compile the Software
+ * source code solely for use in connection with Cypress's
+ * integrated circuit products.  Any reproduction, modification, translation,
+ * compilation, or representation of this Software except as specified
+ * above is prohibited without the express written permission of Cypress.
+ *
+ * Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
+ * reserves the right to make changes to the Software without notice. Cypress
+ * does not assume any liability arising out of the application or use of the
+ * Software or any product or circuit described in the Software. Cypress does
+ * not authorize its products for use in any products where a malfunction or
+ * failure of the Cypress product may reasonably be expected to result in
+ * significant property damage, injury or death ("High Risk Product"). By
+ * including Cypress's product in a High Risk Product, the manufacturer
+ * of such system or application assumes all risk of such use and in doing
+ * so agrees to indemnify Cypress against all liability.
+ *******************************************************************************/
 
 #include "cybsp.h"
 #include "cyhal.h"
@@ -52,19 +52,18 @@
 #include "flash_qspi.h"
 #endif
 
-#define QSPI_SLAVE_SELECT_LINE              (1UL)
+#define QSPI_SLAVE_SELECT_LINE (1UL)
 
-#define LED_TOGGLE_INTERVAL_MS              (1000u)
+#define LED_TOGGLE_INTERVAL_MS (1000u)
 
-#define BLINK_TASK_STACK_SIZE               (3 * 1024)
-#define BLINK_TASK_PRIORITY                 (1)
+#define BLINK_TASK_STACK_SIZE (3 * 1024)
+#define BLINK_TASK_PRIORITY (1)
 
-#define GOLIOTH_MAIN_TASK_STACK_SIZE        (5 * 1024)
-#define GOLIOTH_MAIN_TASK_PRIORITY          (1)
+#define GOLIOTH_MAIN_TASK_STACK_SIZE (5 * 1024)
+#define GOLIOTH_MAIN_TASK_PRIORITY (1)
 
 static void blink_task(void* arg) {
-    for (;;)
-    {
+    for (;;) {
         vTaskDelay(LED_TOGGLE_INTERVAL_MS / portTICK_PERIOD_MS);
         cyhal_gpio_toggle(CYBSP_USER_LED);
     }
@@ -85,8 +84,7 @@ static void blink_task(void* arg) {
  *  int
  *
  ******************************************************************************/
-int main(void)
-{
+int main(void) {
     cy_rslt_t result;
 
     /* Initialize the device and board peripherals */
@@ -105,20 +103,23 @@ int main(void)
     if (CY_SMIF_SUCCESS == qspi_status) {
         printf("External Memory initialized w/ SFDP.");
     } else {
-        printf("External Memory initialization w/ SFDP FAILED: 0x%08"PRIx32, (uint32_t)qspi_status);
+        printf("External Memory initialization w/ SFDP FAILED: 0x%08" PRIx32,
+               (uint32_t)qspi_status);
     }
 #endif
 
     /* Initialize the User LED */
-    result = cyhal_gpio_init(CYBSP_USER_LED, CYHAL_GPIO_DIR_OUTPUT,
-              CYHAL_GPIO_DRIVE_STRONG, CYBSP_LED_STATE_OFF);
+    result = cyhal_gpio_init(
+            CYBSP_USER_LED, CYHAL_GPIO_DIR_OUTPUT, CYHAL_GPIO_DRIVE_STRONG, CYBSP_LED_STATE_OFF);
     CY_ASSERT(result == CY_RSLT_SUCCESS);
 
-    (void) result; /* To avoid compiler warning in release build */
+    (void)result; /* To avoid compiler warning in release build */
 
     printf("\n=========================================================\n");
     printf("[GoliothApp] Version: %d.%d.%d, CPU: CM4\n",
-           APP_VERSION_MAJOR, APP_VERSION_MINOR, APP_VERSION_BUILD);
+           APP_VERSION_MAJOR,
+           APP_VERSION_MINOR,
+           APP_VERSION_BUILD);
     printf("\n=========================================================\n");
 
     /* Update watchdog timer to mark successful start up of application */
@@ -129,10 +130,14 @@ int main(void)
     printf("[GoliothApp] User LED toggles at %d msec interval\r\n\n", LED_TOGGLE_INTERVAL_MS);
 
     /* Create the tasks. */
-    xTaskCreate(blink_task, "Blink task", BLINK_TASK_STACK_SIZE, NULL,
-                BLINK_TASK_PRIORITY, NULL);
-    xTaskCreate(golioth_main_task, "Golioth main task", GOLIOTH_MAIN_TASK_STACK_SIZE, NULL,
-                GOLIOTH_MAIN_TASK_PRIORITY, NULL);
+    xTaskCreate(blink_task, "Blink task", BLINK_TASK_STACK_SIZE, NULL, BLINK_TASK_PRIORITY, NULL);
+    xTaskCreate(
+            golioth_main_task,
+            "Golioth main task",
+            GOLIOTH_MAIN_TASK_STACK_SIZE,
+            NULL,
+            GOLIOTH_MAIN_TASK_PRIORITY,
+            NULL);
 
     /* Start the FreeRTOS scheduler. */
     vTaskStartScheduler();
@@ -140,8 +145,7 @@ int main(void)
     /* Should never get here. */
     CY_ASSERT(0);
 
-    for (;;)
-    {
+    for (;;) {
         /* Toggle the user LED periodically */
         cyhal_system_delay_ms(LED_TOGGLE_INTERVAL_MS);
         cyhal_gpio_toggle(CYBSP_USER_LED);
@@ -151,4 +155,3 @@ int main(void)
 }
 
 /* [] END OF FILE */
-

--- a/port/esp_idf/fw_update_esp_idf.c
+++ b/port/esp_idf/fw_update_esp_idf.c
@@ -4,7 +4,7 @@
 #include "esp_partition.h"
 #include "esp_flash_partitions.h"
 #include "esp_system.h"
-#include <string.h> // memcpy
+#include <string.h>  // memcpy
 
 #define TAG "fw_update_esp_idf"
 

--- a/port/esp_idf/libcoap/include/coap_config_posix.h
+++ b/port/esp_idf/libcoap/include/coap_config_posix.h
@@ -34,13 +34,12 @@
 
 #define ipi_spec_dst ipi_addr
 struct in6_pktinfo {
-  struct in6_addr ipi6_addr;        /* src/dst IPv6 address */
-  unsigned int ipi6_ifindex;        /* send/recv interface index */
+    struct in6_addr ipi6_addr; /* src/dst IPv6 address */
+    unsigned int ipi6_ifindex; /* send/recv interface index */
 };
 #define IN6_IS_ADDR_V4MAPPED(a) \
-        ((((__const uint32_t *) (a))[0] == 0)                                 \
-         && (((__const uint32_t *) (a))[1] == 0)                              \
-         && (((__const uint32_t *) (a))[2] == htonl (0xffff)))
+    ((((__const uint32_t*)(a))[0] == 0) && (((__const uint32_t*)(a))[1] == 0) \
+     && (((__const uint32_t*)(a))[2] == htonl(0xffff)))
 
 /* As not defined, just need to define is as something innocuous */
 #define IPV6_PKTINFO IPV6_CHECKSUM

--- a/port/modus_toolbox/fw_update_mcuboot.c
+++ b/port/modus_toolbox/fw_update_mcuboot.c
@@ -59,12 +59,12 @@ golioth_status_t fw_update_handle_block(
         GLTH_LOGD(TAG, "Secondary flash area:");
         GLTH_LOGD(TAG, "   fa_id        = %d", _secondary_flash_area->fa_id);
         GLTH_LOGD(TAG, "   fa_device_id = %d", _secondary_flash_area->fa_device_id);
-        GLTH_LOGD(TAG, "   fa_off       = 0x%08"PRIx32, _secondary_flash_area->fa_off);
-        GLTH_LOGD(TAG, "   fa_size      = %"PRIu32, (uint32_t)_secondary_flash_area->fa_size);
+        GLTH_LOGD(TAG, "   fa_off       = 0x%08" PRIx32, _secondary_flash_area->fa_off);
+        GLTH_LOGD(TAG, "   fa_size      = %" PRIu32, (uint32_t)_secondary_flash_area->fa_size);
 
         // Erase secondary flash area
         uint32_t erase_size = _secondary_flash_area->fa_size;
-        GLTH_LOGI(TAG, "Erasing %"PRIu32" bytes of flash in secondary area", erase_size);
+        GLTH_LOGI(TAG, "Erasing %" PRIu32 " bytes of flash in secondary area", erase_size);
         status = flash_area_erase(_secondary_flash_area, 0, erase_size);
         GLTH_LOGI(TAG, "Done erasing flash");
         if (status != 0) {
@@ -74,11 +74,7 @@ golioth_status_t fw_update_handle_block(
     }
 
     // Write secondary flash area at offset
-    status = flash_area_write(
-            _secondary_flash_area,
-            offset,
-            block,
-            block_size);
+    status = flash_area_write(_secondary_flash_area, offset, block, block_size);
     if (status != 0) {
         GLTH_LOGE(TAG, "flash_area_write error: %d", status);
         return GOLIOTH_ERR_FAIL;

--- a/port/modus_toolbox/libcoap/include/coap_config.h
+++ b/port/modus_toolbox/libcoap/include/coap_config.h
@@ -39,13 +39,12 @@
 
 #define ipi_spec_dst ipi_addr
 struct in6_pktinfo {
-  struct in6_addr ipi6_addr;        /* src/dst IPv6 address */
-  unsigned int ipi6_ifindex;        /* send/recv interface index */
+    struct in6_addr ipi6_addr; /* src/dst IPv6 address */
+    unsigned int ipi6_ifindex; /* send/recv interface index */
 };
 #define IN6_IS_ADDR_V4MAPPED(a) \
-        ((((__const uint32_t *) (a))[0] == 0)                                 \
-         && (((__const uint32_t *) (a))[1] == 0)                              \
-         && (((__const uint32_t *) (a))[2] == htonl (0xffff)))
+    ((((__const uint32_t*)(a))[0] == 0) && (((__const uint32_t*)(a))[1] == 0) \
+     && (((__const uint32_t*)(a))[2] == htonl(0xffff)))
 
 #define IPV6_PKTINFO IPV6_CHECKSUM
 #define IN6_IS_ADDR_MULTICAST(a) false

--- a/port/modus_toolbox/libcoap/include/libcoap_posix_timers.h
+++ b/port/modus_toolbox/libcoap/include/libcoap_posix_timers.h
@@ -1,3 +1,3 @@
 #include <time.h>
 
-int clock_gettime( clockid_t clock_id, struct timespec *tp );
+int clock_gettime(clockid_t clock_id, struct timespec* tp);

--- a/port/modus_toolbox/libcoap/libcoap_posix_timers.c
+++ b/port/modus_toolbox/libcoap/libcoap_posix_timers.c
@@ -6,7 +6,7 @@ static uint32_t millis(void) {
     return xTaskGetTickCount() * portTICK_PERIOD_MS;
 }
 
-int clock_gettime( clockid_t clock_id, struct timespec *tp ) {
+int clock_gettime(clockid_t clock_id, struct timespec* tp) {
     uint32_t now_ms = millis();
     tp->tv_sec = now_ms / 1000ul;
     tp->tv_nsec = (now_ms % 1000ul) * 1000000ul;

--- a/port/modus_toolbox/libcoap/mbedtls_timing.c
+++ b/port/modus_toolbox/libcoap/mbedtls_timing.c
@@ -11,7 +11,7 @@ static uint32_t millis(void) {
 }
 
 unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time* val, int reset) {
-    struct _hr_time* t = (struct _hr_time*) val;
+    struct _hr_time* t = (struct _hr_time*)val;
 
     if (reset) {
         t->start_ms = millis();
@@ -52,4 +52,3 @@ int mbedtls_timing_get_delay(void* data) {
 
     return 0;
 }
-

--- a/scripts/lint/format_all_files.sh
+++ b/scripts/lint/format_all_files.sh
@@ -20,7 +20,7 @@ find $REPO_ROOT/examples/esp_idf/common -type f -name "*.c" -o -name "*.h" \
 find $REPO_ROOT/examples/esp_idf/*/main -type f -name "*.c" -o -name "*.h" \
     | grep -v -E ".*build.*" \
     | xargs clang-format -i -style=file --verbose
-j
-find $REPO_ROOT/examples/modus_toolbox/golioth_app/source -type f -name "*.c" -o -name "*.h" \
+
+find $REPO_ROOT/examples/modus_toolbox/golioth_basics/golioth_app/source -type f -name "*.c" -o -name "*.h" \
     | grep -v -E ".*build.*" \
     | xargs clang-format -i -style=file --verbose

--- a/src/golioth_coap_client.c
+++ b/src/golioth_coap_client.c
@@ -122,11 +122,11 @@ static coap_response_t coap_response_handler(
 
     if (req) {
         if (req->type == GOLIOTH_COAP_REQUEST_EMPTY) {
-            GLTH_LOGD(TAG, "%d.%02d (empty req), len %"PRIu32, class, code, (uint32_t)data_len);
+            GLTH_LOGD(TAG, "%d.%02d (empty req), len %" PRIu32, class, code, (uint32_t)data_len);
         } else if (class != 2) {  // not 2.XX, i.e. not success
             GLTH_LOGW(
                     TAG,
-                    "%d.%02d (req type: %d, path: %s%s), len %"PRIu32,
+                    "%d.%02d (req type: %d, path: %s%s), len %" PRIu32,
                     class,
                     code,
                     req->type,
@@ -136,7 +136,7 @@ static coap_response_t coap_response_handler(
         } else {
             GLTH_LOGD(
                     TAG,
-                    "%d.%02d (req type: %d, path: %s%s), len %"PRIu32,
+                    "%d.%02d (req type: %d, path: %s%s), len %" PRIu32,
                     class,
                     code,
                     req->type,
@@ -145,7 +145,7 @@ static coap_response_t coap_response_handler(
                     (uint32_t)data_len);
         }
     } else {
-        GLTH_LOGD(TAG, "%d.%02d (unsolicited), len %"PRIu32, class, code, (uint32_t)data_len);
+        GLTH_LOGD(TAG, "%d.%02d (unsolicited), len %" PRIu32, class, code, (uint32_t)data_len);
     }
 
     if (req && token_matches_request(req, received)) {
@@ -172,7 +172,8 @@ static coap_response_t coap_response_handler(
 
                 GLTH_LOGD(
                         TAG,
-                        "Request block index = %"PRIu32", response block index = %"PRIu32", offset 0x%08"PRIX32,
+                        "Request block index = %" PRIu32 ", response block index = %" PRIu32
+                        ", offset 0x%08" PRIX32,
                         (uint32_t)req->get_block.block_index,
                         (uint32_t)opt_block_index,
                         opt_block_index * 1024);
@@ -182,7 +183,13 @@ static coap_response_t coap_response_handler(
 
                 if (req->get_block.callback) {
                     req->get_block.callback(
-                            client, &response, req->path, data, data_len, is_last, req->get_block.arg);
+                            client,
+                            &response,
+                            req->path,
+                            data,
+                            data_len,
+                            is_last,
+                            req->get_block.arg);
                 }
             } else if (req->type == GOLIOTH_COAP_REQUEST_POST) {
                 if (req->post.callback) {
@@ -516,7 +523,12 @@ static int validate_cn_call_back(
         unsigned depth,
         int validated,
         void* arg) {
-    GLTH_LOGI(TAG, "Server Cert: Depth = %u, Len = %"PRIu32", Valid = %d", depth, (uint32_t)asn1_length, validated);
+    GLTH_LOGI(
+            TAG,
+            "Server Cert: Depth = %u, Len = %" PRIu32 ", Valid = %d",
+            depth,
+            (uint32_t)asn1_length,
+            validated);
     return 1;
 }
 
@@ -710,7 +722,7 @@ static golioth_status_t coap_io_loop_once(
         } else {
             time_spent_waiting_ms += num_ms;
             if (request_msg.got_response) {
-                GLTH_LOGD(TAG, "Received response in %"PRId32" ms", time_spent_waiting_ms);
+                GLTH_LOGD(TAG, "Received response in %" PRId32 " ms", time_spent_waiting_ms);
                 break;
             } else {
                 // During normal operation, there will be other kinds of IO to process,

--- a/src/golioth_fw_update.c
+++ b/src/golioth_fw_update.c
@@ -26,7 +26,7 @@ static golioth_status_t download_and_write_flash(void) {
     int32_t main_size = _main_component->size;
 
     // Handle blocks one at a time
-    GLTH_LOGI(TAG, "Image size = %"PRIu32, main_size);
+    GLTH_LOGI(TAG, "Image size = %" PRIu32, main_size);
     size_t nblocks = golioth_ota_size_to_nblocks(main_size);
     size_t bytes_written = 0;
     for (size_t i = 0; /* empty */; i++) {
@@ -51,11 +51,7 @@ static golioth_status_t download_and_write_flash(void) {
 
         assert(block_nbytes <= GOLIOTH_OTA_BLOCKSIZE);
 
-        status = fw_update_handle_block(
-                _ota_block_buffer,
-                block_nbytes,
-                bytes_written,
-                main_size);
+        status = fw_update_handle_block(_ota_block_buffer, block_nbytes, bytes_written, main_size);
         if (status != GOLIOTH_OK) {
             GLTH_LOGE(TAG, "Failed to handle block index %d", i);
             return status;
@@ -68,7 +64,7 @@ static golioth_status_t download_and_write_flash(void) {
         }
     }
 
-    GLTH_LOGI(TAG, "Total bytes written: %"PRIu32, (uint32_t)bytes_written);
+    GLTH_LOGI(TAG, "Total bytes written: %" PRIu32, (uint32_t)bytes_written);
     fw_update_post_download();
 
     return GOLIOTH_OK;

--- a/src/golioth_lightdb.c
+++ b/src/golioth_lightdb.c
@@ -44,7 +44,7 @@ static golioth_status_t golioth_lightdb_set_int_internal(
         golioth_set_cb_fn callback,
         void* callback_arg) {
     char buf[16] = {};
-    snprintf(buf, sizeof(buf), "%"PRId32, value);
+    snprintf(buf, sizeof(buf), "%" PRId32, value);
     return golioth_coap_client_set(
             client,
             path_prefix,


### PR DESCRIPTION
Ran scripts/lint/format_all_files.sh. Also fixed a stray 'j' character in the format_all_files.sh script.

Signed-off-by: Nick Miller <nick@golioth.io>