### PR TITLE
zephyr: common: document credentials_get

### DIFF
--- a/examples/zephyr/common/include/samples/common/sample_credentials.h
+++ b/examples/zephyr/common/include/samples/common/sample_credentials.h
@@ -9,6 +9,18 @@
 
 #include "golioth.h"
 
+/**
+ * @brief This function returns Golioth credentials in one of three different ways
+ *
+ *   1. Return hardcoded PSK credentials
+ *   2. Return hardcoded certificate (PKI) credentials
+ *   3. Return PSK credentials stored on the settings partition
+ *
+ * The function is defined in both hardcoded_credentials.c and settings_golioth.c and will be
+ * automatically added to the build based on Kconfig symbols.
+ *
+ * @return golioth_client_config_t configuration to use when creating a golioth_client_t
+ */
 const golioth_client_config_t* golioth_sample_credentials_get(void);
 
 #endif /* __GOLIOTH_INCLUDE_SAMPLE_CREDENTIALS_H__ */


### PR DESCRIPTION
Document that golioth_sample_credentials_get() can return credentials from one of three sources.