### PR TITLE
doxygen: update include path

### DIFF
--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -864,7 +864,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = "../../src/include" \
+INPUT                  = "../../include" \
                          "../../README.md"
 
 # This tag can be used to specify the character encoding of the source files


### PR DESCRIPTION
After updating our include path, the Doxygen site is now showing information for the private functions instead of the user API.

Include path for APIs was moved up one directory. This commit changes Doxygen to match.