### PR TITLE
test: set ENABLE_DOCS to OFF to disable libcoap Doxygen build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ target_include_directories(cjson PUBLIC "${cjson_dir}")
 
 # Build libcoap
 
+set(ENABLE_DOCS OFF)
 add_subdirectory("${repo_root}/external/libcoap" build)
 
 # Function for declaring unit tests


### PR DESCRIPTION
Doxygen build fails, since libcoap's `CMakeLists.txt` is included instead of
being the root file and specific (libcoap) folder structure is assumed.
Disable libcoap Doxygen build by forcing `ENABLE_DOCS` option to be `OFF`.