### PR TITLE
examples: zephyr: add pin map for ESP32-WROVER

### DIFF
--- a/examples/zephyr/dfu/README.md
+++ b/examples/zephyr/dfu/README.md
@@ -72,14 +72,14 @@ esptool.py write_flash --verify 0x0 PATH_TO_ESP_AT/factory/factory_WROOM-32.bin
 Connect nRF52840 DK and ESP32-DevKitC V4 (or other
 ESP32-WROOM-32/ESP32-ROVER-32 based board) using wires:
 
-  | nRF52840 DK | ESP32-WROOM-32  | ESP32-WROVER-32 |
-  | ----------- | --------------- | ----------------|
-  | P1.01 (RX)  | IO17 (TX)       | IO22 (TX)       |
-  | P1.02 (TX)  | IO16 (RX)       | IO19 (RX)       |
-  | P1.03 (CTS) | IO14 (RTS)      | IO14 (RTS)      |
-  | P1.04 (RTS) | IO15 (CTS)      | IO15 (CTS)      |
-  | P1.05       | EN              | EN              |
-  | GND         | GND             | GND             |
+| nRF52840 DK | ESP32-WROOM-32  | ESP32-WROVER-32 |
+| ----------- | --------------- | ----------------|
+| P1.01 (RX)  | IO17 (TX)       | IO22 (TX)       |
+| P1.02 (TX)  | IO16 (RX)       | IO19 (RX)       |
+| P1.03 (CTS) | IO14 (RTS)      | IO14 (RTS)      |
+| P1.04 (RTS) | IO15 (CTS)      | IO15 (CTS)      |
+| P1.05       | EN              | EN              |
+| GND         | GND             | GND             |
 
 Configure the following Kconfig options based on your WiFi AP
 credentials:

--- a/examples/zephyr/hello/README.md
+++ b/examples/zephyr/hello/README.md
@@ -83,14 +83,14 @@ esptool.py write_flash --verify 0x0 PATH_TO_ESP_AT/factory/factory_WROOM-32.bin
 Connect nRF52840 DK and ESP32-DevKitC V4 (or other ESP32-WROOM-32 based
 board) using wires:
 
-  | nRF52840 DK | ESP32-WROOM-32 |
-  | ----------- | ---------------|
-  | P1.01 (RX)  | IO17 (TX)      |
-  | P1.02 (TX)  | IO16 (RX)      |
-  | P1.03 (CTS) | IO14 (RTS)     |
-  | P1.04 (RTS) | IO15 (CTS)     |
-  | P1.05       | EN             |
-  | GND         | GND            |
+| nRF52840 DK | ESP32-WROOM-32  | ESP32-WROVER-32 |
+| ----------- | --------------- | ----------------|
+| P1.01 (RX)  | IO17 (TX)       | IO22 (TX)       |
+| P1.02 (TX)  | IO16 (RX)       | IO19 (RX)       |
+| P1.03 (CTS) | IO14 (RTS)      | IO14 (RTS)      |
+| P1.04 (RTS) | IO15 (CTS)      | IO15 (CTS)      |
+| P1.05       | EN              | EN              |
+| GND         | GND             | GND             |
 
 Configure the following Kconfig options based on your WiFi AP
 credentials:

--- a/examples/zephyr/lightdb/delete/README.md
+++ b/examples/zephyr/lightdb/delete/README.md
@@ -61,14 +61,14 @@ esptool.py write_flash --verify 0x0 PATH_TO_ESP_AT/factory/factory_WROOM-32.bin
 Connect nRF52840 DK and ESP32-DevKitC V4 (or other ESP32-WROOM-32 based
 board) using wires:
 
-| nRF52840 DK | ESP32-WROOM-32 |
-| ----------- | -------------- |
-| P1.01 (RX)  | IO17 (TX)      |
-| P1.02 (TX)  | IO16 (RX)      |
-| P1.03 (CTS) | IO14 (RTS)     |
-| P1.04 (RTS) | IO15 (CTS)     |
-| P1.05       | EN             |
-| GND         | GND            |
+| nRF52840 DK | ESP32-WROOM-32  | ESP32-WROVER-32 |
+| ----------- | --------------- | ----------------|
+| P1.01 (RX)  | IO17 (TX)       | IO22 (TX)       |
+| P1.02 (TX)  | IO16 (RX)       | IO19 (RX)       |
+| P1.03 (CTS) | IO14 (RTS)      | IO14 (RTS)      |
+| P1.04 (RTS) | IO15 (CTS)      | IO15 (CTS)      |
+| P1.05       | EN              | EN              |
+| GND         | GND             | GND             |
 
 Configure the following Kconfig options based on your WiFi AP
 credentials:

--- a/examples/zephyr/lightdb/get/README.md
+++ b/examples/zephyr/lightdb/get/README.md
@@ -61,14 +61,14 @@ esptool.py write_flash --verify 0x0 PATH_TO_ESP_AT/factory/factory_WROOM-32.bin
 Connect nRF52840 DK and ESP32-DevKitC V4 (or other ESP32-WROOM-32 based
 board) using wires:
 
-| nRF52840 DK | ESP32-WROOM-32 |
-| ----------- | -------------- |
-| P1.01 (RX)  | IO17 (TX)      |
-| P1.02 (TX)  | IO16 (RX)      |
-| P1.03 (CTS) | IO14 (RTS)     |
-| P1.04 (RTS) | IO15 (CTS)     |
-| P1.05       | EN             |
-| GND         | GND            |
+| nRF52840 DK | ESP32-WROOM-32  | ESP32-WROVER-32 |
+| ----------- | --------------- | ----------------|
+| P1.01 (RX)  | IO17 (TX)       | IO22 (TX)       |
+| P1.02 (TX)  | IO16 (RX)       | IO19 (RX)       |
+| P1.03 (CTS) | IO14 (RTS)      | IO14 (RTS)      |
+| P1.04 (RTS) | IO15 (CTS)      | IO15 (CTS)      |
+| P1.05       | EN              | EN              |
+| GND         | GND             | GND             |
 
 Configure the following Kconfig options based on your WiFi AP
 credentials:

--- a/examples/zephyr/lightdb/observe/README.md
+++ b/examples/zephyr/lightdb/observe/README.md
@@ -61,14 +61,14 @@ esptool.py write_flash --verify 0x0 PATH_TO_ESP_AT/factory/factory_WROOM-32.bin
 Connect nRF52840 DK and ESP32-DevKitC V4 (or other ESP32-WROOM-32 based
 board) using wires:
 
-| nRF52840 DK | ESP32-WROOM-32 |
-| ----------- | -------------- |
-| P1.01 (RX)  | IO17 (TX)      |
-| P1.02 (TX)  | IO16 (RX)      |
-| P1.03 (CTS) | IO14 (RTS)     |
-| P1.04 (RTS) | IO15 (CTS)     |
-| P1.05       | EN             |
-| GND         | GND            |
+| nRF52840 DK | ESP32-WROOM-32  | ESP32-WROVER-32 |
+| ----------- | --------------- | ----------------|
+| P1.01 (RX)  | IO17 (TX)       | IO22 (TX)       |
+| P1.02 (TX)  | IO16 (RX)       | IO19 (RX)       |
+| P1.03 (CTS) | IO14 (RTS)      | IO14 (RTS)      |
+| P1.04 (RTS) | IO15 (CTS)      | IO15 (CTS)      |
+| P1.05       | EN              | EN              |
+| GND         | GND             | GND             |
 
 Configure the following Kconfig options based on your WiFi AP
 credentials:

--- a/examples/zephyr/lightdb/set/README.md
+++ b/examples/zephyr/lightdb/set/README.md
@@ -60,15 +60,14 @@ esptool.py write_flash --verify 0x0 PATH_TO_ESP_AT/factory/factory_WROOM-32.bin
 Connect nRF52840 DK and ESP32-DevKitC V4 (or other ESP32-WROOM-32 based
 board) using wires:
 
-|             |                |
-| ----------- | -------------- |
-| nRF52840 DK | ESP32-WROOM-32 |
-| P1.01 (RX)  | IO17 (TX)      |
-| P1.02 (TX)  | IO16 (RX)      |
-| P1.03 (CTS) | IO14 (RTS)     |
-| P1.04 (RTS) | IO15 (CTS)     |
-| P1.05       | EN             |
-| GND         | GND            |
+| nRF52840 DK | ESP32-WROOM-32  | ESP32-WROVER-32 |
+| ----------- | --------------- | ----------------|
+| P1.01 (RX)  | IO17 (TX)       | IO22 (TX)       |
+| P1.02 (TX)  | IO16 (RX)       | IO19 (RX)       |
+| P1.03 (CTS) | IO14 (RTS)      | IO14 (RTS)      |
+| P1.04 (RTS) | IO15 (CTS)      | IO15 (CTS)      |
+| P1.05       | EN              | EN              |
+| GND         | GND             | GND             |
 
 Configure the following Kconfig options based on your WiFi AP
 credentials:

--- a/examples/zephyr/lightdb_stream/README.md
+++ b/examples/zephyr/lightdb_stream/README.md
@@ -67,14 +67,14 @@ esptool.py write_flash --verify 0x0 PATH_TO_ESP_AT/factory/factory_WROOM-32.bin
 Connect nRF52840 DK and ESP32-DevKitC V4 (or other ESP32-WROOM-32 based
 board) using wires:
 
-| nRF52840 DK | ESP32-WROOM-32 |
-| ----------- | -------------- |
-| P1.01 (RX)  | IO17 (TX)      |
-| P1.02 (TX)  | IO16 (RX)      |
-| P1.03 (CTS) | IO14 (RTS)     |
-| P1.04 (RTS) | IO15 (CTS)     |
-| P1.05       | EN             |
-| GND         | GND            |
+| nRF52840 DK | ESP32-WROOM-32  | ESP32-WROVER-32 |
+| ----------- | --------------- | ----------------|
+| P1.01 (RX)  | IO17 (TX)       | IO22 (TX)       |
+| P1.02 (TX)  | IO16 (RX)       | IO19 (RX)       |
+| P1.03 (CTS) | IO14 (RTS)      | IO14 (RTS)      |
+| P1.04 (RTS) | IO15 (CTS)      | IO15 (CTS)      |
+| P1.05       | EN              | EN              |
+| GND         | GND             | GND             |
 
 Configure the following Kconfig options based on your WiFi AP
 credentials:

--- a/examples/zephyr/logging/README.md
+++ b/examples/zephyr/logging/README.md
@@ -83,14 +83,14 @@ esptool.py write_flash --verify 0x0 PATH_TO_ESP_AT/factory/factory_WROOM-32.bin
 Connect nRF52840 DK and ESP32-DevKitC V4 (or other ESP32-WROOM-32 based
 board) using wires:
 
-  | nRF52840 DK | ESP32-WROOM-32 |
-  | ----------- | ---------------|
-  | P1.01 (RX)  | IO17 (TX)      |
-  | P1.02 (TX)  | IO16 (RX)      |
-  | P1.03 (CTS) | IO14 (RTS)     |
-  | P1.04 (RTS) | IO15 (CTS)     |
-  | P1.05       | EN             |
-  | GND         | GND            |
+| nRF52840 DK | ESP32-WROOM-32  | ESP32-WROVER-32 |
+| ----------- | --------------- | ----------------|
+| P1.01 (RX)  | IO17 (TX)       | IO22 (TX)       |
+| P1.02 (TX)  | IO16 (RX)       | IO19 (RX)       |
+| P1.03 (CTS) | IO14 (RTS)      | IO14 (RTS)      |
+| P1.04 (RTS) | IO15 (CTS)      | IO15 (CTS)      |
+| P1.05       | EN              | EN              |
+| GND         | GND             | GND             |
 
 Configure the following Kconfig options based on your WiFi AP
 credentials:

--- a/examples/zephyr/rpc/README.md
+++ b/examples/zephyr/rpc/README.md
@@ -84,14 +84,14 @@ esptool.py write_flash --verify 0x0 PATH_TO_ESP_AT/factory/factory_WROOM-32.bin
 Connect nRF52840 DK and ESP32-DevKitC V4 (or other ESP32-WROOM-32 based
 board) using wires:
 
-  | nRF52840 DK | ESP32-WROOM-32 |
-  | ----------- | ---------------|
-  | P1.01 (RX)  | IO17 (TX)      |
-  | P1.02 (TX)  | IO16 (RX)      |
-  | P1.03 (CTS) | IO14 (RTS)     |
-  | P1.04 (RTS) | IO15 (CTS)     |
-  | P1.05       | EN             |
-  | GND         | GND            |
+| nRF52840 DK | ESP32-WROOM-32  | ESP32-WROVER-32 |
+| ----------- | --------------- | ----------------|
+| P1.01 (RX)  | IO17 (TX)       | IO22 (TX)       |
+| P1.02 (TX)  | IO16 (RX)       | IO19 (RX)       |
+| P1.03 (CTS) | IO14 (RTS)      | IO14 (RTS)      |
+| P1.04 (RTS) | IO15 (CTS)      | IO15 (CTS)      |
+| P1.05       | EN              | EN              |
+| GND         | GND             | GND             |
 
 Configure the following Kconfig options based on your WiFi AP
 credentials:


### PR DESCRIPTION
Add the pin mapping for using the ESP32-WROVER as an AT modem to the matrix that already shows mappings for the ESP32-WROOM in each README file.