### PR TITLE
Initialize and update submodules in subshell

### DIFF
--- a/examples/zephyr/README.md
+++ b/examples/zephyr/README.md
@@ -39,7 +39,7 @@ dependencies:
 ```console
 west init -m https://github.com/golioth/golioth-firmware-sdk.git --mf west-zephyr.yml
 west update
-cd modules/lib/golioth-firmware-sdk && git submodule update --init --recursive
+(cd modules/lib/golioth-firmware-sdk && git submodule update --init --recursive)
 ```
 
 Follow [Zephyr Getting
@@ -54,7 +54,7 @@ dependencies:
 ```console
 west init -m https://github.com/golioth/golioth-firmware-sdk.git --mf west-ncs.yml
 west update
-cd modules/lib/golioth-firmware-sdk && git submodule update --init --recursive
+(cd modules/lib/golioth-firmware-sdk && git submodule update --init --recursive)
 ```
 
 Follow [nRF Connect SDK Getting
@@ -81,7 +81,7 @@ and clone all repositories including that one by running:
 
 ```console
 west update
-cd modules/lib/golioth-firmware-sdk && git submodule update --init --recursive
+(cd modules/lib/golioth-firmware-sdk && git submodule update --init --recursive)
 ```
 
 # Sample applications


### PR DESCRIPTION
Updates the Zephyr examples README.md to run the firmware SDK git submodule initialization and update in a subshell so that you remain in the top-level directory after running the command.