### PR TITLE
Add missing heatshrink dep to MTB, fix misc compilation warnings

### DIFF
--- a/examples/modus_toolbox/golioth_basics/golioth_app/Makefile
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/Makefile
@@ -186,7 +186,8 @@ SOURCES+=\
     $(wildcard $(GOLIOTHSDK_PATH)/port/freertos/*.c)\
     $(wildcard $(GOLIOTHSDK_PATH)/port/modus_toolbox/*.c)\
     $(wildcard $(GOLIOTHSDK_PATH)/port/modus_toolbox/libcoap/*.c)\
-    $(wildcard $(GOLIOTHSDK_PATH)/examples/common/*.c)
+    $(wildcard $(GOLIOTHSDK_PATH)/examples/common/*.c)\
+    $(GOLIOTHSDK_PATH)/external/heatshrink/heatshrink_decoder.c
 
 # Like SOURCES, but for include directories. Value should be paths to
 # directories (without a leading -I).
@@ -210,6 +211,7 @@ INCLUDES+=\
     $(GOLIOTHSDK_PATH)/src/priv_include\
     $(GOLIOTHSDK_PATH)/port/modus_toolbox\
     $(GOLIOTHSDK_PATH)/port/modus_toolbox/libcoap/include\
+    $(GOLIOTHSDK_PATH)/external/heatshrink\
     $(GOLIOTHSDK_PATH)/examples/common
 
 # Add additional defines to the build process (without a leading -D).

--- a/src/golioth_coap_client.c
+++ b/src/golioth_coap_client.c
@@ -577,7 +577,7 @@ static golioth_status_t create_session(
     if (auth_type == GOLIOTH_TLS_AUTH_TYPE_PSK) {
         golioth_psk_credentials_t psk_creds = client->config.credentials.psk;
 
-        GLTH_LOGI(TAG, "Session PSK-ID: %.*s", psk_creds.psk_id_len, psk_creds.psk_id);
+        GLTH_LOGI(TAG, "Session PSK-ID: %.*s", (int)psk_creds.psk_id_len, psk_creds.psk_id);
 
         coap_dtls_cpsk_t dtls_psk = {
                 .version = COAP_DTLS_CPSK_SETUP_VERSION,

--- a/src/golioth_fw_update.c
+++ b/src/golioth_fw_update.c
@@ -157,13 +157,16 @@ static golioth_status_t download_and_write_flash(void) {
     uint64_t elapsed_ms = golioth_sys_now_ms() - start_time_ms;
     GLTH_LOGI(TAG, "Download took %" PRIu64 " ms", elapsed_ms);
     GLTH_LOGI(TAG, "Block Latency Stats:");
-    GLTH_LOGI(TAG, "   Min: %d ms", stats.block_min_ms);
+    GLTH_LOGI(TAG, "   Min: %" PRIu32 " ms", stats.block_min_ms);
     GLTH_LOGI(TAG, "   Ave: %.3f ms", stats.block_ema_ms);
-    GLTH_LOGI(TAG, "   Max: %d ms", stats.block_max_ms);
+    GLTH_LOGI(TAG, "   Max: %" PRIu32 " ms", stats.block_max_ms);
     GLTH_LOGI(TAG, "Total bytes written: %" PRIu32, (uint32_t)bytes_written);
 
     if (hsd) {
-        GLTH_LOGI(TAG, "Compression saved %" PRId32 " bytes", (int)bytes_written - (int)main_size);
+        GLTH_LOGI(
+                TAG,
+                "Compression saved %" PRId32 " bytes",
+                (int32_t)bytes_written - (int32_t)main_size);
         heatshrink_decoder_free(hsd);
     }
 


### PR DESCRIPTION
* Fixes a compilation error in Modus Toolbox (was missing heatshrink in Makefile)
* Fixes two printf-related warnings (one from Linux, one from Modus Toolbox)