### PR TITLE
ci: add pre-commit and gitlint workflows

### DIFF
--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -1,0 +1,23 @@
+name: gitlint
+
+on:
+  pull_request:
+
+  workflow_dispatch:
+
+jobs:
+  gitlint:
+    runs-on: ubuntu-latest
+
+    container:
+      image: jorisroovers/gitlint:0.19.1
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run gitlint
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          gitlint --commits origin/$GITHUB_BASE_REF..

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,29 @@
+name: pre-commit
+
+on:
+  pull_request:
+
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    container:
+      image: kiwicom/pre-commit:3.0.4
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run pre-commit
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          CODE=0 # run pre-commit
+          for CID in `git rev-list --reverse origin/$GITHUB_BASE_REF..`; do
+              git show $CID -s --format='    pre-commit %h ("%s")'
+              git checkout -f -q $CID
+              pre-commit run --color always --show-diff-on-failure --from-ref $CID^ --to-ref $CID || CODE=$?
+          done
+          exit $CODE

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,7 @@
+[general]
+# Set the extra-path where gitlint will search for user defined rules
+# See http://jorisroovers.github.io/gitlint/user_defined_rules for details
+extra-path=scripts/gitlint
+
+[body-max-line-length]
+line-length=75

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+exclude: '^patches/'
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.10
+    hooks:
+      - id: forbid-crlf

--- a/scripts/gitlint/commit_rules.py
+++ b/scripts/gitlint/commit_rules.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+from gitlint.rules import CommitRule, RuleViolation
+
+
+class SignedOffBy(CommitRule):
+    """ This rule will enforce that each commit contains a "Signed-off-by" line.
+    We keep things simple here and just check whether the commit body contains a line that starts with "Signed-off-by".
+    """
+
+    # A rule MUST have a human friendly name
+    name = "body-requires-signed-off-by"
+
+    # A rule MUST have an *unique* id, we recommend starting with UC (for User-defined Commit-rule).
+    id = "UC1"
+
+    def validate(self, commit):
+        flags = re.UNICODE
+        flags |= re.IGNORECASE
+        for line in commit.message.body:
+            if line.lower().startswith("signed-off-by"):
+                if not re.search(r"(^)Signed-off-by: ([-'\w.]+) ([-'\w.]+) (.*)", line, flags=flags):
+                    return [RuleViolation(self.id, "Signed-off-by: must have a full name", line_nr=1)]
+                else:
+                    return
+        return [RuleViolation(self.id, "Body does not contain a 'Signed-off-by:' line", line_nr=1)]


### PR DESCRIPTION
There are few things that pre-commit checks, probably best described by
looking at the configured hooks documentation.

gitlint will allow for basic style check of commits messages. Add also
gitlint user defined check for Signed-off-by line.

This configuration was copied from Zephyr SDK.