### PR TITLE
tests: fix breaking change in hatch python package

### DIFF
--- a/tests/hil/scripts/pytest-hil/pyproject.toml
+++ b/tests/hil/scripts/pytest-hil/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.19"]
 build-backend = "hatchling.build"
 
 [project]
@@ -15,6 +15,9 @@ dependencies = [
 classifiers = [
     "Framework :: Pytest",
 ]
+
+[tool.hatch.build.targets.wheel]
+include = [ "*.py" ]
 
 [project.entry-points.pytest11]
 hil = "plugin"


### PR DESCRIPTION
Hatch now throws an error if files are not selected are not supplied to wheel. This commit includes all python files to satisfy the new condition.

Read more: https://github.com/pypa/hatch/issues/1113