### PR TITLE
zephyr: hello: watch for correct phrase in twister

### DIFF
--- a/examples/zephyr/hello/sample.yaml
+++ b/examples/zephyr/hello/sample.yaml
@@ -6,7 +6,7 @@ common:
   harness_config:
     type: one_line
     regex:
-      - "(.*)Client connected!"
+      - "(.*)Golioth client connected"
   tags: golioth socket goliothd
 tests:
   sample.golioth.hello.psk.fast.default:


### PR DESCRIPTION
Update Twister to look for the correct success phrase output by the device when connecting to Golioth.

A typical session looks like this:

```
DEBUG   - DEVICE: *** Booting Zephyr OS build v3.3.99-ncs1-1 ***
DEBUG   - DEVICE: [00:00:00.454,345] <dbg> hello_zephyr: main: start hello sample
DEBUG   - DEVICE: [00:00:00.454,376] <inf> golioth_samples: Waiting for interface to be up
DEBUG   - DEVICE: [00:00:11.387,390] <inf> lte_monitor: Network: Searching
DEBUG   - DEVICE: [00:00:11.425,811] <inf> lte_monitor: RRC: Connected
DEBUG   - DEVICE: [00:00:14.113,983] <inf> lte_monitor: RRC: Idle
DEBUG   - DEVICE: [00:00:14.652,038] <inf> lte_monitor: RRC: Connected
DEBUG   - DEVICE: [00:00:16.893,218] <inf> lte_monitor: RRC: Idle
DEBUG   - DEVICE: [00:00:18.502,166] <inf> lte_monitor: RRC: Connected
DEBUG   - DEVICE: [00:00:21.818,450] <inf> lte_monitor: Network: Registered (roaming)
DEBUG   - DEVICE: [00:00:21.819,366] <inf> golioth_mbox: Mbox created, bufsize: 1144, num_items: 10, item_size: 104
DEBUG   - DEVICE: [00:00:22.080,047] <inf> golioth_coap_client: Start CoAP session with host: coaps://coap.golioth.io
DEBUG   - DEVICE: [00:00:22.080,108] <inf> golioth_coap_client: Session PSK-ID: 20230921194938-nrf9160df@ci
DEBUG   - DEVICE: [00:00:22.082,427] <inf> golioth_coap_client: Entering CoAP I/O loop
DEBUG   - DEVICE: [00:00:24.741,882] <inf> golioth_coap_client: Golioth CoAP client connected
DEBUG   - DEVICE: [00:00:24.742,095] <inf> hello_zephyr: Sending hello! 0
DEBUG   - DEVICE: [00:00:24.742,156] <inf> hello_zephyr: Golioth client connected
DEBUG   - run status: nrf9160dk_nrf9160_ns/sample.golioth.hello.psk.long_start passed
```

This update keys on the Hello example's `on_client_event()` logging output:
https://github.com/golioth/golioth-firmware-sdk/blob/5bd0f605dd767f74605519d38546bb419c21a69b/examples/zephyr/hello/src/main.c#L25.