### PR TITLE
tests: add program method to pytest hil fixture

### DIFF
--- a/.github/workflows/hil_test.yml
+++ b/.github/workflows/hil_test.yml
@@ -64,15 +64,7 @@ jobs:
         with:
           name: zephyr.hex
           path: .
-      - name: Flash build
-        run: |
-          source $HOME/runner_env.sh
-          nrfjprog --recover -f NRF52 --snr $CI_NRF52840DK_SNR
-          nrfjprog --program zephyr.hex --sectoranduicrerase --verify -f NRF52 --snr $CI_NRF52840DK_SNR
-          nrfjprog --pinresetenable -f NRF52 --snr $CI_NRF52840DK_SNR
-          nrfjprog --pinreset -f NRF52 --snr $CI_NRF52840DK_SNR
-          sleep 3
       - name: Run test
         run: |
           source $HOME/runner_env.sh
-          pytest --rootdir . tests/hil/tests/connection --board nrf52840dk --port $CI_NRF52840DK_PORT --credentials-file $HOME/credentials_nrf52840dk.yml
+          pytest --rootdir . tests/hil/tests/connection --board nrf52840dk --port $CI_NRF52840DK_PORT --credentials-file $HOME/credentials_nrf52840dk.yml --fw-image zephyr.hex --serial-number $CI_NRF52840DK_SNR

--- a/tests/hil/scripts/pytest-hil/board.py
+++ b/tests/hil/scripts/pytest-hil/board.py
@@ -1,11 +1,19 @@
 from abc import ABC, abstractmethod
 import serial
-from time import time
+from time import time, sleep
 import re
 import yaml
 
 class Board(ABC):
-    def __init__(self, port, baud, credentials_file):
+    def __init__(self, port, baud, credentials_file, fw_image, serial_number):
+        self.serial_number = serial_number
+
+        if fw_image:
+            self.program(fw_image)
+
+            # Wait for reboot
+            sleep(3)
+
         self.serial_device = serial.Serial(port, baud, timeout=1)
 
         # Read credentials
@@ -52,6 +60,10 @@ class Board(ABC):
 
     @abstractmethod
     def reset(self):
+        pass
+
+    @abstractmethod
+    def program(self, fw_image):
         pass
 
     @abstractmethod

--- a/tests/hil/scripts/pytest-hil/nordicboard.py
+++ b/tests/hil/scripts/pytest-hil/nordicboard.py
@@ -1,0 +1,14 @@
+from board import Board
+from pynrfjprog import HighLevel
+
+class NordicBoard(Board):
+    def program(self, fw_image):
+        with HighLevel.API() as api:
+            with HighLevel.DebugProbe(api, int(self.serial_number)) as probe:
+                program_options = HighLevel.ProgramOptions(
+                    erase_action=HighLevel.EraseAction.ERASE_ALL,
+                    reset=HighLevel.ResetAction.RESET_SYSTEM,
+                    verify=HighLevel.VerifyAction.VERIFY_READ,
+                )
+
+                probe.program(fw_image, program_options=program_options)

--- a/tests/hil/scripts/pytest-hil/nrf52840dk.py
+++ b/tests/hil/scripts/pytest-hil/nrf52840dk.py
@@ -1,6 +1,7 @@
 from zephyrboard import ZephyrBoard
+from nordicboard import NordicBoard
 
-class nRF52840DK(ZephyrBoard):
+class nRF52840DK(ZephyrBoard, NordicBoard):
     @property
     def USES_WIFI(self):
         return True

--- a/tests/hil/scripts/pytest-hil/plugin.py
+++ b/tests/hil/scripts/pytest-hil/plugin.py
@@ -12,6 +12,10 @@ def pytest_addoption(parser):
         "--credentials-file", action="store", type=str,
         help="YAML formatted settings file"
     )
+    parser.addoption("--fw-image", type=str,
+            help="Firmware binary to program to device")
+    parser.addoption("--serial-number", type=str,
+            help="Serial number to identify on-board debugger")
 
 @pytest.fixture(scope="session")
 def board_name(request):
@@ -29,9 +33,18 @@ def baud(request):
 def credentials_file(request):
     return request.config.getoption("--credentials-file")
 
+@pytest.fixture(scope="session")
+def fw_image(request):
+    return request.config.getoption("--fw-image")
+
+@pytest.fixture(scope="session")
+def serial_number(request):
+    return request.config.getoption("--serial-number")
+
+
 @pytest.fixture(scope="module")
-def board(board_name, port, baud, credentials_file):
+def board(board_name, port, baud, credentials_file, fw_image, serial_number):
     if board_name.lower() == "nrf52840dk":
-        return nRF52840DK(port, baud, credentials_file)
+        return nRF52840DK(port, baud, credentials_file, fw_image, serial_number)
     else:
         raise ValueError("Unknown board")

--- a/tests/hil/scripts/pytest-hil/pyproject.toml
+++ b/tests/hil/scripts/pytest-hil/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "hatchling.build"
 [project]
 name = "pytest-hil"
 version = "0.1.0"
+dependencies = [
+  'pynrfjprog',
+]
 classifiers = [
     "Framework :: Pytest",
 ]


### PR DESCRIPTION
Add the ability to program DUTs through the pytest-hil fixture, so that device specific programming logic can be removed from the GitHub Actions workflow yaml.

Closes golioth/firmware-issue-tracker#304