### PR TITLE
examples: zephyr: common: do not wait for dormant WiFi interface

### DIFF
--- a/examples/zephyr/common/net_connect.c
+++ b/examples/zephyr/common/net_connect.c
@@ -67,8 +67,11 @@ static void wait_for_dhcp_bound(struct net_if* iface) {
 void net_connect(void) {
     struct net_if* iface = net_if_get_default();
 
-    LOG_INF("Waiting for interface to be up");
-    wait_for_iface_up(iface);
+    if (!(IS_ENABLED(CONFIG_GOLIOTH_SAMPLE_WIFI) &&
+          net_if_flag_is_set(iface, NET_IF_DORMANT))) {
+        LOG_INF("Waiting for interface to be up");
+        wait_for_iface_up(iface);
+    }
 
     if (IS_ENABLED(CONFIG_GOLIOTH_SAMPLE_WIFI)) {
         LOG_INF("Connecting to WiFi");


### PR DESCRIPTION
DORMANT state in case of WiFi means that interface is ready for WiFi mgmt commands, such as "WiFi connect". This means that such interface will not get into UP state automatically and it makes no sense to wait for that event.

Above behavior was introduced some time ago in Zephyr upstream, however none of the WiFi drivers were updated yet to follow this behavior (remaining in DORMANT state before connecting to Access Point). Since the first driver (ESP-AT) was converted in Zephyr mainline, add support for such behavior.

Originally made by @mniestroj in Zephyr SDK.