### PR TITLE
examples: esp_idf: clone and checkout all modules in one step

### DIFF
--- a/examples/esp_idf/README.md
+++ b/examples/esp_idf/README.md
@@ -16,10 +16,8 @@ For Linux users, you can install esp-idf with these commands:
 sudo apt-get install git wget flex bison gperf python3 python3-venv cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0
 mkdir -p ~/esp
 cd ~/esp
-git clone --recursive https://github.com/espressif/esp-idf.git
+git clone --recursive https://github.com/espressif/esp-idf.git -b v5.0
 cd esp-idf
-git checkout v5.0
-git submodule update --init --recursive
 ./install.sh all
 ```
 


### PR DESCRIPTION
Instead of invoking `git clone ...` on default branch, recursively cloning
all modules and then manually checking out latest release tag (v5.0)
followed by updating submodules, just do everything in one step by simply
providing `git clone ... -b v5.0`.