### PR TITLE
log: dynamically allocate serialized JSON strings

### DIFF
--- a/src/golioth_debug.c
+++ b/src/golioth_debug.c
@@ -106,7 +106,7 @@ void golioth_debug_printf(
     }
 
     // Temporarily allocate a buffer to store the message
-    char* msg_buffer = malloc(buffer_size);
+    char* msg_buffer = golioth_sys_malloc(buffer_size);
     if (!msg_buffer) {
         return;
     }
@@ -143,7 +143,7 @@ void golioth_debug_printf(
 
     // It's safe to free the message buffer, since the async log above
     // makes a copy of the message.
-    free(msg_buffer);
+    golioth_sys_free(msg_buffer);
 }
 
 void golioth_debug_set_client(golioth_client_t client) {

--- a/src/golioth_debug.c
+++ b/src/golioth_debug.c
@@ -69,6 +69,12 @@ void golioth_debug_hexdump(const char* tag, const void* addr, int len) {
     printf("  %s\n", buff);
 }
 
+// Important Note!
+//
+// Do not use GLTH_LOGX statements in this function, as it can cause an infinite
+// recursion with golioth_log_X_async().
+//
+// If you must log, use printf instead.
 void golioth_debug_printf(
         uint64_t tstamp_ms,
         golioth_debug_log_level_t level,

--- a/src/golioth_log.c
+++ b/src/golioth_log.c
@@ -13,6 +13,12 @@
 #define TAG "golioth_log"
 
 #define CONFIG_GOLIOTH_LOG_MAX_MESSAGE_LEN 100
+// Important Note!
+//
+// Do not use GLTH_LOGX statements in this file, as it can cause an infinite
+// recursion with golioth_debug_printf().
+//
+// If you must log, use printf instead.
 
 typedef enum {
     GOLIOTH_LOG_LEVEL_ERROR,


### PR DESCRIPTION
Before this change, any GLTH_LOGX statements longer than 100 characters
were getting silently dropped, because cJSON_PrintPreallocated failed to
serialize to the static buffer, which only had room for 100 characters.

Instead, we will let cJSON dynamically allocate the necessary storage
for us during serialization, and free it after adding it to the CoAP
client queue.