### PR TITLE
fix: emit accurate logging message on failure to create fw update thread

### DIFF
--- a/src/golioth_fw_update.c
+++ b/src/golioth_fw_update.c
@@ -280,7 +280,7 @@ void golioth_fw_update_init_with_config(
                 .stack_size = CONFIG_GOLIOTH_OTA_THREAD_STACK_SIZE,
                 .prio = 3});
         if (!thread) {
-            GLTH_LOGE(TAG, "Failed to create shell thread");
+            GLTH_LOGE(TAG, "Failed to create firmware update thread");
         } else {
             initialized = true;
         }


### PR DESCRIPTION
Fixes the logging message on failure to create a firmware update thread, which previously referred to creating a shell thread, likely copied from the remote shell thread.