### PR TITLE
remote_shell: include assert.h

### DIFF
--- a/src/golioth_remote_shell.c
+++ b/src/golioth_remote_shell.c
@@ -11,6 +11,7 @@
 #include "golioth_config.h"
 #include "golioth_sys.h"
 #include "cJSON.h"
+#include <assert.h>
 #include <string.h>
 
 LOG_TAG_DEFINE(golioth_remote_shell);


### PR DESCRIPTION
assert() is defined only after including assert.h.