### PR TITLE
ci: increase fetch depth for linting

### DIFF
--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -13,6 +13,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: 'recursive'
+        # Fetch depth must be greater than the number of commits included in the push in order to
+        # compare against commit prior to merge. 15 is chosen as a reasonable default for the upper
+        # bound of commits in a single PR.
+        fetch-depth: 15
     - name: Setup Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
Sets the fetch depth for linting to 10, which serves as a reasonable upper bound for the number of commits in a single PR. If the default fetch-depth of 1 is used, we are unable to calculate files changed as part of a PR being merged.

Follow-up to https://github.com/golioth/golioth-firmware-sdk/pull/189