### PR TITLE
ci: run test_esp32s3.yml every night

### DIFF
--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  schedule:
+    # Run workflow at the start of every day (12 AM UTC)
+    - cron: "0 0 * * *"
 
 jobs:
   build_for_hw_test:


### PR DESCRIPTION
Currently, the workflow only runs on PRs and merges to main, meaning if there is no activity in this repo, it's possible a change to Golioth servers could have broken the end-to-end test.

Running a nightly test on a fixed schedule should help catch any serious issues within 24 hours, regardless of whether a PR has been created.

Signed-off-by: Nick Miller <nick@golioth.io>