### PR TITLE
ESP32-DevKitC-WROVER (ESP-IDF) HIL test

### DIFF
--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Save Artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.hil_board }}
+        name: ${{ inputs.hil_board }}-connection-esp-idf
         path: tests/hil/platform/esp-idf/build/merged.bin
 
   test:
@@ -50,7 +50,7 @@ jobs:
       - name: Download build
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.hil_board }}
+          name: ${{ inputs.hil_board }}-connection-esp-idf
           path: .
       - name: Run test
         env:

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Save artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.hil_board }}
+        name: ${{ inputs.hil_board }}-connection-zephyr
         path: build/zephyr/${{ inputs.binary_name }}
 
   test:
@@ -77,7 +77,7 @@ jobs:
       - name: Download build
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.hil_board }}
+          name: ${{ inputs.hil_board }}-connection-zephyr
           path: .
       - name: Run test
         env:

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -47,6 +47,8 @@ jobs:
         include:
           - hil_board: esp32s3_devkitc
             idf_target: esp32s3
+          - hil_board: esp32_devkitc_wrover
+            idf_target: esp32
     uses: ./.github/workflows/hil_test_esp-idf.yml
     with:
       hil_board: ${{ matrix.hil_board }}


### PR DESCRIPTION
Run our HIL tests on the ESP32-DevKitC-WROVER board (running ESP-IDF) in CI.

Closes golioth/firmware-issue-tracker#310