### PR TITLE
linux: build libcoap from source

### DIFF
--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -46,17 +46,7 @@ jobs:
     - name: Install Linux deps
       shell: bash
       run: |
-        sudo apt install libssl-dev libcjson-dev
-    - name: Build and install libcoap for Linux
-      shell: bash
-      run: |
-        cd external/libcoap
-        cmake -E remove_directory build
-        cmake -E make_directory build
-        cd build
-        cmake ..
-        cmake --build .
-        sudo cmake --build . -- install
+        sudo apt install libssl-dev
     - name: Build golioth_basics
       shell: bash
       run: |

--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -6,20 +6,6 @@
 sudo apt install libssl-dev
 ```
 
-## Build and install libcoap
-
-We build from source in order to use a specific commit of `libcoap`.
-
-```sh
-cd external/libcoap
-cmake -E remove_directory build
-cmake -E make_directory build
-cd build
-cmake ..
-cmake --build .
-sudo cmake --build . -- install
-```
-
 ## Build and run
 
 Build:

--- a/port/linux/golioth_sdk/CMakeLists.txt
+++ b/port/linux/golioth_sdk/CMakeLists.txt
@@ -2,8 +2,11 @@ set(repo_root ../../..)
 set(sdk_src ${repo_root}/src)
 set(sdk_port ${repo_root}/port)
 
-find_package(OpenSSL MODULE REQUIRED)
-find_package(libcoap CONFIG REQUIRED)
+option(ENABLE_DOCS OFF)
+option(ENABLE_EXAMPLES OFF)
+option(ENABLE_SERVER_MODE OFF)
+option(ENABLE_TCP OFF)
+add_subdirectory("${repo_root}/external/libcoap" build)
 
 # Build cJSON from source
 set(cjson_dir "${repo_root}/external/cJSON")
@@ -44,4 +47,4 @@ target_include_directories(golioth_sdk
 )
 target_link_libraries(golioth_sdk
     PUBLIC cjson
-    PRIVATE libcoap::coap-3 pthread rt)
+    PRIVATE coap-3 pthread rt)


### PR DESCRIPTION
Previously, it was assumed the user would build and install libcoap to the system.

To make the build more self-contained and easier for users, libcoap is now built as part of the overall project via add_subdirectory.

Signed-off-by: Nick Miller <nick@golioth.io>