### PR TITLE
submodule: change heatshrink URL to golioth/heatshrink

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/DaveGamble/cJSON
 [submodule "external/heatshrink"]
 	path = external/heatshrink
-	url = https://github.com/atomicobject/heatshrink.git
+	url = https://github.com/golioth/heatshrink.git


### PR DESCRIPTION
The submodule now points to the Golioth fork of
`atomicobject/heatshrink`.

The fork is required in order to change configuration in
heatshrink_config.h, which will happen in subsequent commits.

For local repo clones, you will need to update with:

```
git submodule sync --recursive
git submodule update --recursive
```

Signed-off-by: Nick Miller <nick@golioth.io>