### PR TITLE
esp_idf: convert GOLIOTH_REMOTE_SHELL_ENABLE to bool

### DIFF
--- a/port/esp_idf/components/golioth_sdk/Kconfig
+++ b/port/esp_idf/components/golioth_sdk/Kconfig
@@ -190,8 +190,7 @@ config GOLIOTH_AUTO_LOG_TO_CLOUD
         configuration item. The flag can also be set at runtime.
 
 config GOLIOTH_REMOTE_SHELL_ENABLE
-    int "(Experimental) Enable remote shell"
-    default 0
+    bool "(Experimental) Enable remote shell"
     help
         Enable/disable golioth_remote_shell feature.
 


### PR DESCRIPTION
This option was defined as `int`, but it actually is a only a boolean
option. Convert it to `bool`.