### PR TITLE
esp_idf/test: increase connect timeout to 2x resp timeout

### DIFF
--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -103,7 +103,9 @@ static void test_golioth_client_create(void) {
 static void test_connects_to_golioth(void) {
     TEST_ASSERT_NOT_NULL(_client);
     TEST_ASSERT_EQUAL(GOLIOTH_OK, golioth_client_start(_client));
-    TEST_ASSERT_EQUAL(pdTRUE, xSemaphoreTake(_connected_sem, 10000 / portTICK_PERIOD_MS));
+    TEST_ASSERT_EQUAL(
+            pdTRUE,
+            xSemaphoreTake(_connected_sem, TEST_RESPONSE_TIMEOUT_S * 1000 / portTICK_PERIOD_MS));
 }
 
 static void test_golioth_client_heap_usage(void) {


### PR DESCRIPTION
test_connects_to_golioth() often fails due to a known bug on the backend that can cause the DTLS handshake to timeout (GB-564).

In a prior commit, the macro TEST_RESPONSE_TIMEOUT_S was introduced which sets the connect timeout to 2x + 1 seconds, where x is the timeout for a single request. This allows for one timeout to occur without failing the test.

It was intended that the test_connects_to_golioth() test use this macro, but it was overlooked/missed in the prior commit.