### PR TITLE
zephyr: use submodules keyword in manifest

### DIFF
--- a/examples/zephyr/README.md
+++ b/examples/zephyr/README.md
@@ -74,6 +74,7 @@ based project (e.g. Zephyr RTOS):
   path: modules/lib/golioth-firmware-sdk
   revision: main
   url: https://github.com/golioth/golioth-firmware-sdk.git
+  submodules: true
   import: west-external.yml
 ```
 
@@ -81,8 +82,11 @@ and clone all repositories including that one by running:
 
 ```console
 west update
-cd modules/lib/golioth-firmware-sdk && git submodule update --init --recursive
 ```
+
+> :memo: When the Golioth Firmware SDK is added as a project in a
+> manifest file, the `submodules` keyword ensures that submodules are
+> updated recursively each time `west update` is used.
 
 # Sample applications
 


### PR DESCRIPTION
When adding the Golioth Firmware SDK to an existing West manifest, use the submodules keyword to automatically update git submodules. This eliminates the need to manually call `git submodule <subcommand>` commands.

Note: this will not work when the Firmware SDK is used as the manifest repository.