### PR TITLE
port/esp_idf: Fix typo

### DIFF
--- a/port/esp_idf/components/golioth_sdk/CMakeLists.txt
+++ b/port/esp_idf/components/golioth_sdk/CMakeLists.txt
@@ -29,7 +29,7 @@ idf_component_register(
         "app_update"
         "esp_timer"
     SRCS
-        "${sdk_port}/freertos//golioth_sys_freertos.c"
+        "${sdk_port}/freertos/golioth_sys_freertos.c"
         "${sdk_port}/esp_idf/fw_update_esp_idf.c"
         "${sdk_port}/esp_idf/serial_tap_esp_idf.c"
         "${sdk_src}/golioth_status.c"


### PR DESCRIPTION
Remove extra '/' in path