### PR TITLE
ota: handle -ENOENT from zcbor_map_decode() in case of no releases

### DIFF
--- a/src/golioth_ota.c
+++ b/src/golioth_ota.c
@@ -232,12 +232,12 @@ golioth_status_t golioth_ota_payload_as_manifest(
 
     memset(manifest, 0, sizeof(*manifest));
 
-    if (payload_size == 1 && payload[0] == 0xa0) {
-        return GOLIOTH_OK;
-    }
-
     err = zcbor_map_decode(zsd, map_entries, ARRAY_SIZE(map_entries));
     if (err) {
+        if (err == -ENOENT) {
+            return GOLIOTH_OK;
+        }
+
         GLTH_LOGW(TAG, "Failed to decode desired map: %d", err);
         return GOLIOTH_ERR_INVALID_FORMAT;
     }

--- a/src/zcbor_utils.c
+++ b/src/zcbor_utils.c
@@ -91,7 +91,7 @@ int zcbor_map_decode(zcbor_state_t* zsd, struct zcbor_map_entry* entries, size_t
     struct zcbor_map_entry* entry;
     size_t num_decoded = 0;
     struct zcbor_map_key key;
-    int err;
+    int err = 0;
     bool ok;
 
     ok = zcbor_map_start_decode(zsd);
@@ -122,15 +122,21 @@ int zcbor_map_decode(zcbor_state_t* zsd, struct zcbor_map_entry* entries, size_t
         }
     }
 
+    if (num_decoded == 0) {
+        err = -ENOENT;
+        goto map_end_decode;
+    }
+
     if (num_decoded < num_entries) {
         return -EBADMSG;
     }
 
+map_end_decode:
     ok = zcbor_list_map_end_force_decode(zsd);
     if (!ok) {
         GLTH_LOGW(TAG, "Did not end CBOR map correctly");
         return -EBADMSG;
     }
 
-    return 0;
+    return err;
 }

--- a/src/zcbor_utils.h
+++ b/src/zcbor_utils.h
@@ -81,6 +81,7 @@ int zcbor_map_tstr_decode(zcbor_state_t* zsd, void* value);
  *
  * @retval  0       On success
  * @retval -EBADMSG Failed to parse all map entries
+ * @retval -ENOENT  Map was empty
  * @retval <0       Other error returned from @ entries decode callback
  */
 int zcbor_map_decode(zcbor_state_t* zsd, struct zcbor_map_entry* entries, size_t num_entries);

--- a/src/zcbor_utils.h
+++ b/src/zcbor_utils.h
@@ -78,6 +78,10 @@ int zcbor_map_tstr_decode(zcbor_state_t* zsd, void* value);
  * @param[inout] zsd          The current state of the decoding
  * @param[in]    entries      Array with entries to be decoded
  * @param[in]    num_entries  Number of entries (size of @a entries array)
+ *
+ * @retval  0       On success
+ * @retval -EBADMSG Failed to parse all map entries
+ * @retval <0       Other error returned from @ entries decode callback
  */
 int zcbor_map_decode(zcbor_state_t* zsd, struct zcbor_map_entry* entries, size_t num_entries);
 


### PR DESCRIPTION
So far 0xA0 (as it is an empty map) was checked explicitly. Change that to
handling -ENOENT output from zcbor_map_decode(). This makes CBOR
details (such as processing A0 byte) be handled in CBOR (zcbor) utils,
while keeping 'ota' module using higher-level APIs.