### PR TITLE
debug: implement hexdump macro

### DIFF
--- a/examples/esp_idf/common/wifi.h
+++ b/examples/esp_idf/common/wifi.h
@@ -5,6 +5,9 @@
  */
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
 void wifi_init(const char* ssid, const char* password);
 void wifi_wait_for_connected(void);
 bool wifi_wait_for_connected_with_timeout(uint32_t timeout_s);

--- a/port/esp_idf/components/golioth_sdk/CMakeLists.txt
+++ b/port/esp_idf/components/golioth_sdk/CMakeLists.txt
@@ -61,6 +61,7 @@ idf_component_register(
         "${sdk_src}/golioth_statistics.c"
         "${sdk_src}/golioth_settings.c"
         "${sdk_src}/golioth_remote_shell.c"
+        "${sdk_src}/golioth_debug.c"
         "${sdk_src}/golioth_ringbuf.c"
         "${sdk_src}/golioth_event_group.c"
         "${sdk_src}/golioth_mbox.c"

--- a/src/golioth_coap_client.c
+++ b/src/golioth_coap_client.c
@@ -131,6 +131,9 @@ static coap_response_t coap_response_handler(
                     req->path_prefix,
                     req->path,
                     (uint32_t)data_len);
+
+            // In case of 4.xx, the payload often has a useful error message
+            GLTH_LOG_BUFFER_HEXDUMP(TAG, data, min(data_len, 256), GOLIOTH_DEBUG_LOG_LEVEL_DEBUG);
         } else {
             GLTH_LOGD(
                     TAG,
@@ -175,7 +178,8 @@ static coap_response_t coap_response_handler(
                         (uint32_t)req->get_block.block_index,
                         (uint32_t)opt_block_index,
                         opt_block_index * 1024);
-                GLTH_LOG_BUFFER_HEXDUMP(TAG, data, min(32, data_len), GLTH_LOG_DEBUG);
+                GLTH_LOG_BUFFER_HEXDUMP(
+                        TAG, data, min(32, data_len), GOLIOTH_DEBUG_LOG_LEVEL_DEBUG);
 
                 bool is_last = (COAP_OPT_BLOCK_MORE(block_opt) == 0);
 
@@ -1019,7 +1023,6 @@ golioth_status_t golioth_client_stop(golioth_client_t client) {
     golioth_sys_sem_take(c->run_sem, GOLIOTH_WAIT_FOREVER);
 
     // Wait for client to be fully stopped
-    uint64_t timeout_ms = golioth_time_millis() + 2000;
     while (golioth_client_is_running(client)) {
         golioth_time_delay_ms(100);
     }

--- a/src/golioth_debug.c
+++ b/src/golioth_debug.c
@@ -1,4 +1,5 @@
 #include "golioth_debug.h"
+#include <stdio.h>
 
 static golioth_debug_log_level_t _level = GOLIOTH_DEBUG_LOG_LEVEL_INFO;
 
@@ -8,4 +9,57 @@ void golioth_debug_set_log_level(golioth_debug_log_level_t level) {
 
 golioth_debug_log_level_t golioth_debug_get_log_level(void) {
     return _level;
+}
+
+// Adapted from https://stackoverflow.com/a/7776146
+void golioth_debug_hexdump(const char* tag, const void* addr, int len) {
+    const int per_line = 16;
+
+    int i;
+    unsigned char buff[per_line + 1];
+    const unsigned char* pc = (const unsigned char*)addr;
+
+    if (len <= 0) {
+        return;
+    }
+
+    // Output description if given.
+    if (tag != NULL) {
+        printf("%s:\n", tag);
+    }
+
+    // Process every byte in the data.
+    for (i = 0; i < len; i++) {
+        // Multiple of per_line means new or first line (with line offset).
+
+        if ((i % per_line) == 0) {
+            // Only print previous-line ASCII buffer for lines beyond first.
+            if (i != 0) {
+                printf("  %s\n", buff);
+            }
+
+            // Output the offset of current line.
+            printf("  %04x ", i);
+        }
+
+        // Now the hex code for the specific character.
+        printf(" %02x", pc[i]);
+
+        // And buffer a printable ASCII character for later.
+        if ((pc[i] < 0x20) || (pc[i] > 0x7e)) {  // isprint() may be better.
+            buff[i % per_line] = '.';
+        } else {
+            buff[i % per_line] = pc[i];
+        }
+        buff[(i % per_line) + 1] = '\0';
+    }
+
+    // Pad out last line if not exactly per_line characters.
+    while ((i % per_line) != 0) {
+        printf("   ");
+        i++;
+    }
+
+    // And print the final ASCII buffer.
+    printf("  %s\n", buff);
 }

--- a/src/golioth_rpc.c
+++ b/src/golioth_rpc.c
@@ -77,7 +77,7 @@ static void on_rpc(
         return;
     }
 
-    GLTH_LOG_BUFFER_HEXDUMP(TAG, payload, min(64, payload_size), GLTH_LOG_DEBUG);
+    GLTH_LOG_BUFFER_HEXDUMP(TAG, payload, min(64, payload_size), GOLIOTH_DEBUG_LOG_LEVEL_DEBUG);
 
     cJSON* json = cJSON_ParseWithLength((const char*)payload, payload_size);
     if (!json) {

--- a/src/golioth_settings.c
+++ b/src/golioth_settings.c
@@ -73,7 +73,7 @@ static void on_settings(
         return;
     }
 
-    GLTH_LOG_BUFFER_HEXDUMP(TAG, payload, min(64, payload_size), GLTH_LOG_DEBUG);
+    GLTH_LOG_BUFFER_HEXDUMP(TAG, payload, min(64, payload_size), GOLIOTH_DEBUG_LOG_LEVEL_DEBUG);
 
     cJSON* json = cJSON_ParseWithLength((const char*)payload, payload_size);
     if (!json) {

--- a/src/include/golioth_debug.h
+++ b/src/include/golioth_debug.h
@@ -14,3 +14,4 @@ typedef enum {
 
 void golioth_debug_set_log_level(golioth_debug_log_level_t level);
 golioth_debug_log_level_t golioth_debug_get_log_level(void);
+void golioth_debug_hexdump(const char* tag, const void* addr, int len);

--- a/src/include/golioth_sys.h
+++ b/src/include/golioth_sys.h
@@ -139,7 +139,12 @@ void golioth_sys_thread_destroy(golioth_sys_thread_t thread);
 #endif
 
 #ifndef GLTH_LOG_BUFFER_HEXDUMP
-#define GLTH_LOG_BUFFER_HEXDUMP(TAG, ...) /* TODO - default hexdump implementation */
+#define GLTH_LOG_BUFFER_HEXDUMP(TAG, payload, size, level) \
+    do { \
+        if ((level) <= golioth_debug_get_log_level()) { \
+            golioth_debug_hexdump(TAG, payload, size); \
+        } \
+    } while (0);
 #endif
 
 #else /* CONFIG_GOLIOTH_DEBUG_LOG_ENABLE */


### PR DESCRIPTION
Hexdump is useful for debugging.

Had to fix a few compilation errors related to usage of the
hexdump macro (previously were not compiled, so the errors
slipped through).

Signed-off-by: Nick Miller <nick@golioth.io>