### PR TITLE
editorconfig: use indent of 2 for yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,7 +34,7 @@ indent_size = 4
 # YAML
 [*.{yml,yaml}]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 # Shell Script
 [*.sh]


### PR DESCRIPTION
Update the .editorconfig to reflect the indent we're using in practice.