### PR TITLE
ci: catch ram overflow build failures

### DIFF
--- a/.github/workflows/twister-build.yml
+++ b/.github/workflows/twister-build.yml
@@ -49,6 +49,7 @@ jobs:
     - name: Run twister
       run: >
         zephyr/scripts/twister
+        --overflow-as-errors
         -j 2
         -b
         -p ${{ inputs.board }}


### PR DESCRIPTION
Twister treats overflows in the RAM during builds as "skipped" tests instead of errors by default. Enabling the `--overflow-as-errors` option ensures we can catch overflows in CI.

Fixes golioth/firmware-issue-tracker#296