### PR TITLE
esp-idf: publicly require json and nvs_flash components

### DIFF
--- a/port/esp_idf/components/golioth_sdk/CMakeLists.txt
+++ b/port/esp_idf/components/golioth_sdk/CMakeLists.txt
@@ -9,15 +9,16 @@ idf_component_register(
     PRIV_INCLUDE_DIRS
         "${sdk_src}/priv_include"
         "${idf_path}/components/freertos/include/freertos"
+    REQUIRES
+        "json"
+        "nvs_flash"
     PRIV_REQUIRES
         "libcoap"
         "heatshrink"
-        "json"
         "lwip"
         "mbedtls"
         "app_update"
         "esp_timer"
-        "nvs_flash"
     SRCS
         "${sdk_port}/freertos//golioth_sys_freertos.c"
         "${sdk_port}/esp_idf/fw_update_esp_idf.c"


### PR DESCRIPTION
Adding `nvs_flash` and `json` to the REQUIRE list of `golioth_sdk`.

The `json` component is required by the public SDK header `golioth_rpc.h` and the `nvs_flash` component is required by the public example headers in `examples/esp_idf/common`.

This makes it so external application can REQUIRE only `golioth_sdk`, without having to explicitly REQUIRE `json` or `nvs_flash`.

Signed-off-by: Nick Miller <nick@golioth.io>