### PR TITLE
test: add settings test

### DIFF
--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -21,7 +21,7 @@
 #define TAG "test"
 
 // Wait this long, in seconds, for a response to a request
-#define TEST_RESPONSE_TIMEOUT_S (CONFIG_GOLIOTH_COAP_RESPONSE_TIMEOUT_S + 1)
+#define TEST_RESPONSE_TIMEOUT_S (2 * CONFIG_GOLIOTH_COAP_RESPONSE_TIMEOUT_S + 1)
 
 static const char* _current_version = "1.2.3";
 

--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <string.h>
+#include <inttypes.h>
 #include <cJSON.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -60,6 +61,32 @@ static golioth_rpc_status_t on_double(
     return RPC_OK;
 }
 
+static golioth_settings_status_t on_setting(
+        const char* key,
+        const golioth_settings_value_t* value) {
+    GLTH_LOGD(TAG, "Received setting: key = %s, type = %d", key, value->type);
+
+    if (0 == strcmp(key, "TEST_SETTING")) {
+        // This setting is expected to be an int, return an error if it's not
+        if (value->type != GOLIOTH_SETTINGS_VALUE_TYPE_INT) {
+            return GOLIOTH_SETTINGS_VALUE_FORMAT_NOT_VALID;
+        }
+
+        // This setting must be in range [1, 100], return an error if it's not
+        if (value->i32 < 1 || value->i32 > 100) {
+            return GOLIOTH_SETTINGS_VALUE_OUTSIDE_RANGE;
+        }
+
+        // Setting has passed all checks, so set it in LightDB
+        GLTH_LOGI(TAG, "Setting LightDB TEST_SETTING to %" PRId32, value->i32);
+        golioth_lightdb_set_int_async(_client, "TEST_SETTING", value->i32, NULL, NULL);
+        return GOLIOTH_SETTINGS_SUCCESS;
+    }
+
+    // If the setting is not recognized, don't worry about, just return success
+    return GOLIOTH_SETTINGS_SUCCESS;
+}
+
 static void test_connects_to_wifi(void) {
     if (_wifi_connected) {
         return;
@@ -88,6 +115,7 @@ static void test_golioth_client_create(void) {
         TEST_ASSERT_NOT_NULL(_client);
         golioth_client_register_event_callback(_client, on_client_event, NULL);
         golioth_rpc_register(_client, "double", on_double, NULL);
+        golioth_settings_register_callback(_client, on_setting);
     }
 }
 

--- a/examples/esp_idf/test/verify.py
+++ b/examples/esp_idf/test/verify.py
@@ -184,7 +184,7 @@ def run_settings_test(project_id, device_id, api_key):
     assert create.status_code == 200, print(create)
 
     # Wait some time for changes to propagate to cloud database
-    sleep(3)
+    sleep(10)
 
     # API: Read LightDB, verify random value matches
     ldb_data = api_lightdb_get(project_id, device_id, api_key, setting_name)

--- a/src/golioth_rpc.c
+++ b/src/golioth_rpc.c
@@ -40,6 +40,7 @@ typedef struct {
     void* callback_arg;
 } golioth_rpc_t;
 
+// TODO - move this into the client struct so it's not global
 static golioth_rpc_t _rpcs[CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS];
 static int _num_rpcs;
 

--- a/src/golioth_settings.c
+++ b/src/golioth_settings.c
@@ -41,6 +41,7 @@
 #define SETTINGS_PATH_PREFIX ".c/"
 #define SETTINGS_STATUS_PATH "status"
 
+// TODO - move this into the client struct so it's not global
 static struct {
     bool initialized;
     golioth_settings_cb callback;
@@ -177,11 +178,6 @@ cleanup:
 golioth_status_t golioth_settings_register_callback(
         golioth_client_t client,
         golioth_settings_cb callback) {
-    if (_golioth_settings.initialized) {
-        GLTH_LOGE(TAG, "Unable to register more than one callback");
-        return GOLIOTH_ERR_NOT_ALLOWED;
-    }
-
     if (!callback) {
         GLTH_LOGE(TAG, "Callback must not be NULL");
         return GOLIOTH_ERR_NULL;


### PR DESCRIPTION
Relies heavily on Golioth API to create/delete/read settings. Test firmware modified to receive the TEST_SETTING setting and set the value received in LightDB state so it can be read via API and confirmed to match the original value.

Leaving the debug prints in verify.py since this is a new test and I'm not sure how stable/flaky it will be in CI.

Signed-off-by: Nick Miller <nick@golioth.io>