### PR TITLE
shell: follow IDF basic console configuration

### DIFF
--- a/examples/esp_idf/README.md
+++ b/examples/esp_idf/README.md
@@ -46,3 +46,10 @@ idf.py build
 idf.py flash
 idf.py monitor
 ```
+
+### USB serial configuration for Adafruit ESP32-S2/S3 Feather Boards
+
+If you're using an Adafruit Feather board with a USB-C connector,
+you will need to set `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG` to `y` via
+`sdkconfig` or `idf.py menuconfig`. This is required in order to use
+the command-line shell that is integrated with the ESP-IDF examples.

--- a/examples/esp_idf/common/shell.c
+++ b/examples/esp_idf/common/shell.c
@@ -358,39 +358,6 @@ static void register_ping_command(void) {
     ESP_ERROR_CHECK(esp_console_cmd_register(&ping_cmd));
 }
 
-static void initialize_console(void) {
-    fflush(stdout);
-    fsync(fileno(stdout));
-    setvbuf(stdin, NULL, _IONBF, 0);
-    esp_vfs_dev_uart_port_set_rx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CR);
-    esp_vfs_dev_uart_port_set_tx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CRLF);
-#ifndef CONFIG_ESP_CONSOLE_USB_CDC
-    const uart_config_t uart_config = {
-        .baud_rate = CONFIG_ESP_CONSOLE_UART_BAUDRATE,
-        .data_bits = UART_DATA_8_BITS,
-        .parity = UART_PARITY_DISABLE,
-        .stop_bits = UART_STOP_BITS_1,
-#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
-        .source_clk = UART_SCLK_REF_TICK,
-#else
-        .source_clk = UART_SCLK_XTAL,
-#endif
-    };
-    ESP_ERROR_CHECK(uart_driver_install(CONFIG_ESP_CONSOLE_UART_NUM, 256, 0, 0, NULL, 0));
-    ESP_ERROR_CHECK(uart_param_config(CONFIG_ESP_CONSOLE_UART_NUM, &uart_config));
-    esp_vfs_dev_uart_use_driver(CONFIG_ESP_CONSOLE_UART_NUM);
-#endif
-    esp_console_config_t console_config = {
-            .max_cmdline_args = 8, .max_cmdline_length = 256, .hint_color = atoi(LOG_COLOR_CYAN)};
-    ESP_ERROR_CHECK(esp_console_init(&console_config));
-    linenoiseSetMultiLine(1);
-    linenoiseSetCompletionCallback(&esp_console_get_completion);
-    linenoiseSetHintsCallback((linenoiseHintsCallback*)&esp_console_get_hint);
-    linenoiseHistorySetMaxLen(100);
-    linenoiseSetMaxLineLen(console_config.max_cmdline_length);
-    linenoiseAllowEmpty(false);
-}
-
 void shell_input_line(const char* line, size_t line_len) {
     int ret;
     esp_err_t err = esp_console_run(line, &ret);
@@ -405,8 +372,23 @@ void shell_input_line(const char* line, size_t line_len) {
     }
 }
 
-static void shell_task(void* arg) {
-    initialize_console();
+void shell_start(void) {
+    esp_console_repl_t* repl = NULL;
+    esp_console_repl_config_t repl_config = ESP_CONSOLE_REPL_CONFIG_DEFAULT();
+    repl_config.prompt = "esp32>";
+
+#if CONFIG_ESP_CONSOLE_UART
+    esp_console_dev_uart_config_t uart_config = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_console_new_repl_uart(&uart_config, &repl_config, &repl));
+#elif CONFIG_ESP_CONSOLE_USB_CDC
+    esp_console_dev_usb_cdc_config_t cdc_config = ESP_CONSOLE_DEV_CDC_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_console_new_repl_usb_cdc(&cdc_config, &repl_config, &repl));
+#elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    esp_console_dev_usb_serial_jtag_config_t usbjtag_config =
+            ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_console_new_repl_usb_serial_jtag(&usbjtag_config, &repl_config, &repl));
+#endif
+
     esp_console_register_help_command();
 
     for (int i = 0; i < COUNT_OF(_cmds); i++) {
@@ -417,68 +399,9 @@ static void shell_task(void* arg) {
         ESP_ERROR_CHECK(esp_console_cmd_register(&_custom_cmds[i]));
     }
 
-    // Ping command requires args to be setup, so register it seperately
     register_ping_command();
 
-    const char* prompt = LOG_COLOR_I PROMPT_STR "> " LOG_RESET_COLOR;
-    printf("\n"
-           "Type 'help' to get the list of commands.\n"
-           "Use UP/DOWN arrows to navigate through command history.\n"
-           "Press TAB when typing command name to auto-complete.\n"
-           "Press Enter or Ctrl+C will terminate the console environment.\n");
-
-    int probe_status = linenoiseProbe();
-    if (probe_status) { /* zero indicates success */
-        printf("\n"
-               "Your terminal application does not support escape sequences.\n"
-               "Line editing and history features are disabled.\n"
-               "On Windows, try using Putty instead.\n");
-        linenoiseSetDumbMode(1);
-        prompt = PROMPT_STR "> ";
-    }
-
-    while (true) {
-        char* line = linenoise(prompt);
-        if (line == NULL) {
-            continue;
-        }
-
-        if (strlen(line) > 0) {
-            linenoiseHistoryAdd(line);
-        }
-
-        int ret;
-        esp_err_t err = esp_console_run(line, &ret);
-        if (err == ESP_ERR_NOT_FOUND) {
-            printf("Unrecognized command\n");
-        } else if (err == ESP_ERR_INVALID_ARG) {
-            // command was empty
-        } else if (err == ESP_OK && ret != ESP_OK) {
-            printf("Command returned non-zero error code: 0x%x (%s)\n", ret, esp_err_to_name(ret));
-        } else if (err != ESP_OK) {
-            printf("Internal error: %s\n", esp_err_to_name(err));
-        }
-        /* linenoise allocates line buffer on the heap, so need to free it */
-        linenoiseFree(line);
-    }
-}
-
-void shell_start(void) {
-    static bool initialized = false;
-    if (!initialized) {
-        bool task_created = xTaskCreate(
-                shell_task,
-                "shell",
-                7168,
-                NULL,  // task arg
-                2,     // pri
-                NULL);
-        if (!task_created) {
-            ESP_LOGE(TAG, "Failed to create shell task");
-        } else {
-            initialized = true;
-        }
-    }
+    ESP_ERROR_CHECK(esp_console_start_repl(repl));
 }
 
 void shell_register_command(const esp_console_cmd_t* cmd) {


### PR DESCRIPTION
Previously, the file shell.c was based on the ESP-IDF example in ${IDF_PATH}/examples/system/console/advanced. This worked for most boards, but it did not work for the Adafruit ESP32-S2/S3 Feather boards, which use USB C and require CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG.

It turns out the ESP-IDF "basic" console examples are a better fit for what we need in shell.c, and they easily support CONSOLE_ESP_CONSOLE_{UART,USB_CDC,USB_SERIAL_JTAG} options, which should cover any ESP32 board.

Tested and confirmed the new shell.c works on the following boards:

ESP32-DevkitC
Magtag ESP32-S2,
Adafruit ESP32-S3 Feather

Signed-off-by: Nick Miller <nick@golioth.io>