### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/firebase-doxygen-main.yml
+++ b/.github/workflows/firebase-doxygen-main.yml
@@ -7,7 +7,7 @@ jobs:
   deploy_doxygen_prod:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Doxygen
         run: sudo apt install doxygen graphviz
       - name: Generate Doxygen

--- a/.github/workflows/firebase-doxygen-pr.yml
+++ b/.github/workflows/firebase-doxygen-pr.yml
@@ -4,7 +4,7 @@ jobs:
   deploy_doxygen_dev:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Doxygen
         run: sudo apt install doxygen graphviz
       - name: Generate Doxygen

--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -13,7 +13,7 @@ jobs:
       image: jorisroovers/gitlint:0.19.1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
         # Fetch depth must be greater than the number of commits included in the push in order to
@@ -18,7 +18,7 @@ jobs:
         # bound of commits in a single PR.
         fetch-depth: 15
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -73,11 +73,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -118,11 +118,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -141,11 +141,11 @@ jobs:
       MTB_DOWNLOAD_ID: 1x_YeXR4XSjaf-NZimKxQ8MIyDGo72yHt
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
         architecture: 'x64'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
       image: kiwicom/pre-commit:3.0.4
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -98,7 +98,7 @@ jobs:
 
     steps:
     - name: Checkout repository without submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Download build tarball
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/twister-build.yml
+++ b/.github/workflows/twister-build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: modules/lib/golioth-firmware-sdk
         submodules: 'recursive'
@@ -50,7 +50,7 @@ jobs:
         -o reports
         -T modules/lib/golioth-firmware-sdk
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: twister-artifacts-${{ inputs.board }}


### PR DESCRIPTION
Several of the actions that we use in CI are out of date and GitHub throws warnings when they are run, due to running on a deprecated node. This updates the actions to their latest versions.