### PR TITLE
ci: use minimal docker image for build test

### DIFF
--- a/.github/workflows/twister-build.yml
+++ b/.github/workflows/twister-build.yml
@@ -15,8 +15,7 @@ on:
 
 jobs:
   twister_build:
-    container:
-      image: zephyrprojectrtos/ci:v0.26.5
+    container: golioth/golioth-zephyr-base:0.16.3-SDK-v0
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
     runs-on: ubuntu-latest
@@ -36,6 +35,11 @@ jobs:
         EOF
 
         west update -o=--depth=1 -n
+        pip3 install -r zephyr/scripts/requirements-base.txt
+        pip3 install -r zephyr/scripts/requirements-build-test.txt
+        pip3 install -r zephyr/scripts/requirements-run-test.txt
+        # Needed for TF-M
+        pip3 install cryptography pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.9.0 jinja2 click
 
     - name: Download binary blobs
       if: ${{ inputs.binary_blob }}


### PR DESCRIPTION
The official Zephyr CI Docker image is rather large, and includes many toolchains, modules, and other things that we don't need for our own builds. Using our own, smaller Docker image in CI can cut the time it takes to download and initialize the container from about 2-2.5 minutes down to about 30 seconds. This container does not come pre-installed with Zephyr's required python dependencies so this also adds a step in the CI workflow to install them, which is more robust anyway.