### PR TITLE
zephyr: remove CIPHERSUITES and unused tests

### DIFF
--- a/examples/zephyr/hello/sample.yaml
+++ b/examples/zephyr/hello/sample.yaml
@@ -13,36 +13,3 @@ tests:
     platform_allow: >
       nrf52840dk_nrf52840
       qemu_x86
-  sample.golioth.hello.psk.fast.gcm:
-    platform_allow: >
-      nrf52840dk_nrf52840
-      qemu_x86
-    extra_configs:
-      - CONFIG_MBEDTLS_CIPHER_GCM_ENABLED=y
-      - CONFIG_MBEDTLS_CIPHER_CCM_ENABLED=n
-      - CONFIG_MBEDTLS_CIPHER_MODE_CBC_ENABLED=n
-  sample.golioth.hello.psk.fast.ccm:
-    platform_allow: >
-      nrf52840dk_nrf52840
-      qemu_x86
-    extra_configs:
-      - CONFIG_MBEDTLS_CIPHER_GCM_ENABLED=n
-      - CONFIG_MBEDTLS_CIPHER_CCM_ENABLED=y
-      - CONFIG_MBEDTLS_CIPHER_MODE_CBC_ENABLED=n
-  sample.golioth.hello.psk.fast.cbc:
-    platform_allow: >
-      nrf52840dk_nrf52840
-      qemu_x86
-    extra_configs:
-      - CONFIG_MBEDTLS_CIPHER_GCM_ENABLED=n
-      - CONFIG_MBEDTLS_CIPHER_CCM_ENABLED=n
-      - CONFIG_MBEDTLS_CIPHER_MODE_CBC_ENABLED=y
-  sample.golioth.hello.psk.fast.ccm_8:
-    platform_allow: >
-      nrf52840dk_nrf52840
-      qemu_x86
-    extra_configs:
-      - CONFIG_MBEDTLS_CIPHER_GCM_ENABLED=n
-      - CONFIG_MBEDTLS_CIPHER_CCM_ENABLED=y
-      - CONFIG_MBEDTLS_CIPHER_MODE_CBC_ENABLED=n
-      - CONFIG_GOLIOTH_CIPHERSUITES="TLS_PSK_WITH_AES_128_CCM_8"

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -23,43 +23,6 @@ menu "Golioth SDK Configuration"
 
 rsource '${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/src/Kconfig'
 
-config GOLIOTH_CIPHERSUITES
-	string "Ciphersuites"
-	# Select single PSK ciphersuite (following ciphersuite preference in mbedTLS)
-	default "TLS_PSK_WITH_AES_128_GCM_SHA256" if (GOLIOTH_AUTH_METHOD_PSK && MBEDTLS_BUILTIN && MBEDTLS_CIPHER_GCM_ENABLED)
-	default "TLS_PSK_WITH_AES_128_CCM" if (GOLIOTH_AUTH_METHOD_PSK && MBEDTLS_BUILTIN && MBEDTLS_CIPHER_CCM_ENABLED)
-	default "TLS_PSK_WITH_AES_128_CBC_SHA256" if (GOLIOTH_AUTH_METHOD_PSK && MBEDTLS_BUILTIN && MBEDTLS_CIPHER_MODE_CBC_ENABLED)
-	# Same, but for NCS flavour of mbedTLS
-	default "TLS_PSK_WITH_AES_128_GCM_SHA256" if (GOLIOTH_AUTH_METHOD_PSK && ZEPHYR_NRF_MODULE && MBEDTLS_TLS_LIBRARY && MBEDTLS_GCM_C)
-	default "TLS_PSK_WITH_AES_128_CCM" if (GOLIOTH_AUTH_METHOD_PSK && ZEPHYR_NRF_MODULE && MBEDTLS_TLS_LIBRARY && MBEDTLS_CCM_C)
-	default "TLS_PSK_WITH_AES_128_CBC_SHA256" if (GOLIOTH_AUTH_METHOD_PSK && ZEPHYR_NRF_MODULE && MBEDTLS_TLS_LIBRARY && MBEDTLS_CIPHER_MODE_CBC)
-	# Select all supported PSK ciphersuites if not using MBEDTLS_BUILTIN
-	default "TLS_PSK_WITH_AES_128_GCM_SHA256 TLS_PSK_WITH_AES_128_CCM TLS_PSK_WITH_AES_128_CBC_SHA256 TLS_PSK_WITH_AES_128_CCM_8" if GOLIOTH_AUTH_METHOD_PSK
-	# Select single cert-based ciphersuite (following ciphersuite preference in mbedTLS)
-	default "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" if (GOLIOTH_AUTH_METHOD_CERT && MBEDTLS_BUILTIN && MBEDTLS_CIPHER_GCM_ENABLED)
-	default "TLS_ECDHE_ECDSA_WITH_AES_128_CCM" if (GOLIOTH_AUTH_METHOD_CERT && MBEDTLS_BUILTIN && MBEDTLS_CIPHER_CCM_ENABLED)
-	# Same, but for NCS flavour of mbedTLS
-	default "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" if (GOLIOTH_AUTH_METHOD_CERT && ZEPHYR_NRF_MODULE && MBEDTLS_TLS_LIBRARY && MBEDTLS_GCM_C)
-	default "TLS_ECDHE_ECDSA_WITH_AES_128_CCM" if (GOLIOTH_AUTH_METHOD_CERT && ZEPHYR_NRF_MODULE && MBEDTLS_TLS_LIBRARY && MBEDTLS_CCM_C)
-	# Select all supported cert-based ciphersuites if not using MBEDTLS_BUILTIN
-	default "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_ECDSA_WITH_AES_128_CCM TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8" if GOLIOTH_AUTH_METHOD_CERT
-	help
-	  Ciphersuite list used during (D)TLS handshakes. Default value contains currently supported
-	  ciphersuites by Golioth server.
-
-	  Use string representations of ciphersuites as defined by IANA in:
-	  https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml
-
-	  Select single ciphersuite to reduce data exchanged during (D)TLS handshake, due to reduced
-	  ciphersuite list in Client Hello message.
-
-	  Make sure that credentials (e.g. using Zephyr TLS credentials subsystem) are configured
-	  for each ciphersuite (e.g. PSKs for PSK-based ciphersuites or certificates for
-	  certificate-based ciphersuites) that is negotiated.
-
-	  If empty, then underlying TLS implementation (e.g. mbedTLS library) decides which
-	  ciphersuites to use. Relying on that is not recommended!
-
 choice GOLIOTH_AUTH_METHOD
 	prompt "Authentication method support"
 


### PR DESCRIPTION
CIPHERSUITES was added to Kconfig in a previous commit because it was used in the `hello` twister testing. However, those test cases were for features yet to be implemented. This removes the unused tests.