### PR TITLE
coap_client: remove unused psk and psk_len

### DIFF
--- a/src/golioth_coap_client.c
+++ b/src/golioth_coap_client.c
@@ -33,8 +33,6 @@ typedef struct {
     bool end_session;
     bool session_connected;
     golioth_client_config_t config;
-    const char* psk;
-    size_t psk_len;
     golioth_coap_request_msg_t* pending_req;
     golioth_coap_observe_info_t observations[CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS];
     // token to use for block GETs (must use same token for all blocks)


### PR DESCRIPTION
These are not used anywhere, and can be deleted from golioth_coap_client_t.