### PR TITLE
examples: zephyr: dfu: fix version number in readme

### DIFF
--- a/examples/zephyr/dfu/README.md
+++ b/examples/zephyr/dfu/README.md
@@ -225,14 +225,14 @@ commands below.
    an artifact to Golioth:
 
     ```console
-    $ goliothctl dfu artifact create <binary_file> --version 1.2.3
+    $ goliothctl dfu artifact create <binary_file> --version 1.2.4
     ```
 
 2. Create a new release consisting of this single firmware and roll it
 out to all devices in the project:
 
     ```console
-    $ goliothctl dfu release create --release-tags 1.2.3 --components main@1.2.3 --rollout true
+    $ goliothctl dfu release create --release-tags 1.2.4 --components main@1.2.4 --rollout true
     ```
 
 Note: the artifact upload and release rollout process is also available


### PR DESCRIPTION
The instructions are to build the update image with version 1.2.4, but the upload instructions use version 1.2.3. This commit changes the upload instructions to match the version number that gets built.