### PR TITLE
port: remove COAP_RESOURCES_NOHASH definition

### DIFF
--- a/port/esp_idf/libcoap/include/coap_config.h
+++ b/port/esp_idf/libcoap/include/coap_config.h
@@ -40,6 +40,4 @@
 
 #define HAVE_GETRANDOM
 
-#define COAP_RESOURCES_NOHASH
-
 #endif /* _CONFIG_H_ */

--- a/port/modus_toolbox/libcoap/include/coap_config.h
+++ b/port/modus_toolbox/libcoap/include/coap_config.h
@@ -22,7 +22,6 @@
 
 #define COAP_CONSTRAINED_STACK 1
 #define COAP_DISABLE_TCP 1
-#define COAP_RESOURCES_NOHASH
 #define ESPIDF_VERSION /* hack for net.c, to avoid usage of SIOCGIFADDR, which is not defined */
 // #define WITH_LWIP 1 /* compilation error related to MEMP macros */
 


### PR DESCRIPTION
Remove `COAP_RESOURCES_NOHASH` from our codebase, as it was deprecated in
libcoap back in 2018.

See: https://github.com/obgm/libcoap/commit/fbe1b8283d98fb796302a45dd442624e44642f91