### PR TITLE
port: esp_idf: define HAVE_PTHREAD_{H,MUTEX_LOCK}

### DIFF
--- a/port/esp_idf/libcoap/include/coap_config_posix.h
+++ b/port/esp_idf/libcoap/include/coap_config_posix.h
@@ -32,6 +32,8 @@
 #define HAVE_NETINET_IN_H
 #define HAVE_STRUCT_CMSGHDR
 #define COAP_DISABLE_TCP 0
+#define HAVE_PTHREAD_H
+#define HAVE_PTHREAD_MUTEX_LOCK
 
 #define ipi_spec_dst ipi_addr
 struct in6_pktinfo {


### PR DESCRIPTION
This way libcoap will use `pthread_mutex_*()` APIs from `pthread.h`. This
suppresses preprecessor `#warning` messages about mutex stubs.

Fixes: #78