### PR TITLE
add workflow-displatch to esp32s3 test

### DIFF
--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -8,6 +8,8 @@ on:
     # Run workflow at the start of every day (12 AM UTC)
     - cron: "0 0 * * *"
 
+  workflow_dispatch:
+
 jobs:
   build_for_hw_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
this presents a button on the GitHub actions page to manually trigger a hardware-in-the-loop (HIL) test on the esp32s3