### PR TITLE
fw_update_linux: fix double-close of _fp

### DIFF
--- a/port/linux/fw_update_linux.c
+++ b/port/linux/fw_update_linux.c
@@ -45,6 +45,7 @@ golioth_status_t fw_update_handle_block(
 void fw_update_post_download(void) {
     if (_fp) {
         fclose(_fp);
+        _fp = NULL;
     }
 }
 #else


### PR DESCRIPTION
If a second firmware update is attempted, then the program will abort due to attempting to fclose(_fp) a second time.

Setting _fp to NULL after fclose() prevents it from being called a second time.