### PR TITLE
golioth_sys_linux: restart sem_timedwait on EINTR

### DIFF
--- a/port/linux/golioth_sys_linux.c
+++ b/port/linux/golioth_sys_linux.c
@@ -64,7 +64,10 @@ bool golioth_sys_sem_take(golioth_sys_sem_t sem, int32_t ms_to_wait) {
                 .tv_sec = abs_timeout_ms / 1000,
                 .tv_nsec = (abs_timeout_ms % 1000) * 1000000,
         };
-        err = sem_timedwait(sem, &abs_timeout);
+
+        while ((err = sem_timedwait(sem, &abs_timeout)) == -1 && errno == EINTR) {
+            continue;  // Restart if interrupt by signal
+        }
     } else {
         err = sem_wait(sem);
     }


### PR DESCRIPTION
Before this change, the Linux implementation of golioth_sys_sem_take was not waiting long enough in the case where another signal is received, i.e. sem_timedwait return EINTR.

This fixes the issue by calling sem_timedwait in a loop if the errno is EINTR.

Signed-off-by: Nick Miller <nick@golioth.io>