### PR TITLE
.github: remove check for fork pull request

### DIFF
--- a/.github/workflows/firebase-doxygen-pr.yml
+++ b/.github/workflows/firebase-doxygen-pr.yml
@@ -12,8 +12,6 @@ jobs:
           cd docs/doxygen
           doxygen
       - name: Deploy docs to dev
-        # The 'if' will prevent running this step if in a fork pull request
-        if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -11,8 +11,6 @@ on:
 jobs:
   build_for_hw_test:
     runs-on: ubuntu-latest
-    # The 'if' will prevent running this job if from a fork pull request
-    if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v3


### PR DESCRIPTION
This check is no longer needed.

The original intent was to prevent self-hosted Actions Runner jobs from executing from fork pull requests, as a security measure to prevent remote code execution.

However, we have since disabled automatic execution of these jobs for PRs from outside collaborators in the GitHub repo settings (requires approval before running), so the guard in the .yml is not needed anymore.

Signed-off-by: Nick Miller <nick@golioth.io>