### PR TITLE
Ci Improvements

### DIFF
--- a/.ci-west-ncs.yml
+++ b/.ci-west-ncs.yml
@@ -1,0 +1,20 @@
+manifest:
+  self:
+    path: modules/lib/golioth-firmware-sdk
+    import:
+      file: west-ncs.yml
+      name-allowlist:
+        - cmsis
+        - hal_nordic
+        - littlefs
+        - mbedtls
+        - mcuboot
+        - net-tools
+        - nrf
+        - nrfxlib
+        - qcbor
+        - segger
+        - tinycrypt
+        - trusted-firmware-m
+        - zcbor
+        - zephyr

--- a/.ci-west-zephyr.yml
+++ b/.ci-west-zephyr.yml
@@ -1,0 +1,18 @@
+manifest:
+  self:
+    path: modules/lib/golioth-firmware-sdk
+    import:
+      file: west-zephyr.yml
+      name-allowlist:
+        - cmsis
+        - hal_espressif
+        - hal_nordic
+        - hal_nxp
+        - littlefs
+        - mbedtls
+        - mcuboot
+        - net-tools
+        - segger
+        - tinycrypt
+        - zcbor
+        - zephyr

--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -172,30 +172,30 @@ jobs:
   esp32_devkitc_wrover_build:
     uses: ./.github/workflows/twister-build.yml
     with:
-      manifest: west-zephyr.yml
+      manifest: .ci-west-zephyr.yml
       board: esp32_devkitc_wrover
       binary_blob: hal_espressif
 
   mimxrt1024_evk_build:
     uses: ./.github/workflows/twister-build.yml
     with:
-      manifest: west-zephyr.yml
+      manifest: .ci-west-zephyr.yml
       board: mimxrt1024_evk
 
   nrf52840dk_build:
     uses: ./.github/workflows/twister-build.yml
     with:
-      manifest: west-zephyr.yml
+      manifest: .ci-west-zephyr.yml
       board: nrf52840dk_nrf52840
 
   nrf9160dk_build:
     uses: ./.github/workflows/twister-build.yml
     with:
-      manifest: west-ncs.yml
+      manifest: .ci-west-ncs.yml
       board: nrf9160dk_nrf9160_ns
 
   qemu_build:
     uses: ./.github/workflows/twister-build.yml
     with:
-      manifest: west-zephyr.yml
+      manifest: .ci-west-zephyr.yml
       board: qemu_x86

--- a/.github/workflows/twister-build.yml
+++ b/.github/workflows/twister-build.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Run twister
       run: >
         zephyr/scripts/twister
+        -j 2
         -b
         -p ${{ inputs.board }}
         -o reports


### PR DESCRIPTION
A couple small improvements to speed up build times:

Twister defaults to using twice the number of CPU cores when running build-only tests. Ninja also uses the number of CPU cores for building, meaning we could have 2\*N\*N (8 in our case) threads compiling simultaneously, which leads to bottlenecks and slows down builds. Experimentally, limiting twister to 2 threads (from a default of 4) results in the fastest build times.

We only need a subset of the projects that are in the main Zephyr and NCS West manifests in order to build our samples and tests. By using a manifest that only downloads the projects that we actually need, we can speed up our CI build times.