### PR TITLE
README: add feature x platform table

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ instructions to build and run the examples.
 
 The `golioth_basics` example (`examples/<platform>/golioth_basics`) is recommended
 as a starting point, to learn how to connect to Golioth and use services like
-[LightDB state](https://docs.golioth.io/cloud/services/lightdb),
+[LightDB State](https://docs.golioth.io/cloud/services/lightdb),
 [LightDB Stream](https://docs.golioth.io/cloud/services/lightdb-stream),
 [Logging](https://docs.golioth.io/cloud/services/logging),
 and [OTA](https://docs.golioth.io/cloud/services/ota).
@@ -83,6 +83,28 @@ and [OTA](https://docs.golioth.io/cloud/services/ota).
 
 The `docs` folder contains additional documentation, such as a platform
 integration guide and a platform porting guide.
+
+## Features Supported by Platform
+
+This SDK currently supports the following platforms:
+
+* Espressif ESP-IDF
+* Infineon ModusToolbox
+
+The following table lists which SDK features (rows) are support for each platform (columns).
+
+| Feature | ESP-IDF | ModusToolbox |
+| --- | --- | --- |
+| OTA FW Update | :heavy_check_mark: | :heavy_check_mark: |
+| Cloud Logging | :heavy_check_mark: | :heavy_check_mark: |
+| LightDB State | :heavy_check_mark: | :heavy_check_mark: |
+| LightDB Stream | :heavy_check_mark: | :heavy_check_mark: |
+| Remote Procedure Call | :heavy_check_mark: | :heavy_check_mark: |
+| Settings | :heavy_check_mark: | :heavy_check_mark: |
+| Remote Shell | :heavy_check_mark: | :x: |
+| CoAP/DTLS Client | :heavy_check_mark: | :heavy_check_mark: |
+| PSK Auth | :heavy_check_mark: | :heavy_check_mark: |
+| Certificate Auth | :heavy_check_mark: | :x: |
 
 ## Verified Devices
 
@@ -109,4 +131,4 @@ The `verify.py` script will return 0 on success (all tests pass), and non-zero o
 | ESP32-S3-DevKitC-1  | ESP-IDF (v4.4.2)     | ESP32-S3-WROOM-1 | Every commit, CI/CD   |
 | ESP32-DevKitC-32E   | ESP-IDF (v4.4.1)     | ESP32-WROOM-32E  | v0.3.0 (Oct 4, 2022)  |
 | ESP32-C3-DevKitM-1  | ESP-IDF (v4.4.1)     | ESP32-C3-MINI-1  | v0.3.0 (Oct 4, 2022)  |
-| CY8CPROTO-062-4343W | ModusToolbox (2.4.0) | PSoC® 6 CYW4343W | v0.3.0 (Oct 4, 2022)  |
+| CY8CPROTO-062-4343W | ModusToolbox (3.0.0) | PSoC® 6 CYW4343W | v0.3.0 (Oct 17, 2022)  |


### PR DESCRIPTION
The new remote shell feature does not yet work on ModusToolbox, so it's a good excuse to make a table in the README with a list of features of the core SDK and whether they're supported on each platform.

Also, a capitalization fix and an update to the last tested version and date of ModusToolbox.

Signed-off-by: Nick Miller <nick@golioth.io>