### PR TITLE
esp-idf: libcoap: update to 4.3.1

### DIFF
--- a/port/esp_idf/components/golioth_sdk/CMakeLists.txt
+++ b/port/esp_idf/components/golioth_sdk/CMakeLists.txt
@@ -4,8 +4,8 @@ set(sdk_idf_port ${sdk_root}/port/esp_idf)
 set(libcoap_dir ${sdk_root}/external/libcoap)
 
 set(libcoap_srcs
-    "${libcoap_dir}/src/address.c"
-    "${libcoap_dir}/src/async.c"
+    "${libcoap_dir}/src/coap_address.c"
+    "${libcoap_dir}/src/coap_async.c"
     "${libcoap_dir}/src/block.c"
     "${libcoap_dir}/src/coap_asn1.c"
     "${libcoap_dir}/src/coap_cache.c"
@@ -22,11 +22,11 @@ set(libcoap_srcs
     "${libcoap_dir}/src/encode.c"
     "${libcoap_dir}/src/mem.c"
     "${libcoap_dir}/src/net.c"
-    "${libcoap_dir}/src/option.c"
+    "${libcoap_dir}/src/coap_option.c"
     "${libcoap_dir}/src/pdu.c"
     "${libcoap_dir}/src/resource.c"
     "${libcoap_dir}/src/str.c"
-    "${libcoap_dir}/src/subscribe.c"
+    "${libcoap_dir}/src/coap_subscribe.c"
     "${libcoap_dir}/src/uri.c")
 
 idf_component_register(
@@ -59,7 +59,6 @@ idf_component_register(
         "${sdk_src}/golioth_statistics.c"
         "${sdk_src}/golioth_settings.c")
 
-list(APPEND EXTRA_C_FLAGS_LIST -Werror)
 component_compile_options(${EXTRA_C_FLAGS_LIST})
 
 target_compile_definitions(${COMPONENT_LIB} PUBLIC WITH_POSIX)

--- a/port/esp_idf/libcoap/include/coap3/coap.h
+++ b/port/esp_idf/libcoap/include/coap3/coap.h
@@ -24,8 +24,8 @@ extern "C" {
 #include "coap3/libcoap.h"
 
 #include "coap3/coap_forward_decls.h"
-#include "coap3/address.h"
-#include "coap3/async.h"
+#include "coap3/coap_address.h"
+#include "coap3/coap_async.h"
 #include "coap3/block.h"
 #include "coap3/coap_cache.h"
 #include "coap3/coap_dtls.h"
@@ -36,12 +36,12 @@ extern "C" {
 #include "coap3/encode.h"
 #include "coap3/mem.h"
 #include "coap3/net.h"
-#include "coap3/option.h"
+#include "coap3/coap_option.h"
 #include "coap3/pdu.h"
 #include "coap3/coap_prng.h"
 #include "coap3/resource.h"
 #include "coap3/str.h"
-#include "coap3/subscribe.h"
+#include "coap3/coap_subscribe.h"
 #include "coap3/uri.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Update to libcoap tip of main branch, which is release 4.3.1.

Signed-off-by: Nick Miller <nick@golioth.io>