### PR TITLE
coap_client: remove sys/socket.h

### DIFF
--- a/src/golioth_coap_client.c
+++ b/src/golioth_coap_client.c
@@ -5,7 +5,6 @@
  */
 #include <stdbool.h>
 #include <string.h>
-#include <sys/socket.h>
 #include <netdb.h>      // struct addrinfo
 #include <sys/param.h>  // MIN
 #include <coap3/coap.h>


### PR DESCRIPTION
It seems that there is nothing actually using this header, so remove it.