### PR TITLE
examples: zephyr: remove reference to west-external.yml

### DIFF
--- a/examples/zephyr/README.md
+++ b/examples/zephyr/README.md
@@ -75,7 +75,6 @@ based project (e.g. Zephyr RTOS):
   revision: main
   url: https://github.com/golioth/golioth-firmware-sdk.git
   submodules: true
-  import: west-external.yml
 ```
 
 and clone all repositories including that one by running:


### PR DESCRIPTION
Removes reference to non-existent west-external.yml.

This currently causes `west update` to break when adding `golioth-firmware-sdk` to existing projects.