### PR TITLE
github-ci: update to actions/checkout@v3

### DIFF
--- a/.github/workflows/firebase-doxygen-main.yml
+++ b/.github/workflows/firebase-doxygen-main.yml
@@ -7,7 +7,7 @@ jobs:
   deploy_doxygen_prod:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Doxygen
         run: sudo apt install doxygen graphviz
       - name: Generate Doxygen

--- a/.github/workflows/firebase-doxygen-pr.yml
+++ b/.github/workflows/firebase-doxygen-pr.yml
@@ -4,7 +4,7 @@ jobs:
   deploy_doxygen_dev:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Doxygen
         run: sudo apt install doxygen graphviz
       - name: Generate Doxygen

--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: Setup Python
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: Setup Python
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: Setup Python

--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: Setup Python
@@ -108,7 +108,7 @@ jobs:
 
     steps:
     - name: Checkout repository without submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Download build tarball
       uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
This suppresses following warning:

> Node.js 12 actions are deprecated.