### PR TITLE
examples: zephyr: fix example paths

### DIFF
--- a/examples/zephyr/lightdb/delete/README.md
+++ b/examples/zephyr/lightdb/delete/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This sample demonstrates how to connect to Golioth and delete values
-from LigthDB.
+from LightDB.
 
 ## Requirements
 

--- a/examples/zephyr/lightdb/delete/README.md
+++ b/examples/zephyr/lightdb/delete/README.md
@@ -91,11 +91,11 @@ CONFIG_GOLIOTH_SAMPLE_HARDCODED_KEY_PATH="keys/device.key.der"
 This application has been built and tested with QEMU x86 (qemu_x86).
 
 On your Linux host computer, open a terminal window, locate the source
-code of this sample application (i.e., `samples/lightdb/delete`) and
+code of this sample application (i.e., `examples/zephyr/lightdb/delete`) and
 type:
 
 ```console
-$ west build -b qemu_x86 samples/lightdb/delete
+$ west build -b qemu_x86 examples/zephyr/lightdb/delete
 $ west build -t run
 ```
 
@@ -168,20 +168,22 @@ CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
 ```
 
 On your host computer open a terminal window, locate the source code of
-this sample application (i.e., `samples/lightdb/delete`) and type:
+this sample application (i.e., `examples/zephyr/lightdb/delete`) and
+type:
 
 ```console
-$ west build -b nrf52840dk_nrf52840 samples/lightdb/delete
+$ west build -b nrf52840dk_nrf52840 examples/zephyr/lightdb/delete
 $ west flash
 ```
 
 #### nRF9160 DK
 
 On your host computer open a terminal window, locate the source code of
-this sample application (i.e., `samples/ligthdb/delete`) and type:
+this sample application (i.e., `examples/zephyr/lightdb/delete`) and
+type:
 
 ```console
-$ west build -b nrf9160dk_nrf9160_ns samples/lightdb/delete
+$ west build -b nrf9160dk_nrf9160_ns examples/zephyr/lightdb/delete
 $ west flash
 ```
 

--- a/examples/zephyr/lightdb/get/README.md
+++ b/examples/zephyr/lightdb/get/README.md
@@ -178,7 +178,7 @@ $ west flash
 #### nRF9160 DK
 
 On your host computer open a terminal window, locate the source code of
-this sample application (i.e., `samples/ligthdb/get`) and type:
+this sample application (i.e., `examples/zephyr/lightdb/get`) and type:
 
 ```console
 $ west build -b nrf9160dk_nrf9160_ns examples/zephyr/lightdb/get

--- a/examples/zephyr/lightdb/observe/README.md
+++ b/examples/zephyr/lightdb/observe/README.md
@@ -91,11 +91,11 @@ CONFIG_GOLIOTH_SAMPLE_HARDCODED_KEY_PATH="keys/device.key.der"
 This application has been built and tested with QEMU x86 (qemu_x86).
 
 On your Linux host computer, open a terminal window, locate the source
-code of this sample application (i.e., `samples/lightdb/observe`) and
-type:
+code of this sample application (i.e.,
+`examples/zephyr/lightdb/observe`) and type:
 
 ```console
-$ west build -b qemu_x86 samples/lightdb/observe
+$ west build -b qemu_x86 examples/zephyr/lightdb/observe
 $ west build -t run
 ```
 
@@ -168,20 +168,22 @@ CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
 ```
 
 On your host computer open a terminal window, locate the source code of
-this sample application (i.e., `samples/lightdb/observe`) and type:
+this sample application (i.e., `examples/zephyr/lightdb/observe`) and
+type:
 
 ```console
-$ west build -b nrf52840dk_nrf52840 samples/lightdb/observe
+$ west build -b nrf52840dk_nrf52840 examples/zephyr/lightdb/observe
 $ west flash
 ```
 
 #### nRF9160 DK
 
 On your host computer open a terminal window, locate the source code of
-this sample application (i.e., `samples/ligthdb/observe`) and type:
+this sample application (i.e., `examples/zephyr/lightdb/observe`) and
+type:
 
 ```console
-$ west build -b nrf9160dk_nrf9160_ns samples/lightdb/observe
+$ west build -b nrf9160dk_nrf9160_ns examples/zephyr/lightdb/observe
 $ west flash
 ```
 

--- a/examples/zephyr/lightdb/set/README.md
+++ b/examples/zephyr/lightdb/set/README.md
@@ -177,7 +177,7 @@ $ west flash
 #### nRF9160 DK
 
 On your host computer open a terminal window, locate the source code of
-this sample application (i.e., `samples/ligthdb/set`) and type:
+this sample application (i.e., `examples/zephyr/lightdb/set`) and type:
 
 ```console
 $ west build -b nrf9160dk_nrf9160_ns examples/zephyr/lightdb/set

--- a/examples/zephyr/lightdb_stream/README.md
+++ b/examples/zephyr/lightdb_stream/README.md
@@ -184,7 +184,8 @@ $ west flash
 #### nRF9160 DK
 
 On your host computer open a terminal window, locate the source code of
-this sample application (i.e., `samples/ligthdb_stream`) and type:
+this sample application (i.e., `examples/zephyr/lightdb_stream`) and
+type:
 
 ```console
 $ west build -b nrf9160dk_nrf9160_ns examples/zephyr/lightdb_stream


### PR DESCRIPTION
Fixes paths in the zephyr examples that were referencing the no longer
existent samples directory.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>