### PR TITLE
examples: zephyr: fix esp32 wrover documentation formatting

### DIFF
--- a/examples/zephyr/dfu/README.md
+++ b/examples/zephyr/dfu/README.md
@@ -93,29 +93,29 @@ CONFIG_GOLIOTH_SAMPLE_HARDCODED_KEY_PATH="keys/device.key.der"
 
 ### Platform specific configuration
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
-Configure the following Kconfig options based on your WiFi AP credentials:
+Configure the following Kconfig options based on your WiFi AP
+credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
 
-   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
-   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+On your host computer open a terminal window, locate the source code of
+this sample application (i.e., `examples/zephyr/dfu`) and type:
 
-On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/dfu``) and type:
-
-.. code-block:: console
-
-   $ west build -b esp32_devkitc_wrover examples/zephyr/dfu
-   $ west flash
+```console
+$ west build -b esp32_devkitc_wrover examples/zephyr/dfu
+$ west flash
+```
 
 #### nRF52840 DK + ESP32-WROOM-32
 

--- a/examples/zephyr/golioth_basics/README.md
+++ b/examples/zephyr/golioth_basics/README.md
@@ -45,24 +45,25 @@ QEMU](https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.ht
 on how to setup networking on host and configure NAT/masquerading to
 access Internet.
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
-Configure the following Kconfig options based on your WiFi AP credentials:
+Configure the following Kconfig options based on your WiFi AP
+credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
 ```cfg
 CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
 CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
 ```
 
-On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/golioth_basics``) and type:
+On your host computer open a terminal window, locate the source code of
+this sample application (i.e., `examples/zephyr/golioth_basics`) and
+type:
 
 ```console
 $ west build -b esp32_devkitc_wrover examples/zephyr/golioth_basics

--- a/examples/zephyr/hello/README.md
+++ b/examples/zephyr/hello/README.md
@@ -104,29 +104,29 @@ QEMU](https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.ht
 on how to setup networking on host and configure NAT/masquerading to
 access Internet.
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
-Configure the following Kconfig options based on your WiFi AP credentials:
+Configure the following Kconfig options based on your WiFi AP
+credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
-.. code-block:: cfg
-
-   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
-   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```cfg
+CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
 
 On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/hello``) and type:
+sample application (i.e., `examples/zephyr/hello`) and type:
 
-.. code-block:: console
-
-   $ west build -b esp32_devkitc_wrover examples/zephyr/hello
-   $ west flash
+```console
+$ west build -b esp32_devkitc_wrover examples/zephyr/hello
+$ west flash
+```
 
 #### nRF52840 DK + ESP32-WROOM-32
 

--- a/examples/zephyr/lightdb/delete/README.md
+++ b/examples/zephyr/lightdb/delete/README.md
@@ -104,29 +104,30 @@ QEMU](https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.ht
 on how to setup networking on host and configure NAT/masquerading to
 access Internet.
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
-Configure the following Kconfig options based on your WiFi AP credentials:
+Configure the following Kconfig options based on your WiFi AP
+credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
 
-   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
-   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+On your host computer open a terminal window, locate the source code of
+this sample application (i.e., `examples/zephyr/lightdb/delete`) and
+type:
 
-On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/lightdb/delete``) and type:
-
-.. code-block:: console
-
-   $ west build -b esp32_devkitc_wrover examples/zephyr/lightdb/delete
-   $ west flash
+```console
+$ west build -b esp32_devkitc_wrover examples/zephyr/lightdb/delete
+$ west flash
+```
 
 #### nRF52840 DK + ESP32-WROOM-32
 

--- a/examples/zephyr/lightdb/get/README.md
+++ b/examples/zephyr/lightdb/get/README.md
@@ -104,29 +104,29 @@ QEMU](https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.ht
 on how to setup networking on host and configure NAT/masquerading to
 access Internet.
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
-Configure the following Kconfig options based on your WiFi AP credentials:
+Configure the following Kconfig options based on your WiFi AP
+credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
 
-   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
-   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+On your host computer open a terminal window, locate the source code of
+this sample application (i.e., `examples/zephyr/lightdb/get`) and type:
 
-On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/lightdb/get``) and type:
-
-.. code-block:: console
-
-   $ west build -b esp32_devkitc_wrover examples/zephyr/lightdb/get
-   $ west flash
+```console
+$ west build -b esp32_devkitc_wrover examples/zephyr/lightdb/get
+$ west flash
+```
 
 #### nRF52840 DK + ESP32-WROOM-32
 

--- a/examples/zephyr/lightdb/observe/README.md
+++ b/examples/zephyr/lightdb/observe/README.md
@@ -104,29 +104,30 @@ QEMU](https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.ht
 on how to setup networking on host and configure NAT/masquerading to
 access Internet.
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
-Configure the following Kconfig options based on your WiFi AP credentials:
+Configure the following Kconfig options based on your WiFi AP
+credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
 
-   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
-   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+On your host computer open a terminal window, locate the source code of
+this sample application (i.e., `examples/zephyr/lightdb/observe`) and
+type:
 
-On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/lightdb/observe``) and type:
-
-.. code-block:: console
-
-   $ west build -b esp32_devkitc_wrover examples/zephyr/lightdb/observe
-   $ west flash
+```console
+$ west build -b esp32_devkitc_wrover examples/zephyr/lightdb/observe
+$ west flash
+```
 
 #### nRF52840 DK + ESP32-WROOM-32
 

--- a/examples/zephyr/lightdb/set/README.md
+++ b/examples/zephyr/lightdb/set/README.md
@@ -103,29 +103,28 @@ QEMU](https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.ht
 on how to setup networking on host and configure NAT/masquerading to
 access Internet.
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
 Configure the following Kconfig options based on your WiFi AP credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
 
-   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
-   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+On your host computer open a terminal window, locate the source code of
+this sample application (i.e., `examples/zephyr/lightdb/set`) and type:
 
-On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/lightdb/set``) and type:
-
-.. code-block:: console
-
-   $ west build -b esp32_devkitc_wrover examples/zephyr/lightdb/set
-   $ west flash
+```console
+$ west build -b esp32_devkitc_wrover examples/zephyr/lightdb/set
+$ west flash
+```
 
 #### nRF52840 DK + ESP32-WROOM-32
 

--- a/examples/zephyr/lightdb_stream/README.md
+++ b/examples/zephyr/lightdb_stream/README.md
@@ -106,29 +106,30 @@ QEMU](https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.ht
 on how to setup networking on host and configure NAT/masquerading to
 access Internet.
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
-Configure the following Kconfig options based on your WiFi AP credentials:
+Configure the following Kconfig options based on your WiFi AP
+credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
 
-   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
-   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+On your host computer open a terminal window, locate the source code of
+this sample application (i.e., `examples/zephyr/lightdb_stream`) and
+type:
 
-On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/lightdb_stream``) and type:
-
-.. code-block:: console
-
-   $ west build -b esp32_devkitc_wrover examples/zephyr/lightdb_stream
-   $ west flash
+```console
+$ west build -b esp32_devkitc_wrover examples/zephyr/lightdb_stream
+$ west flash
+```
 
 #### nRF52840 DK + ESP32
 

--- a/examples/zephyr/logging/README.md
+++ b/examples/zephyr/logging/README.md
@@ -104,29 +104,29 @@ QEMU](https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.ht
 on how to setup networking on host and configure NAT/masquerading to
 access Internet.
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
-Configure the following Kconfig options based on your WiFi AP credentials:
+Configure the following Kconfig options based on your WiFi AP
+credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
 
-   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
-   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+On your host computer open a terminal window, locate the source code of
+this sample application (i.e., `examples/zephyr/logging`) and type:
 
-On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/logging``) and type:
-
-.. code-block:: console
-
-   $ west build -b esp32_devkitc_wrover examples/zephyr/logging
-   $ west flash
+```console
+$ west build -b esp32_devkitc_wrover examples/zephyr/logging
+$ west flash
+```
 
 #### nRF52840 DK + ESP32-WROOM-32
 

--- a/examples/zephyr/rpc/README.md
+++ b/examples/zephyr/rpc/README.md
@@ -105,29 +105,29 @@ QEMU](https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.ht
 on how to setup networking on host and configure NAT/masquerading to
 access Internet.
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
-Configure the following Kconfig options based on your WiFi AP credentials:
+Configure the following Kconfig options based on your WiFi AP
+credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
 
-   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
-   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+On your host computer open a terminal window, locate the source code of
+this sample application (i.e., `examples/zephyr/rpc`) and type:
 
-On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/rpc``) and type:
-
-.. code-block:: console
-
-   $ west build -b esp32_devkitc_wrover examples/zephyr/rpc
-   $ west flash
+```console
+$ west build -b esp32_devkitc_wrover examples/zephyr/rpc
+$ west flash
+```
 
 #### nRF52840 DK + ESP32-WROOM-32
 

--- a/examples/zephyr/settings/README.md
+++ b/examples/zephyr/settings/README.md
@@ -105,29 +105,29 @@ QEMU](https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.ht
 on how to setup networking on host and configure NAT/masquerading to
 access Internet.
 
-ESP32-DevKitC-WROVER
---------------------
+#### ESP32-DevKitC-WROVER
 
-Configure the following Kconfig options based on your WiFi AP credentials:
+Configure the following Kconfig options based on your WiFi AP
+credentials:
 
 - GOLIOTH_SAMPLE_WIFI_SSID  - WiFi SSID
 - GOLIOTH_SAMPLE_WIFI_PSK   - WiFi PSK
 
-by adding these lines to configuration file (e.g. ``prj.conf`` or
-``board/esp32_devkitc_wrover.conf``):
+by adding these lines to configuration file (e.g. `prj.conf` or
+`board/esp32_devkitc_wrover.conf`):
 
-.. code-block:: cfg
+```cfg
+CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
 
-   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
-   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+On your host computer open a terminal window, locate the source code of
+this sample application (i.e., `examples/zephyr/settings`) and type:
 
-On your host computer open a terminal window, locate the source code of this
-sample application (i.e., ``examples/zephyr/settings``) and type:
-
-.. code-block:: console
-
-   $ west build -b esp32_devkitc_wrover examples/zephyr/settings
-   $ west flash
+```console
+$ west build -b esp32_devkitc_wrover examples/zephyr/settings
+$ west flash
+```
 
 #### nRF52840 DK + ESP32-WROOM-32
 


### PR DESCRIPTION
Updates the documentation for using the esp32 WROVER to match the formatting of other platforms.