### PR TITLE
client: handle NACKed CoAP requests

### DIFF
--- a/src/golioth_coap_client.c
+++ b/src/golioth_coap_client.c
@@ -44,10 +44,8 @@ typedef struct {
     golioth_rpc_t rpc;
 } golioth_coap_client_t;
 
-static bool token_matches_request(
-        const golioth_coap_request_msg_t* req,
-        const coap_pdu_t* received) {
-    coap_bin_const_t rcvd_token = coap_pdu_get_token(received);
+static bool token_matches_request(const golioth_coap_request_msg_t* req, const coap_pdu_t* pdu) {
+    coap_bin_const_t rcvd_token = coap_pdu_get_token(pdu);
     bool len_matches = (rcvd_token.length == req->token_len);
     return (len_matches && (0 == memcmp(rcvd_token.s, req->token, req->token_len)));
 }

--- a/src/priv_include/golioth_coap_client.h
+++ b/src/priv_include/golioth_coap_client.h
@@ -87,6 +87,7 @@ typedef struct {
     /// Primarily intended to be used for synchronous requests, to avoid blocking forever.
     uint64_t ageout_ms;
     bool got_response;
+    bool got_nack;
 
     /// (sync request only) Notification from coap thread to user sync function that
     /// request is completed.


### PR DESCRIPTION
CoAP requests can be NACKed by libcoap stack for multiple reasons. The most
probable is `COAP_NACK_TOO_MANY_RETRIES`, which is triggered when network
medium goes down.