### PR TITLE
golioth_coap_client: use COAP_LOG_INFO instead of abitrary number

### DIFF
--- a/src/golioth_coap_client.c
+++ b/src/golioth_coap_client.c
@@ -945,7 +945,7 @@ golioth_client_t golioth_client_create(const golioth_client_config_t* config) {
     if (!_initialized) {
         // Connect logs from libcoap to the ESP logger
         coap_set_log_handler(coap_log_handler);
-        coap_set_log_level(6);  // 3: error, 4: warning, 6: info, 7: debug, 9:mbedtls
+        coap_set_log_level(COAP_LOG_INFO);
 
         // Seed the random number generator. Used for token generation.
         time_t t;


### PR DESCRIPTION
libcoap introduced enums for log levels, so use those instead of abitrary
log level integer.