### PR TITLE
zephyr: drop doubled include path

### DIFF
--- a/port/zephyr/CMakeLists.txt
+++ b/port/zephyr/CMakeLists.txt
@@ -6,7 +6,6 @@ zephyr_include_directories(include)
 zephyr_include_directories(../../src/include)
 
 zephyr_library()
-zephyr_library_include_directories(../../src/include)
 zephyr_library_include_directories(../../src/priv_include)
 
 zephyr_include_directories(


### PR DESCRIPTION
`../../src/include` is already included with `zephyr_include_directories()`,
which adds it to global scope. There is no reason to add it to (Golioth
SDK) library scope explicitly again.