### PR TITLE
Update Linux example docs with production cert flow

### DIFF
--- a/examples/linux/certificate_auth/README.md
+++ b/examples/linux/certificate_auth/README.md
@@ -3,9 +3,6 @@
 Demonstrates how to connect to the Golioth server using PKI (Public Key Infrastructure)
 certificates.
 
-Since PKI auth is not yet supported by the production Golioth server (coap.golioth.io),
-this example is intended primarily for internal Golioth developers.
-
 ## Generate project root certificate authority and key
 
 To connect to Golioth, you will need to generate and upload a
@@ -32,10 +29,11 @@ Anyone who has it can sign authentic-looking device certificates.
 
 Upload `golioth.crt.pem` to the Golioth console:
 
-* Go to `console.golioth.dev`
-* In the sidebar, click `Certificates`
-* Click `Add Client Certificate Authority` button
-* Leave Type as `Root`, upload the `golioth.crt.pem` file
+* Go to `console.golioth.io`
+* In the sidebar, click `Project Settings`
+* Click `Certificates` tab
+* Click `Add CA Certificate`, leave type as `Root`, upload the
+  `golioth.crt.pem` file
 
 ## Generate a device certificate
 

--- a/examples/linux/certificate_auth/golioth_user_config.h
+++ b/examples/linux/certificate_auth/golioth_user_config.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define CONFIG_GOLIOTH_COAP_HOST_URI "coaps://coap.golioth.dev"
+#define CONFIG_GOLIOTH_COAP_HOST_URI "coaps://coap.golioth.io"


### PR DESCRIPTION
Updates Linux example for cert auth to use new console flow and remove
disclaimer about production readiness.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>