### PR TITLE
esp_idf: rename libcoap component to coap

### DIFF
--- a/port/esp_idf/components/coap/CMakeLists.txt
+++ b/port/esp_idf/components/coap/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Note: this overrides ESP-IDF's coap component
+
 set(sdk_root ../../../..)
 set(sdk_port ${sdk_root}/port)
 set(libcoap_dir ${sdk_root}/external/libcoap)

--- a/port/esp_idf/components/golioth_sdk/CMakeLists.txt
+++ b/port/esp_idf/components/golioth_sdk/CMakeLists.txt
@@ -13,7 +13,7 @@ idf_component_register(
         "json"
         "nvs_flash"
     PRIV_REQUIRES
-        "libcoap"
+        "coap"
         "heatshrink"
         "lwip"
         "mbedtls"


### PR DESCRIPTION
Before this change, we named the libcoap component "libcoap" to avoid a name clash with ESP-IDF's libcoap component named "coap".

However, it's actually better to name the component the same as IDF does, because IDF will resolve the "coap" component to our component instead. It will only do this if the component is named identically:

https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#multiple-components-with-the-same-name

This is important so that the SDK can build correctly in platformio. Otherwise, platformio will link IDF's "coap" component into the binary, which is older than the one we need, and contains a bug that will cause an issue with OTA downloads.

Signed-off-by: Nick Miller <nick@golioth.io>