### PR TITLE
gitignore: ignore ctags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ firebase-debug.log
 mtb_shared
 *.key
 *.pem
+
+# Tag files
+tags
+tags.lock
+tags.temp


### PR DESCRIPTION
Ignore the `tags` files generated by ctags when indexing the source code