### PR TITLE
Docs fixes

### DIFF
--- a/.github/workflows/firebase-doxygen-pr.yml
+++ b/.github/workflows/firebase-doxygen-pr.yml
@@ -1,5 +1,5 @@
 name: Deploy Doxygen to Firebase Hosting on PR
-'on': pull_request_target
+on: pull_request
 jobs:
   deploy_doxygen_dev:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ A software development kit for connecting embedded devices to the
 This SDK can be used on any preemptive operating system that provides an
 Internet stack. Golioth maintains ports for the following platforms:
 
-* [Espressif ESP-IDF](examples/esp_idf/README.md)
-* [Infineon ModusToolbox](examples/modus_toolbox/README.md)
-* [Zephyr & NCS](examples/zephyr/README.md) (Beta)
-* [Linux](examples/linux/README.md) (Experimental)
+* Espressif ESP-IDF
+* Infineon ModusToolbox
+* Zephyr & NCS (Beta)
+* Linux (Experimental)
 
-More information on these ports can be found at the links above.
+More information on these ports can be found in their respective READMEs at
+`examples/<platform>/README.md`
 
 The SDK can be ported to additional platforms by following the Porting Guide in
 the `docs` folder.
@@ -42,7 +43,7 @@ git submodule update --init --recursive
 
 
 > :warning: **Note:** Zephyr-based projects should use the West tool to clone the repo. See the
-[Zephyr Quick Start Guide](exampls/zephyr/README.md).
+Zephyr Quick Start Guide at `examples/zephyr/README.md`.
 
 ### Trying the SDK examples
 

--- a/examples/zephyr/dfu/README.md
+++ b/examples/zephyr/dfu/README.md
@@ -44,34 +44,34 @@ shell. This is based on the Zephyr Settings subsystem.
 Enable the settings shell by including the following configuration overlay
 file:
 
-.. code-block:: console
-
-   $ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```sh
+$ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```
 
 Alternatively, you can add the following options to ``prj.conf``:
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
 
-   CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
 
-   CONFIG_FLASH=y
-   CONFIG_FLASH_MAP=y
-   CONFIG_NVS=y
-
-   CONFIG_SETTINGS=y
-   CONFIG_SETTINGS_RUNTIME=y
-   CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+```
 
 At runtime, configure PSK-ID and PSK using the device shell based on your
 Golioth credentials:
 
-.. code-block:: console
-
-   uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-   uart:~$ settings set golioth/psk <my-psk>
-   uart:-$ kernel reboot cold
+```sh
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:-$ kernel reboot cold
+```
 
 #### Certificate based auth
 

--- a/examples/zephyr/hello/README.md
+++ b/examples/zephyr/hello/README.md
@@ -37,34 +37,34 @@ shell. This is based on the Zephyr Settings subsystem.
 Enable the settings shell by including the following configuration overlay
 file:
 
-.. code-block:: console
-
-   $ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```sh
+$ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```
 
 Alternatively, you can add the following options to ``prj.conf``:
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
 
-   CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
 
-   CONFIG_FLASH=y
-   CONFIG_FLASH_MAP=y
-   CONFIG_NVS=y
-
-   CONFIG_SETTINGS=y
-   CONFIG_SETTINGS_RUNTIME=y
-   CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+```
 
 At runtime, configure PSK-ID and PSK using the device shell based on your
 Golioth credentials:
 
-.. code-block:: console
-
-   uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-   uart:~$ settings set golioth/psk <my-psk>
-   uart:-$ kernel reboot cold
+```sh
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:-$ kernel reboot cold
+```
 
 #### Certificate based auth
 

--- a/examples/zephyr/lightdb/delete/README.md
+++ b/examples/zephyr/lightdb/delete/README.md
@@ -37,34 +37,34 @@ shell. This is based on the Zephyr Settings subsystem.
 Enable the settings shell by including the following configuration overlay
 file:
 
-.. code-block:: console
-
-   $ west build -- -DEXTRA_CONF_FILE=../../common/runtime_psk.conf
+```sh
+$ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```
 
 Alternatively, you can add the following options to ``prj.conf``:
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
 
-   CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
 
-   CONFIG_FLASH=y
-   CONFIG_FLASH_MAP=y
-   CONFIG_NVS=y
-
-   CONFIG_SETTINGS=y
-   CONFIG_SETTINGS_RUNTIME=y
-   CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+```
 
 At runtime, configure PSK-ID and PSK using the device shell based on your
 Golioth credentials:
 
-.. code-block:: console
-
-   uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-   uart:~$ settings set golioth/psk <my-psk>
-   uart:-$ kernel reboot cold
+```sh
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:-$ kernel reboot cold
+```
 
 #### Certificate based auth
 

--- a/examples/zephyr/lightdb/get/README.md
+++ b/examples/zephyr/lightdb/get/README.md
@@ -37,34 +37,34 @@ shell. This is based on the Zephyr Settings subsystem.
 Enable the settings shell by including the following configuration overlay
 file:
 
-.. code-block:: console
-
-   $ west build -- -DEXTRA_CONF_FILE=../../common/runtime_psk.conf
+```sh
+$ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```
 
 Alternatively, you can add the following options to ``prj.conf``:
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
 
-   CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
 
-   CONFIG_FLASH=y
-   CONFIG_FLASH_MAP=y
-   CONFIG_NVS=y
-
-   CONFIG_SETTINGS=y
-   CONFIG_SETTINGS_RUNTIME=y
-   CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+```
 
 At runtime, configure PSK-ID and PSK using the device shell based on your
 Golioth credentials:
 
-.. code-block:: console
-
-   uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-   uart:~$ settings set golioth/psk <my-psk>
-   uart:-$ kernel reboot cold
+```sh
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:-$ kernel reboot cold
+```
 
 #### Certificate based auth
 

--- a/examples/zephyr/lightdb/observe/README.md
+++ b/examples/zephyr/lightdb/observe/README.md
@@ -37,34 +37,34 @@ shell. This is based on the Zephyr Settings subsystem.
 Enable the settings shell by including the following configuration overlay
 file:
 
-.. code-block:: console
-
-   $ west build -- -DEXTRA_CONF_FILE=../../common/runtime_psk.conf
+```sh
+$ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```
 
 Alternatively, you can add the following options to ``prj.conf``:
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
 
-   CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
 
-   CONFIG_FLASH=y
-   CONFIG_FLASH_MAP=y
-   CONFIG_NVS=y
-
-   CONFIG_SETTINGS=y
-   CONFIG_SETTINGS_RUNTIME=y
-   CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+```
 
 At runtime, configure PSK-ID and PSK using the device shell based on your
 Golioth credentials:
 
-.. code-block:: console
-
-   uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-   uart:~$ settings set golioth/psk <my-psk>
-   uart:-$ kernel reboot cold
+```sh
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:-$ kernel reboot cold
+```
 
 #### Certificate based auth
 

--- a/examples/zephyr/lightdb/set/README.md
+++ b/examples/zephyr/lightdb/set/README.md
@@ -37,34 +37,34 @@ shell. This is based on the Zephyr Settings subsystem.
 Enable the settings shell by including the following configuration overlay
 file:
 
-.. code-block:: console
-
-   $ west build -- -DEXTRA_CONF_FILE=../../common/runtime_psk.conf
+```sh
+$ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```
 
 Alternatively, you can add the following options to ``prj.conf``:
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
 
-   CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
 
-   CONFIG_FLASH=y
-   CONFIG_FLASH_MAP=y
-   CONFIG_NVS=y
-
-   CONFIG_SETTINGS=y
-   CONFIG_SETTINGS_RUNTIME=y
-   CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+```
 
 At runtime, configure PSK-ID and PSK using the device shell based on your
 Golioth credentials:
 
-.. code-block:: console
-
-   uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-   uart:~$ settings set golioth/psk <my-psk>
-   uart:-$ kernel reboot cold
+```sh
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:-$ kernel reboot cold
+```
 
 #### Certificate based auth
 

--- a/examples/zephyr/lightdb_stream/README.md
+++ b/examples/zephyr/lightdb_stream/README.md
@@ -39,34 +39,34 @@ shell. This is based on the Zephyr Settings subsystem.
 Enable the settings shell by including the following configuration overlay
 file:
 
-.. code-block:: console
-
-   $ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```sh
+$ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```
 
 Alternatively, you can add the following options to ``prj.conf``:
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
 
-   CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
 
-   CONFIG_FLASH=y
-   CONFIG_FLASH_MAP=y
-   CONFIG_NVS=y
-
-   CONFIG_SETTINGS=y
-   CONFIG_SETTINGS_RUNTIME=y
-   CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+```
 
 At runtime, configure PSK-ID and PSK using the device shell based on your
 Golioth credentials:
 
-.. code-block:: console
-
-   uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-   uart:~$ settings set golioth/psk <my-psk>
-   uart:-$ kernel reboot cold
+```sh
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:-$ kernel reboot cold
+```
 
 #### Certificate based auth
 

--- a/examples/zephyr/logging/README.md
+++ b/examples/zephyr/logging/README.md
@@ -37,34 +37,34 @@ shell. This is based on the Zephyr Settings subsystem.
 Enable the settings shell by including the following configuration overlay
 file:
 
-.. code-block:: console
-
-   $ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```sh
+$ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```
 
 Alternatively, you can add the following options to ``prj.conf``:
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
 
-   CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
 
-   CONFIG_FLASH=y
-   CONFIG_FLASH_MAP=y
-   CONFIG_NVS=y
-
-   CONFIG_SETTINGS=y
-   CONFIG_SETTINGS_RUNTIME=y
-   CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+```
 
 At runtime, configure PSK-ID and PSK using the device shell based on your
 Golioth credentials:
 
-.. code-block:: console
-
-   uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-   uart:~$ settings set golioth/psk <my-psk>
-   uart:-$ kernel reboot cold
+```sh
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:-$ kernel reboot cold
+```
 
 #### Certificate based auth
 

--- a/examples/zephyr/rpc/README.md
+++ b/examples/zephyr/rpc/README.md
@@ -38,34 +38,34 @@ shell. This is based on the Zephyr Settings subsystem.
 Enable the settings shell by including the following configuration overlay
 file:
 
-.. code-block:: console
-
-   $ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```sh
+$ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```
 
 Alternatively, you can add the following options to ``prj.conf``:
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
 
-   CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
 
-   CONFIG_FLASH=y
-   CONFIG_FLASH_MAP=y
-   CONFIG_NVS=y
-
-   CONFIG_SETTINGS=y
-   CONFIG_SETTINGS_RUNTIME=y
-   CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+```
 
 At runtime, configure PSK-ID and PSK using the device shell based on your
 Golioth credentials:
 
-.. code-block:: console
-
-   uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-   uart:~$ settings set golioth/psk <my-psk>
-   uart:-$ kernel reboot cold
+```sh
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:-$ kernel reboot cold
+```
 
 #### Certificate based auth
 

--- a/examples/zephyr/settings/README.md
+++ b/examples/zephyr/settings/README.md
@@ -38,34 +38,34 @@ shell. This is based on the Zephyr Settings subsystem.
 Enable the settings shell by including the following configuration overlay
 file:
 
-.. code-block:: console
-
-   $ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```sh
+$ west build -- -DEXTRA_CONF_FILE=../common/runtime_psk.conf
+```
 
 Alternatively, you can add the following options to ``prj.conf``:
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
 
-   CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
 
-   CONFIG_FLASH=y
-   CONFIG_FLASH_MAP=y
-   CONFIG_NVS=y
-
-   CONFIG_SETTINGS=y
-   CONFIG_SETTINGS_RUNTIME=y
-   CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
-   CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_GOLIOTH_SAMPLE_PSK_SETTINGS=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_AUTOLOAD=y
+CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
+```
 
 At runtime, configure PSK-ID and PSK using the device shell based on your
 Golioth credentials:
 
-.. code-block:: console
-
-   uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-   uart:~$ settings set golioth/psk <my-psk>
-   uart:-$ kernel reboot cold
+```sh
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:-$ kernel reboot cold
+```
 
 #### Certificate based auth
 


### PR DESCRIPTION
We were previously running the doxygen workflow on the target branch, which isn't helpful. As a result a few bugs made it through.

- Test doxygen on PR branch
- Remove broken links
- Use Markdown formatted codeblocks instead of RST