### PR TITLE
ci: don't cancel other hil tests when one fails

### DIFF
--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   hil_test_zephyr:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - hil_board: nrf52840dk


### PR DESCRIPTION
The default GitHub Actions behavior is to cancel all other jobs spawned from a matrix when one of the jobs fails. This means our HIL tests are only able to identify at most one failure. Specifying `fail-fast` as false allows all jobs to complete even if one fails, giving us a more complete picture of how many tests are passing or failing.