### PR TITLE
examples: zephyr: fix LightDB Stream log name

### DIFF
--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(hello_zephyr, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(lightdb_stream, LOG_LEVEL_DBG);
 
 #include "golioth.h"
 #include <samples/common/hardcoded_credentials.h>


### PR DESCRIPTION
Use lightdb_stream for the logging module name instead of the name used by the hello sample.