### PR TITLE
.github: use "on: pull_request_target" for doxygen

### DIFF
--- a/.github/workflows/firebase-doxygen-pr.yml
+++ b/.github/workflows/firebase-doxygen-pr.yml
@@ -1,5 +1,5 @@
 name: Deploy Doxygen to Firebase Hosting on PR
-'on': pull_request
+'on': pull_request_target
 jobs:
   deploy_doxygen_dev:
     runs-on: ubuntu-latest


### PR DESCRIPTION
For PRs from forked pull requests, the `firebase-doxygen-pr.yml` workflow will fail with the following error:

```
/home/runner/work/_actions/FirebaseExtended/action-hosting-deploy/v0/bin/action.min.js:274
        throw new Error(`Input required and not supplied: ${name}`);
        ^
```

This happens because the workflow does not have access to the repository secrets from the fork.

This is being resolved by changing the workflow to trigger on `pull_request_target`, which means it runs in the context of the base of the pull request, which has access to the repo secrets.

The workflow still requires approval from a Golioth team member to run, so from a security perspective, it will be as secure as it was before this commit.

More information is available here:

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target