### PR TITLE
Remove broken link for CoAP auth

### DIFF
--- a/src/include/golioth_client.h
+++ b/src/include/golioth_client.h
@@ -21,8 +21,6 @@
 ///
 /// https://docs.golioth.io/reference/protocols/coap
 /// <br>
-/// https://docs.golioth.io/reference/protocols/coap/auth
-/// <br>
 /// https://docs.golioth.io/reference/protocols/device-auth
 /// @{
 


### PR DESCRIPTION
Drops a broken link to the documentation for CoAP authentication. Information is now provided under the device authentication page.