### PR TITLE
esp-idf: upgrade from v4.4.1 to v4.4.2

### DIFF
--- a/.github/workflows/lint_and_build.yml
+++ b/.github/workflows/lint_and_build.yml
@@ -28,13 +28,13 @@ jobs:
     - name: Build golioth_basics project
       uses: espressif/esp-idf-ci-action@v1
       with:
-        esp_idf_version: v4.4.1
+        esp_idf_version: v4.4.2
         target: esp32
         path: 'examples/esp_idf/golioth_basics'
     - name: Build magtag_demo project
       uses: espressif/esp-idf-ci-action@v1
       with:
-        esp_idf_version: v4.4.1
+        esp_idf_version: v4.4.2
         target: esp32
         path: 'examples/esp_idf/magtag_demo'
     # TODO - build ModusToolbox examples

--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build test project
       uses: espressif/esp-idf-ci-action@v1
       with:
-        esp_idf_version: v4.4.1
+        esp_idf_version: v4.4.2
         target: esp32s3
         path: 'examples/esp_idf/test'
     - name: Create build tarball for serial flashing
@@ -53,7 +53,7 @@ jobs:
     - name: Rebuild test project with version 1.2.99
       uses: espressif/esp-idf-ci-action@v1
       with:
-        esp_idf_version: v4.4.1
+        esp_idf_version: v4.4.2
         target: esp32s3
         path: 'examples/esp_idf/test'
     - name: Create and rollout new OTA release using goliothctl

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The `verify.py` script will return 0 on success (all tests pass), and non-zero o
 
 | Board               | Platform             | Module           | Last Tested Commit    |
 | ---                 | ---                  | ---              | ---                   |
-| ESP32-S3-DevKitC-1  | ESP-IDF (v4.4.1)     | ESP32-S3-WROOM-1 | Every commit, CI/CD   |
+| ESP32-S3-DevKitC-1  | ESP-IDF (v4.4.2)     | ESP32-S3-WROOM-1 | Every commit, CI/CD   |
 | ESP32-DevKitC-32E   | ESP-IDF (v4.4.1)     | ESP32-WROOM-32E  | v0.3.0 (Oct 4, 2022)  |
 | ESP32-C3-DevKitM-1  | ESP-IDF (v4.4.1)     | ESP32-C3-MINI-1  | v0.3.0 (Oct 4, 2022)  |
 | CY8CPROTO-062-4343W | ModusToolbox (2.4.0) | PSoC® 6 CYW4343W | v0.3.0 (Oct 4, 2022)  |

--- a/examples/esp_idf/README.md
+++ b/examples/esp_idf/README.md
@@ -2,11 +2,11 @@
 
 This repo contains a set of examples intended to build
 and run in the latest release of esp-idf
-(currently [4.4.1](https://github.com/espressif/esp-idf/releases/tag/v4.4.1)).
+(currently [4.4.2](https://github.com/espressif/esp-idf/releases/tag/v4.4.2)).
 
 ### Install esp-idf
 
-Install version 4.4.1 of esp-idf using the
+Install version 4.4.2 of esp-idf using the
 [installation directions from Espressif](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation).
 This is the version of esp-idf this SDK is tested against.
 
@@ -18,7 +18,7 @@ mkdir -p ~/esp
 cd ~/esp
 git clone --recursive https://github.com/espressif/esp-idf.git
 cd esp-idf
-git checkout v4.4.1
+git checkout v4.4.2
 git submodule update --init --recursive
 ./install.sh all
 ```


### PR DESCRIPTION
The latest ESP-IDF release is v4.4.2.

I tested the golioth_basics example with this version, and it worked without issue (no source code changes needed).

Signed-off-by: Nick Miller <nick@golioth.io>