### PR TITLE
drop cJSON as dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "external/fff"]
 	path = external/fff
 	url = https://github.com/meekrosoft/fff.git
-[submodule "external/cJSON"]
-	path = external/cJSON
-	url = https://github.com/DaveGamble/cJSON
 [submodule "external/heatshrink"]
 	path = external/heatshrink
 	url = https://github.com/atomicobject/heatshrink.git

--- a/docs/Integration_Guide.md
+++ b/docs/Integration_Guide.md
@@ -139,7 +139,6 @@ release 3.0 from Infineon.
 ```
 echo 'https://github.com/golioth/golioth-firmware-sdk#v0.5.0#$$ASSET_REPO$$/golioth-firmware-sdk/v0.5.0' > deps/golioth-firmware-sdk.mtb
 echo 'https://github.com/obgm/libcoap#bbf098a72adeb8b5f9508e5a9f3a409f9a298d7a#$$ASSET_REPO$$/libcoap/bbf098a72adeb8b5f9508e5a9f3a409f9a298d7a' > deps/libcoap.mtb
-echo 'https://github.com/DaveGamble/cJSON#v1.7.15#$$ASSET_REPO$$/cJSON/v1.7.15' > deps/cJSON.mtb
 echo 'https://github.com/mcu-tools/mcuboot#v1.8.1-cypress#$$ASSET_REPO$$/mcuboot/v1.8.1-cypress' > deps/mcuboot.mtb
 ```
 

--- a/examples/modus_toolbox/golioth_basics/golioth_app/.cyignore
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/.cyignore
@@ -12,8 +12,3 @@ $(SEARCH_libcoap)/src/coap_io_riot.c
 $(SEARCH_libcoap)/src/coap_gnutls.c
 $(SEARCH_libcoap)/src/coap_tinydtls.c
 $(SEARCH_libcoap)/src/coap_openssl.c,)
-
-$(if $(SEARCH_cJSON),
-$(SEARCH_cJSON)/fuzzing
-$(SEARCH_cJSON)/tests
-$(SEARCH_cJSON)/test.c,)

--- a/examples/modus_toolbox/golioth_basics/golioth_app/deps/cJSON.mtb
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/deps/cJSON.mtb
@@ -1,1 +1,0 @@
-https://github.com/DaveGamble/cJSON#v1.7.15#$$ASSET_REPO$$/cJSON/v1.7.15

--- a/port/esp_idf/components/golioth_sdk/CMakeLists.txt
+++ b/port/esp_idf/components/golioth_sdk/CMakeLists.txt
@@ -16,7 +16,6 @@ idf_component_register(
         "${sdk_src}/priv_include"
         "${freertos_include_dir}"
     REQUIRES
-        "json"
         "nvs_flash"
         "zcbor"
     PRIV_REQUIRES

--- a/port/linux/golioth_sdk/CMakeLists.txt
+++ b/port/linux/golioth_sdk/CMakeLists.txt
@@ -12,14 +12,6 @@ option(ENABLE_SERVER_MODE "" OFF)
 option(ENABLE_TCP "" OFF)
 add_subdirectory("${repo_root}/external/libcoap" build)
 
-# Build cJSON from source
-set(cjson_dir "${repo_root}/external/cJSON")
-add_library(cjson
-    "${cjson_dir}/cJSON.c"
-    "${cjson_dir}/cJSON_Utils.c"
-)
-target_include_directories(cjson PUBLIC "${cjson_dir}")
-
 set(heatshrink_srcs
     "${heatshrink_dir}/src/heatshrink_decoder.c"
 )
@@ -84,6 +76,5 @@ target_include_directories(golioth_sdk
         ${sdk_src}/priv_include
 )
 target_link_libraries(golioth_sdk
-    PUBLIC cjson
     PRIVATE coap-3 pthread rt)
 target_compile_definitions(golioth_sdk PRIVATE -DHEATSHRINK_DYNAMIC_ALLOC=0)

--- a/port/zephyr/CMakeLists.txt
+++ b/port/zephyr/CMakeLists.txt
@@ -9,11 +9,6 @@ zephyr_library()
 zephyr_library_include_directories(../../src/include)
 zephyr_library_include_directories(../../src/priv_include)
 
-zephyr_include_directories(
-    # cJSON
-    ../../external/cJSON
-)
-
 zephyr_library_include_directories(
     # bsdiff
     ../../external/bsdiff
@@ -55,10 +50,6 @@ zephyr_library_sources(
 
     # bsdiff
     ../../external/bsdiff/bspatch.c
-
-    # cJSON
-    ../../external/cJSON/cJSON.c
-    ../../external/cJSON/cJSON_Utils.c
 
     # heatshrink
     ../../external/heatshrink/src/heatshrink_decoder.c

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -5,7 +5,7 @@ menuconfig GOLIOTH_FIRMWARE_SDK
 	bool "Golioth Firmware SDK"
 	select POSIX_API # libcoap
 	select REBOOT if BOOTLOADER_MCUBOOT
-	select REQUIRES_FULL_LIBC # cJSON, libcoap
+	select REQUIRES_FULL_LIBC # libcoap
 
 if GOLIOTH_FIRMWARE_SDK
 


### PR DESCRIPTION
cJSON library is not used anymore, since all common samples and services were convered to use zcbor library instead.

There is still a `magtag_demo` sample specific to ESP-IDF which uses cJSON. Since cJSON is provided by ESP-IDF itself, it will still work without issues.

Dropping cJSON from SDK allows to reduce maintenance on SDK development team as well as reduce number of 3rdparty projects that need to be cloned and mirrored by downstream projects.