### PR TITLE
ci: use previous commit for linting on main

### DIFF
--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -24,7 +24,12 @@ jobs:
         git fetch --no-recurse-submodules
         echo "Checking code format"
         sudo apt install clang-format
-        REPO_ROOT=`pwd` ./scripts/lint/ci_check_clang_format.sh --merge-base origin/$GITHUB_BASE_REF
+        if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
+            BASE=${{ github.event.before }}
+        else
+            BASE=origin/$GITHUB_BASE_REF
+        fi
+        REPO_ROOT=`pwd` ./scripts/lint/ci_check_clang_format.sh --merge-base $BASE
     - name: Run unit tests
       shell: bash
       run: |


### PR DESCRIPTION
Updates lint workflow to use commit prior to push when merging to main. Previously the step would fail because $GITHUB_BASE_REF is empty.

See https://docs.github.com/en/webhooks/webhook-events-and-payloads#push:~:text=or%20null%20Required-,before,-string%20Required for more information.

Fixes golioth/firmware-issue-tracker#248