### PR TITLE
Update indent rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ Standard: Cpp11
 AccessModifierOffset: -4
 ColumnLimit: 100
 ConstructorInitializerIndentWidth: 8
-ContinuationIndentWidth: 8
+ContinuationIndentWidth: 4
 IndentCaseLabels: true
 IndentWidth: 4
 IndentWrappedFunctionNames: false

--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -24,7 +24,7 @@ jobs:
         git fetch --no-recurse-submodules
         echo "Checking code format"
         sudo apt install clang-format
-        REPO_ROOT=`pwd` ./scripts/lint/ci_check_clang_format.sh
+        REPO_ROOT=`pwd` ./scripts/lint/ci_check_clang_format.sh --merge-base origin/$GITHUB_BASE_REF
     - name: Run unit tests
       shell: bash
       run: |

--- a/scripts/lint/ci_check_clang_format.sh
+++ b/scripts/lint/ci_check_clang_format.sh
@@ -8,10 +8,26 @@ set -euxo pipefail
 
 cd "$(dirname "$0")"
 
-merge_base=origin/main
+MERGE_BASE=origin/main
+
+# https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    --merge-base)
+    MERGE_BASE="$2"
+    shift # past argument
+    ;;
+    *)
+    # unknown option
+    ;;
+esac
+shift # past argument or value
+done
 
 set +e
-./check_clang_format.sh --against "$merge_base" --verbose --show-files
+./check_clang_format.sh --against "$MERGE_BASE" --verbose --show-files
 status=$?
 
 if [[ $status -ne 0 ]]


### PR DESCRIPTION
The main goal behind this PR was to update our clang-format rules to use 4 spaces for ContinuationIndentWidth instead of 8, to match the rest of our indentation widths. This exposed 2 issues that are also fixed in this PR:
- We were previously always checking the diff between `HEAD` and `origin/main` which meant that making a change to .clang-format could flag unrelated commits if the base branch for a PR wasn't `origin/main`.
- The script we use to run clang-format only on files in the git diff checked the whole file, instead of just the lines in the git diff. This could also result in clang-format flagging unrelated changes. Instead of our custom tooling, we can use `git-clang-format`, which is distributed alongside `clang-format` and already has the ability to only check the lines that are in the git diff between two commits.