### PR TITLE
Use docker for hil tests

### DIFF
--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -40,6 +40,13 @@ jobs:
     needs: build
     runs-on: has_${{ inputs.hil_board }}
 
+    container:
+      image: golioth/golioth-hil-base:ff78585
+      volumes:
+        - /dev:/dev
+        - /home/golioth/credentials:/opt/credentials
+      options: --privileged
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -53,9 +60,10 @@ jobs:
           name: ${{ inputs.hil_board }}-connection-esp-idf
           path: .
       - name: Run test
+        shell: bash
         env:
           hil_board: ${{ inputs.hil_board }}
         run: |
-          source $HOME/runner_env.sh
+          source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
-          pytest --rootdir . tests/hil/tests/connection --board esp-idf --port ${!PORT_VAR} --credentials-file $HOME/credentials_${hil_board}.yml --fw-image merged.bin
+          pytest --rootdir . tests/hil/tests/connection --board esp-idf --port ${!PORT_VAR} --credentials-file /opt/credentials/credentials_${hil_board}.yml --fw-image merged.bin

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -67,6 +67,13 @@ jobs:
     needs: build
     runs-on: has_${{ inputs.hil_board }}
 
+    container:
+      image: golioth/golioth-hil-base:ff78585
+      volumes:
+        - /dev:/dev
+        - /home/golioth/credentials:/opt/credentials
+      options: --privileged
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -80,10 +87,11 @@ jobs:
           name: ${{ inputs.hil_board }}-connection-zephyr
           path: .
       - name: Run test
+        shell: bash
         env:
           hil_board: ${{ inputs.hil_board }}
         run: |
-          source $HOME/runner_env.sh
+          source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
           SNR_VAR=CI_${hil_board^^}_SNR
-          pytest --rootdir . tests/hil/tests/connection --board ${hil_board} --port ${!PORT_VAR} --credentials-file $HOME/credentials_${hil_board}.yml --fw-image ${{ inputs.binary_name }} --serial-number ${!SNR_VAR}
+          pytest --rootdir . tests/hil/tests/connection --board ${hil_board} --port ${!PORT_VAR} --credentials-file /opt/credentials/credentials_${hil_board}.yml --fw-image ${{ inputs.binary_name }} --serial-number ${!SNR_VAR}

--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -94,7 +94,7 @@ jobs:
   # ---
   hw_flash_and_test:
     needs: build_for_hw_test
-    runs-on: [self-hosted, has_esp32s3_devkitc]
+    runs-on: [self-hosted, has_esp32s3_devkitc, mikes_orange_pi]
 
     container:
       image: golioth/golioth-hil-base:ff78585

--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -96,6 +96,13 @@ jobs:
     needs: build_for_hw_test
     runs-on: [self-hosted, has_esp32s3_devkitc]
 
+    container:
+      image: golioth/golioth-hil-base:ff78585
+      volumes:
+        - /dev:/dev
+        - /home/golioth/credentials:/opt/credentials
+      options: --privileged
+
     steps:
     - name: Checkout repository without submodules
       uses: actions/checkout@v4
@@ -114,11 +121,22 @@ jobs:
         name: test_new.bin
         path: examples/esp_idf/test
     - name: Install python packages
-      run: python -m pip install esptool requests
+      run: python3 -m pip install esptool requests
+    - name: Install goliothctl
+      run: |
+        echo "deb [trusted=yes] https://repos.golioth.io/apt/ /" | tee /etc/apt/sources.list.d/golioth.list
+        mkdir -p /tmp
+        apt update -y --allow-insecure-repositories
+        apt install goliothctl -y
+    - name: Prepare goliothctl secret
+      run: |
+        mkdir -p ~/.golioth
+        echo -n ${{ secrets.GOLIOTHCTL_DEV }} | base64 -d  > ~/.golioth/.goliothctl.yaml
     - name: Copy credentials_esp32s3_devkitc.yml to examples/esp_idf/test
       run: |
-        cp $HOME/credentials_esp32s3_devkitc.yml examples/esp_idf/test/credentials.yml
+        cp /opt/credentials/credentials_esp32s3_devkitc.yml examples/esp_idf/test/credentials.yml
     - name: Create and rollout new 1.2.99 OTA release using goliothctl
+      shell: bash
       run: |
         cd examples/esp_idf/test
         export GOLIOTH_API_URL=$(cat credentials.yml | grep api_url | awk '{print $2}')
@@ -130,7 +148,8 @@ jobs:
         goliothctl dfu --apiUrl $GOLIOTH_API_URL --projectId $GOLIOTH_PROJECT_ID artifact create test_new.bin --version 1.2.99
         goliothctl dfu --apiUrl $GOLIOTH_API_URL --projectId $GOLIOTH_PROJECT_ID release create --release-tags 1.2.99 --components main@1.2.99 --rollout true
     - name: Flash and Verify Serial Output
+      shell: bash
       run: |
         cd examples/esp_idf/test
-        source $HOME/runner_env.sh
-        python flash.py $CI_ESP32S3_DEVKITC_PORT && python verify.py $CI_ESP32S3_DEVKITC_PORT
+        source /opt/credentials/runner_env.sh
+        python3 flash.py $CI_ESP32S3_DEVKITC_PORT && python3 verify.py $CI_ESP32S3_DEVKITC_PORT

--- a/tests/hil/tests/connection/test_connection.py
+++ b/tests/hil/tests/connection/test_connection.py
@@ -3,4 +3,4 @@ def test_connect(board):
     board.reset()
 
     # Confirm connection to Golioth
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected')
+    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=60)


### PR DESCRIPTION
* Use docker for all HIL testing on this repo
* Specifically target on self-hosted runner for the legacy esp32s3 test to workaround timeouts on some runners. This is being phased out and will soon be replaced with more granular tests

Changing to Docker HIL images was tested before opening this PR:
* https://github.com/golioth/golioth-firmware-sdk/actions/runs/7089709731
* https://github.com/golioth/golioth-firmware-sdk/actions/runs/7067511221
* https://github.com/golioth/golioth-firmware-sdk/actions/runs/7066696608