### PR TITLE
README: minimal example, include nvs_init

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Here is a minimal example that demonstrates how to connect to
 [Golioth cloud](https://docs.golioth.io/cloud) and send the message "Hello, Golioth!":
 
 ```c
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include "nvs.h"
 #include "wifi.h"
 #include "golioth.h"
 
@@ -24,6 +28,7 @@ void app_main(void) {
     const char* golioth_psk_id = "device@project";
     const char* golioth_psk = "supersecret";
 
+    nvs_init();
     wifi_init(wifi_ssid, wifi_password);
     wifi_wait_for_connected();
 


### PR DESCRIPTION
The minimal example code crashes at runtime due to NVS not being initialized (ESP_ERR_NVS_NOT_INITIALIZED). NVS is required by the WiFi driver.

Added nvs_init() as well as a couple of missing #includes, so the code compiles and runs cleanly.

Signed-off-by: Nick Miller <nick@golioth.io>