### PR TITLE
docs:integration: linking and config instructions

### DIFF
--- a/docs/Integration_Guide.md
+++ b/docs/Integration_Guide.md
@@ -23,6 +23,42 @@ to your project's top-level CMakeLists.txt, which will allow esp-idf to find the
 list(APPEND EXTRA_COMPONENT_DIRS third_party/golioth-firmware-sdk/port/esp_idf/components)
 ```
 
+In your `main/CMakeLists.txt`, you can add `golioth_sdk` to your `REQUIRES` or `PRIV_REQUIRES`
+list, for example:
+
+```
+idf_component_register(
+    INCLUDE_DIRS
+        ...
+    SRCS
+        ...
+    PRIV_REQUIRES
+        "golioth_sdk"
+        ...
+)
+```
+
+Next, make sure your `sdkconfig.defaults` file has the following:
+
+```
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_PSK_MODES=y
+CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y
+CONFIG_LWIP_NETBUF_RECVINFO=y
+CONFIG_FREERTOS_USE_TRACE_FACILITY=y
+CONFIG_FREERTOS_USE_STATS_FORMATTING_FUNCTIONS=y
+
+# Default sdkconfig parameters to use the OTA
+# partition table layout, with a 4MB flash size
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+CONFIG_PARTITION_TABLE_TWO_OTA=y
+
+# If the new app firmware does not cancel the rollback,
+# then this will ensure that rollback happens automatically
+# if/when the device is next rebooted.
+CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
+```
+
 Optionally, you can copy the files from `examples/esp_idf/common` into your project and modify
 as needed. These files can be used to help with basic system initialization of
 NVS, WiFi, and shell.


### PR DESCRIPTION
The ESP-IDF integration was missing a couple of steps about how to link the `golioth_sdk` into another component and what the app config should look like.

Signed-off-by: Nick Miller <nick@golioth.io>