### PR TITLE
Use consistent symbols for sample credentials

### DIFF
--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -9,7 +9,7 @@ sudo apt install libssl-dev
 ## Configure PSK and PSK-ID credentials
 
 For the `golioth_basics` example, credentials are sourced from the
-`GOLIOTH_PSK_ID` and `GOLIOTH_PSK` environment variables.
+`GOLIOTH_SAMPLE_PSK_ID` and `GOLIOTH_SAMPLE_PSK` environment variables.
 
 See the `certificate_auth` example [README.md](./certificate_auth/README.md) for
 information on how to configure certificates.

--- a/examples/linux/golioth_basics/main.c
+++ b/examples/linux/golioth_basics/main.c
@@ -8,12 +8,12 @@
 #define TAG "main"
 
 int main(void) {
-    char* golioth_psk_id = getenv("GOLIOTH_PSK_ID");
+    char* golioth_psk_id = getenv("GOLIOTH_SAMPLE_PSK_ID");
     if ((!golioth_psk_id) || strlen(golioth_psk_id) <= 0) {
         fprintf(stderr, "PSK ID is not specified.\n");
         return 1;
     }
-    char* golioth_psk = getenv("GOLIOTH_PSK");
+    char* golioth_psk = getenv("GOLIOTH_SAMPLE_PSK");
     if ((!golioth_psk) || strlen(golioth_psk) <= 0) {
         fprintf(stderr, "PSK is not specified.\n");
         return 1;

--- a/examples/modus_toolbox/README.md
+++ b/examples/modus_toolbox/README.md
@@ -51,10 +51,10 @@ Before compiling the golioth_app, create a file in
 with your WiFi and Golioth credentials:
 
 ```c
-#define WIFI_SSID "WiFiSSID"
-#define WIFI_PASSWORD "WiFiPassword"
-#define GOLIOTH_PSK_ID "device@project"
-#define GOLIOTH_PSK "supersecret"
+#define GOLIOTH_SAMPLE_WIFI_SSID "WiFiSSID"
+#define GOLIOTH_SAMPLE_WIFI_PSK "WiFiPassword"
+#define GOLIOTH_SAMPLE_PSK_ID "device@project"
+#define GOLIOTH_SAMPLE_PSK "supersecret"
 ```
 
 Compile and flash the bootloader:

--- a/examples/modus_toolbox/golioth_basics/golioth_app/source/credentials.inc.template
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/source/credentials.inc.template
@@ -1,4 +1,4 @@
-#define WIFI_SSID "WiFiSSID"
-#define WIFI_PASSWORD "WiFiPassword"
-#define GOLIOTH_PSK_ID "device@project"
-#define GOLIOTH_PSK "supersecret"
+#define GOLIOTH_SAMPLE_WIFI_SSID "WiFiSSID"
+#define GOLIOTH_SAMPLE_WIFI_PSK "WiFiPassword"
+#define GOLIOTH_SAMPLE_PSK_ID "device@project"
+#define GOLIOTH_SAMPLE_PSK "supersecret"

--- a/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.c
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.c
@@ -90,8 +90,8 @@ cy_rslt_t connect_to_wifi_ap(void) {
 
     /* Set the Wi-Fi SSID, password and security type. */
     memset(&wifi_conn_param, 0, sizeof(cy_wcm_connect_params_t));
-    memcpy(wifi_conn_param.ap_credentials.SSID, WIFI_SSID, sizeof(WIFI_SSID));
-    memcpy(wifi_conn_param.ap_credentials.password, WIFI_PASSWORD, sizeof(WIFI_PASSWORD));
+    memcpy(wifi_conn_param.ap_credentials.SSID, GOLIOTH_SAMPLE_WIFI_SSID, sizeof(GOLIOTH_SAMPLE_WIFI_SSID));
+    memcpy(wifi_conn_param.ap_credentials.password, GOLIOTH_SAMPLE_WIFI_PSK, sizeof(GOLIOTH_SAMPLE_WIFI_PSK));
     wifi_conn_param.ap_credentials.security = WIFI_SECURITY_TYPE;
 
     /* Join the Wi-Fi AP. */
@@ -148,8 +148,8 @@ void golioth_main_task(void* arg) {
     //
     // As soon as the task starts, it will try to connect to Golioth using the
     // CoAP protocol over DTLS, with the PSK ID and PSK for authentication.
-    const char* psk_id = GOLIOTH_PSK_ID;
-    const char* psk = GOLIOTH_PSK;
+    const char* psk_id = GOLIOTH_SAMPLE_PSK_ID;
+    const char* psk = GOLIOTH_SAMPLE_PSK;
 
     golioth_client_config_t config = {
             .credentials = {

--- a/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.h
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.h
@@ -49,10 +49,10 @@
 // This is a required file, so if it doesn't exist, you will
 // need to create it and add the following:
 //
-//    #define WIFI_SSID "MySSID"
-//    #define WIFI_PASSWORD "MyPassword"
-//    #define GOLIOTH_PSK_ID "device@project"
-//    #define GOLIOTH_PSK "secret"
+//    #define GOLIOTH_SAMPLE_WIFI_SSID "MySSID"
+//    #define GOLIOTH_SAMPLE_WIFI_PSK "MyPassword"
+//    #define GOLIOTH_SAMPLE_PSK_ID "device@project"
+//    #define GOLIOTH_SAMPLE_PSK "secret"
 //
 // The Golioth credentials can be found at:
 //

--- a/examples/zephyr/README.md
+++ b/examples/zephyr/README.md
@@ -22,8 +22,8 @@ Add credentials to ``~/golioth-workspace/modules/lib/golioth-firmware-sdk/exampl
 file:
 
 ``` cfg
-CONFIG_GOLIOTH_PSK_ID="my-psk-id@my-project"
-CONFIG_GOLIOTH_PSK="my-psk"
+CONFIG_GOLIOTH_SAMPLE_PSK_ID="my-psk-id@my-project"
+CONFIG_GOLIOTH_SAMPLE_PSK="my-psk"
 ```
 
 ### Build and run sample project


### PR DESCRIPTION
Updates all remaining credential symbols that do not use the GOLIOTH_SAMPLE_* prefix convention.