### PR TITLE
port: zephyr: add kconfig for default log level

### DIFF
--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -155,6 +155,10 @@ config LOG_BACKEND_GOLIOTH_MAX_LOG_STRING_SIZE
 
 endif # LOG_BACKEND_GOLIOTH
 
+module = GOLIOTH
+module-str = Golioth
+source "subsys/logging/Kconfig.template.log_config"
+
 rsource '${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/examples/zephyr/common/Kconfig'
 
 endif # GOLIOTH_FIRMWARE_SDK

--- a/port/zephyr/include/golioth_port_config.h
+++ b/port/zephyr/include/golioth_port_config.h
@@ -9,7 +9,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/random/random.h>
 
-#define LOG_TAG_DEFINE(tag) LOG_MODULE_REGISTER(tag)
+#define LOG_TAG_DEFINE(tag) LOG_MODULE_REGISTER(tag, CONFIG_GOLIOTH_LOG_LEVEL)
 
 #define GLTH_LOGE(tag, ...) LOG_ERR(__VA_ARGS__)
 


### PR DESCRIPTION
Add a kconfig option for CONFIG_GOLIOTH_LOG_LEVEL so users can control the verbosity of internal SDK logs.

Resolves golioth/firmware-issue-tracker#319