### PR TITLE
pytest-hil: specify additional dependencies

### DIFF
--- a/tests/hil/scripts/pytest-hil/pyproject.toml
+++ b/tests/hil/scripts/pytest-hil/pyproject.toml
@@ -8,6 +8,8 @@ version = "0.1.0"
 dependencies = [
   'pylink-square',
   'pynrfjprog',
+  'pyserial',
+  'PyYAML',
 ]
 classifiers = [
     "Framework :: Pytest",


### PR DESCRIPTION
pyserial and PyYAML were implicit dependencies of the pytest-hil package. This makes them explicit.