### PR TITLE
esp-idf: basics: Fix doc for remote shell enable

### DIFF
--- a/examples/esp_idf/golioth_basics/README.md
+++ b/examples/esp_idf/golioth_basics/README.md
@@ -29,7 +29,11 @@ https://github.com/goliothlabs/ble_prov_web
 
 ### Remote shell
 
-In `sdkconfig`, set `CONFIG_GOLIOTH_REMOTE_SHELL_ENABLE=1`.
+In `sdkconfig`, set the remote shell enable symbol:
+
+```
+CONFIG_GOLIOTH_REMOTE_SHELL_ENABLE=y
+```
 
 Use the remote shell web app (experimental) to interact with the device:
 


### PR DESCRIPTION
Correct the golioth_basics README for esp-idf to indicate `CONFIG_GOLIOTH_REMOTE_SHELL_ENABLE` should be set to `y`, not `1`.