### PR TITLE
settings,rpc: Move global data to client struct

### DIFF
--- a/src/golioth_coap_client.c
+++ b/src/golioth_coap_client.c
@@ -9,15 +9,11 @@
 #include <netdb.h>      // struct addrinfo
 #include <sys/param.h>  // MIN
 #include <coap3/coap.h>
-#include "golioth_client.h"
 #include "golioth_coap_client.h"
 #include "golioth_statistics.h"
 #include "golioth_util.h"
 #include "golioth_time.h"
-#include "golioth_lightdb.h"
-#include "golioth_settings.h"
 #include "golioth_debug.h"
-#include "golioth_config.h"
 
 #define TAG "golioth_coap_client"
 
@@ -44,6 +40,7 @@ typedef struct {
     golioth_client_event_cb_fn event_callback;
     void* event_callback_arg;
     golioth_settings_t settings;
+    golioth_rpc_t rpc;
 } golioth_coap_client_t;
 
 static bool token_matches_request(
@@ -1488,4 +1485,9 @@ bool golioth_client_has_allocation_leaks(void) {
 golioth_settings_t* golioth_coap_client_get_settings(golioth_client_t client) {
     golioth_coap_client_t* c = (golioth_coap_client_t*)client;
     return &c->settings;
+}
+
+golioth_rpc_t* golioth_coap_client_get_rpc(golioth_client_t client) {
+    golioth_coap_client_t* c = (golioth_coap_client_t*)client;
+    return &c->rpc;
 }

--- a/src/golioth_coap_client.c
+++ b/src/golioth_coap_client.c
@@ -15,6 +15,7 @@
 #include "golioth_util.h"
 #include "golioth_time.h"
 #include "golioth_lightdb.h"
+#include "golioth_settings.h"
 #include "golioth_debug.h"
 #include "golioth_config.h"
 
@@ -42,6 +43,7 @@ typedef struct {
     size_t block_token_len;
     golioth_client_event_cb_fn event_callback;
     void* event_callback_arg;
+    golioth_settings_t settings;
 } golioth_coap_client_t;
 
 static bool token_matches_request(
@@ -1481,4 +1483,9 @@ uint32_t golioth_client_num_items_in_request_queue(golioth_client_t client) {
 
 bool golioth_client_has_allocation_leaks(void) {
     return golioth_statistics_has_allocation_leaks();
+}
+
+golioth_settings_t* golioth_coap_client_get_settings(golioth_client_t client) {
+    golioth_coap_client_t* c = (golioth_coap_client_t*)client;
+    return &c->settings;
 }

--- a/src/include/golioth_rpc.h
+++ b/src/include/golioth_rpc.h
@@ -8,6 +8,7 @@
 #include <cJSON.h>
 #include "golioth_status.h"
 #include "golioth_client.h"
+#include "golioth_config.h"
 
 /// @defgroup golioth_rpc golioth_rpc
 /// Functions for interacting with the Golioth Remote Procedure Call service
@@ -90,5 +91,19 @@ golioth_status_t golioth_rpc_register(
         const char* method,
         golioth_rpc_cb_fn callback,
         void* callback_arg);
+
+/// Private struct to contain data about a single registered method
+typedef struct {
+    const char* method;
+    golioth_rpc_cb_fn callback;
+    void* callback_arg;
+} golioth_rpc_method_t;
+
+/// Private struct to contain RPC state data, stored in
+/// the golioth_coap_client_t struct.
+typedef struct {
+    golioth_rpc_method_t rpcs[CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS];
+    int num_rpcs;
+} golioth_rpc_t;
 
 /// @}

--- a/src/include/golioth_settings.h
+++ b/src/include/golioth_settings.h
@@ -90,6 +90,12 @@ typedef struct {
 typedef golioth_settings_status_t (
         *golioth_settings_cb)(const char* key, const golioth_settings_value_t* value);
 
+/// Private struct to contain settings state data, stored in
+/// the golioth_coap_client_t struct.
+typedef struct {
+    golioth_settings_cb callback;
+} golioth_settings_t;
+
 /// Register callback for handling settings.
 ///
 /// The client will be used to observe for settings from the cloud.

--- a/src/priv_include/golioth_coap_client.h
+++ b/src/priv_include/golioth_coap_client.h
@@ -13,6 +13,7 @@
 #include <coap3/coap.h>  // COAP_MEDIATYPE_*
 #include "golioth_client.h"
 #include "golioth_lightdb.h"
+#include "golioth_settings.h"
 #include "golioth_config.h"
 
 /// Event group bits for request_complete_event
@@ -167,3 +168,7 @@ golioth_status_t golioth_coap_client_observe_async(
         uint32_t content_type,
         golioth_get_cb_fn callback,
         void* callback_arg);
+
+/// Getters, for internal SDK code to access data within the
+/// coap client struct.
+golioth_settings_t* golioth_coap_client_get_settings(golioth_client_t client);

--- a/src/priv_include/golioth_coap_client.h
+++ b/src/priv_include/golioth_coap_client.h
@@ -14,6 +14,7 @@
 #include "golioth_client.h"
 #include "golioth_lightdb.h"
 #include "golioth_settings.h"
+#include "golioth_rpc.h"
 #include "golioth_config.h"
 
 /// Event group bits for request_complete_event
@@ -172,3 +173,4 @@ golioth_status_t golioth_coap_client_observe_async(
 /// Getters, for internal SDK code to access data within the
 /// coap client struct.
 golioth_settings_t* golioth_coap_client_get_settings(golioth_client_t client);
+golioth_rpc_t* golioth_coap_client_get_rpc(golioth_client_t client);


### PR DESCRIPTION
Previously, golioth_settings and golioth_rpc relied on global data for storing
the user's callbacks and other state data. However, this does not work very well
in case of multiple clients, or in cases where the client
is destroyed and recreated (such as in test code).

By storing the data in the client struct, there can be settings and rpc
data stored per client in a thread-safe manner.