### PR TITLE
golioth_rpc_status_t: use GOLIOTH_ namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.x.x] - unreleased
+
+### Breaking Changes
+
+- Add `GOLIOTH_` to each RPC status (e.g. `GOLIOTH_RPC_OK`)
+
 ## [0.7.0] - 2023-06-15
 
 Highlights:

--- a/examples/common/golioth_basics.c
+++ b/examples/common/golioth_basics.c
@@ -49,7 +49,7 @@ static golioth_rpc_status_t on_multiply(
             && zcbor_float_decode(request_params_array, &b);
     if (!ok) {
         GLTH_LOGE(TAG, "Failed to decode array items");
-        return RPC_INVALID_ARGUMENT;
+        return GOLIOTH_RPC_INVALID_ARGUMENT;
     }
 
     value = a * b;
@@ -60,10 +60,10 @@ static golioth_rpc_status_t on_multiply(
             && zcbor_float64_put(response_detail_map, value);
     if (!ok) {
         GLTH_LOGE(TAG, "Failed to encode value");
-        return RPC_RESOURCE_EXHAUSTED;
+        return GOLIOTH_RPC_RESOURCE_EXHAUSTED;
     }
 
-    return RPC_OK;
+    return GOLIOTH_RPC_OK;
 }
 
 

--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -57,7 +57,7 @@ static golioth_rpc_status_t on_double(
     ok = zcbor_float_decode(request_params_array, &value);
     if (!ok) {
         GLTH_LOGE(TAG, "Failed to decode value to be doubled");
-        return RPC_INVALID_ARGUMENT;
+        return GOLIOTH_RPC_INVALID_ARGUMENT;
     }
 
     value *= 2;
@@ -66,10 +66,10 @@ static golioth_rpc_status_t on_double(
             && zcbor_float64_put(response_detail_map, value);
     if (!ok) {
         GLTH_LOGE(TAG, "Failed to encode value");
-        return RPC_RESOURCE_EXHAUSTED;
+        return GOLIOTH_RPC_RESOURCE_EXHAUSTED;
     }
 
-    return RPC_OK;
+    return GOLIOTH_RPC_OK;
 }
 
 static golioth_settings_status_t on_test_setting(int32_t new_value, void* arg) {

--- a/src/golioth_remote_shell.c
+++ b/src/golioth_remote_shell.c
@@ -96,11 +96,11 @@ static golioth_rpc_status_t on_line_input(
         struct zcbor_string tstr;
         bool ok = zcbor_tstr_decode(request_params_array, &tstr);
         if (!ok) {
-            return RPC_INVALID_ARGUMENT;
+            return GOLIOTH_RPC_INVALID_ARGUMENT;
         }
         _line_input_cb((char*)tstr.value, tstr.len);
     }
-    return RPC_OK;
+    return GOLIOTH_RPC_OK;
 }
 
 static void init(void) {

--- a/src/golioth_rpc.c
+++ b/src/golioth_rpc.c
@@ -117,7 +117,7 @@ static void on_rpc(
     golioth_rpc_t* grpc = golioth_coap_client_get_rpc(client);
 
     const golioth_rpc_method_t* matching_rpc = NULL;
-    golioth_rpc_status_t status = RPC_UNKNOWN;
+    golioth_rpc_status_t status = GOLIOTH_RPC_UNKNOWN;
 
     for (int i = 0; i < grpc->num_rpcs; i++) {
         const golioth_rpc_method_t* rpc = &grpc->rpcs[i];

--- a/src/include/golioth_rpc.h
+++ b/src/include/golioth_rpc.h
@@ -17,23 +17,23 @@
 
 /// Enumeration of RPC status codes, sent in the RPC response
 typedef enum {
-    RPC_OK = 0,
-    RPC_CANCELED = 1,
-    RPC_UNKNOWN = 2,
-    RPC_INVALID_ARGUMENT = 3,
-    RPC_DEADLINE_EXCEEDED = 4,
-    RPC_NOT_FOUND = 5,
-    RPC_ALREADYEXISTS = 6,
-    RPC_PERMISSION_DENIED = 7,
-    RPC_RESOURCE_EXHAUSTED = 8,
-    RPC_FAILED_PRECONDITION = 9,
-    RPC_ABORTED = 10,
-    RPC_OUT_OF_RANGE = 11,
-    RPC_UNIMPLEMENTED = 12,
-    RPC_INTERNAL = 13,
-    RPC_UNAVAILABLE = 14,
-    RPC_DATA_LOSS = 15,
-    RPC_UNAUTHENTICATED = 16,
+    GOLIOTH_RPC_OK = 0,
+    GOLIOTH_RPC_CANCELED = 1,
+    GOLIOTH_RPC_UNKNOWN = 2,
+    GOLIOTH_RPC_INVALID_ARGUMENT = 3,
+    GOLIOTH_RPC_DEADLINE_EXCEEDED = 4,
+    GOLIOTH_RPC_NOT_FOUND = 5,
+    GOLIOTH_RPC_ALREADYEXISTS = 6,
+    GOLIOTH_RPC_PERMISSION_DENIED = 7,
+    GOLIOTH_RPC_RESOURCE_EXHAUSTED = 8,
+    GOLIOTH_RPC_FAILED_PRECONDITION = 9,
+    GOLIOTH_RPC_ABORTED = 10,
+    GOLIOTH_RPC_OUT_OF_RANGE = 11,
+    GOLIOTH_RPC_UNIMPLEMENTED = 12,
+    GOLIOTH_RPC_INTERNAL = 13,
+    GOLIOTH_RPC_UNAVAILABLE = 14,
+    GOLIOTH_RPC_DATA_LOSS = 15,
+    GOLIOTH_RPC_UNAUTHENTICATED = 16,
 } golioth_rpc_status_t;
 
 /// Callback function type for remote procedure call
@@ -54,7 +54,7 @@ typedef enum {
 ///           zcbor_float_decode(request_params_array, &b);
 ///      if (!ok) {
 ///            GLTH_LOGE(TAG, "Failed to decode array items");
-///            return RPC_INVALID_ARGUMENT;
+///            return GOLIOTH_RPC_INVALID_ARGUMENT;
 ///      }
 ///
 ///      value = a * b;
@@ -63,10 +63,10 @@ typedef enum {
 ///           zcbor_float64_put(response_detail_map, value);
 ///      if (!ok) {
 ///            GLTH_LOGE(TAG, "Failed to encode value");
-///            return RPC_RESOURCE_EXHAUSTED;
+///            return GOLIOTH_RPC_RESOURCE_EXHAUSTED;
 ///      }
 ///
-///      return RPC_OK;
+///      return GOLIOTH_RPC_OK;
 /// }
 /// @endcode
 ///
@@ -74,8 +74,8 @@ typedef enum {
 /// @param response_detail_map zcbor encode state, inside of the RPC response detail map
 /// @param callback_arg callback_arg, unchanged from callback_arg of @ref golioth_rpc_register
 ///
-/// @return RPC_OK - if method was called successfully
-/// @return RPC_INVALID_ARGUMENT - if params were invalid
+/// @return GOLIOTH_RPC_OK - if method was called successfully
+/// @return GOLIOTH_RPC_INVALID_ARGUMENT - if params were invalid
 /// @return otherwise - method failure
 typedef golioth_rpc_status_t (*golioth_rpc_cb_fn)(
         zcbor_state_t* request_params_array,

--- a/test/test_golioth_rpc.c
+++ b/test/test_golioth_rpc.c
@@ -263,7 +263,7 @@ golioth_rpc_status_t rpc_method_fake(
         TEST_ASSERT_EQUAL(248, param_2);
     }
 
-    return RPC_OK;
+    return GOLIOTH_RPC_OK;
 }
 
 void test_rpc_call_with_return(void) {


### PR DESCRIPTION
Add `GOLIOTH_` to all RPC status names so that the format matches: `GOLIOTH_RPC_OK`