### PR TITLE
zephyr: dfu: allow most DFU steps with bootloader disabled

### DIFF
--- a/port/zephyr/golioth_fw_zephyr.c
+++ b/port/zephyr/golioth_fw_zephyr.c
@@ -168,7 +168,7 @@ golioth_status_t fw_update_handle_block(
     int err;
 
     if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT)) {
-        return GOLIOTH_ERR_NOT_IMPLEMENTED;
+        return GOLIOTH_OK;
     }
 
     if (offset == 0) {
@@ -201,10 +201,6 @@ void fw_update_post_download(void) {
 }
 
 golioth_status_t fw_update_validate(void) {
-    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT)) {
-        return GOLIOTH_ERR_NOT_IMPLEMENTED;
-    }
-
     return GOLIOTH_OK;
 }
 


### PR DESCRIPTION
Allow to transfer DFU artifact with disabled support for bootloader. This
makes it possible to test most DFU steps, with the only exception being
saving artifact to persistent storage (flash). This allows to test DFU with
`qemu_x86` (which does not have emulated flash storage) as well as
platforms like `nrf52840dk_nrf52840` with disabled bootloader
support (simplifies debugging, reduces flash wear, download latencies).