### PR TITLE
port: zephyr: disable cid by default

### DIFF
--- a/examples/zephyr/hello/sample.yaml
+++ b/examples/zephyr/hello/sample.yaml
@@ -18,6 +18,19 @@ tests:
   sample.golioth.hello.psk.long_start:
     platform_allow: nrf9160dk_nrf9160_ns
     timeout: 120
+  sample.golioth.hello.psk.cid.fast.default:
+    platform_allow: >
+      esp32_devkitc_wrover
+      mimxrt1024_evk
+      nrf52840dk_nrf52840
+      qemu_x86
+    extra_configs:
+      - CONFIG_GOLIOTH_USE_CONNECTION_ID=y
+  sample.golioth.hello.psk.cid.long_start:
+    platform_allow: nrf9160dk_nrf9160_ns
+    extra_configs:
+      - CONFIG_GOLIOTH_USE_CONNECTION_ID=y
+    timeout: 120
   sample.golioth.hello.psk.runtime.buildonly:
     build_only: true
     extra_args: EXTRA_CONF_FILE="../common/runtime_psk.conf"

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -11,7 +11,6 @@ menuconfig GOLIOTH_FIRMWARE_SDK
 	select REBOOT if BOOTLOADER_MCUBOOT
 	select REQUIRES_FULL_LIBC # libcoap
 	select MBEDTLS
-    select MBEDTLS_SSL_DTLS_CONNECTION_ID
 	select MBEDTLS_DTLS if MBEDTLS_BUILTIN
 	select MBEDTLS_TLS_LIBRARY if NRF_SECURITY
 	select MBEDTLS_SSL_PROTO_DTLS if NRF_SECURITY
@@ -32,6 +31,15 @@ if GOLIOTH_FIRMWARE_SDK
 menu "Golioth SDK Configuration"
 
 rsource '${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/src/Kconfig'
+
+config GOLIOTH_USE_CONNECTION_ID
+	bool "Use DTLS 1.2 Connection IDs"
+	select MBEDTLS_SSL_DTLS_CONNECTION_ID
+	help
+	  Use DTLS 1.2 Connection IDs. Connection IDs replace IP
+	  addresses as the session identifier, and can be used to
+	  reduce the number of handshakes a device has to make in
+	  certain scenarios.
 
 config GOLIOTH_AUTH_PSK_MBEDTLS_DEPS
 	bool "mbedTLS dependencies for PSK auth"

--- a/port/zephyr/libcoap/coap_io_zephyr.c
+++ b/port/zephyr/libcoap/coap_io_zephyr.c
@@ -217,13 +217,13 @@ int coap_socket_connect_udp(
 
     // If Connection IDs are enabled, set socket option to send CIDs, but not require that the
     // server sends one in return.
-#ifdef CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID
-    int ENABLED = 1;
-    ret = zsock_setsockopt(sock->fd, SOL_TLS, TLS_DTLS_CID, &ENABLED, sizeof(ENABLED));
+#ifdef CONFIG_GOLIOTH_USE_CONNECTION_ID
+    int enabled = 1;
+    ret = zsock_setsockopt(sock->fd, SOL_TLS, TLS_DTLS_CID, &enabled, sizeof(enabled));
     if (ret < 0) {
         goto close_socket;
     }
-#endif /* CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID */
+#endif /* CONFIG_GOLIOTH_USE_CONNECTION_ID */
 
     if (session->proto == COAP_PROTO_UDP) {
         ret = zsock_connect(sock->fd, &connect_addr.addr.sa, connect_addr.size);


### PR DESCRIPTION
Whether enabling connection IDs is beneficial or harmful is dependent on the application, so do not enable them by default. Instead, add a new Kconfig option for using connection IDs.