### PR TITLE
examples: zephyr: remove sample firmware version dependency on mcuboot

### DIFF
--- a/examples/zephyr/common/Kconfig
+++ b/examples/zephyr/common/Kconfig
@@ -67,7 +67,6 @@ config GOLIOTH_SAMPLE_DHCP_BIND
 config GOLIOTH_SAMPLE_FW_VERSION
 	string "DFU Firmware Version"
 	default "0.0.0+0"
-	depends on BOOTLOADER_MCUBOOT
 	help
           Firmware version used by Golioth DFU sample to assign MCUBOOT_IMGTOOL_SIGN_VERSION (if
           using Zephyr) or MCUBOOT_IMAGE_VERSION (if using NCS)


### PR DESCRIPTION
Removes the dependency on BOOTLOADER_MCUBOOT for GOLIOTH_SAMPLE_FW_VERSION as it breaks DFU samples that do not use mcuboot.

Before this change I was seeing:
```
/home/hasheddan/code/github.com/golioth/golioth-firmware-sdk/examples/zephyr/dfu/src/main.c:18:39: error: 'CONFIG_GOLIOTH_SAMPLE_FW_VERSION' undeclared here (not in a function); did you mean 'CONFIG_GOLIOTH_SAMPLE_COMMON'?
   18 | static const char* _current_version = CONFIG_GOLIOTH_SAMPLE_FW_VERSION;
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                       CONFIG_GOLIOTH_SAMPLE_COMMON
[148/396] Building C object zephyr/subsys/net/ip/CMakeFiles/subsys__net__ip.dir/net_context.c.obj
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /home/hasheddan/code/github.com/golioth/golioth-firmware-sdk/examples/zephyr/dfu/build
```

After it compiled successfully.