### PR TITLE
zephyr: add test for hello sample

### DIFF
--- a/examples/zephyr/hello/pytest/conftest.py
+++ b/examples/zephyr/hello/pytest/conftest.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--api-key", type=str,
+                     help="Golioth API key")
+    parser.addoption("--device-name", type=str,
+                     help="Golioth device name")
+    parser.addoption("--credentials-file", type=str,
+                     help="YAML formatted settings file")
+
+
+@pytest.fixture(scope='session')
+def anyio_backend():
+    return 'trio'
+
+@pytest.fixture(scope="session")
+def api_key(request):
+    if request.config.getoption("--api-key") is not None:
+        return request.config.getoption("--api-key")
+    else:
+        return os.environ['GOLIOTH_API_KEY']
+
+@pytest.fixture(scope="session")
+def credentials_file(request):
+    if request.config.getoption("--credentials-file") is not None:
+        return request.config.getoption("---credentials-file")
+    else:
+        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+
+@pytest.fixture(scope="session")
+def device_name(request):
+    if request.config.getoption("--device-name") is not None:
+        return request.config.getoption("--device-name")
+    else:
+        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/hello/pytest/test_sample.py
+++ b/examples/zephyr/hello/pytest/test_sample.py
@@ -5,6 +5,9 @@ import pprint
 import time
 import yaml
 import datetime
+import logging
+
+LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
@@ -45,13 +48,18 @@ async def test_hello(shell, api_key, device_name, credentials_file):
 
     # Test logs received from server
 
+    LOGGER.info("Searching log messages from end to start:")
     test_idx = 2
     test_hits = 0
     for m in reversed(logs):
+
         if m.message == f"Sending hello! {test_idx}":
+            LOGGER.info("### MATCH FOUND! ---> {0}".format(m.message))
             test_hits += 1
             test_idx -= 1
             if test_idx < 0:
                 break
+        else:
+            LOGGER.info(m.message)
 
     assert test_hits == 3, 'Unable to find all Hello messages on server'

--- a/examples/zephyr/hello/pytest/test_sample.py
+++ b/examples/zephyr/hello/pytest/test_sample.py
@@ -1,0 +1,57 @@
+from golioth import Client
+import logging
+import pytest
+import pprint
+import time
+import yaml
+import datetime
+
+pytestmark = pytest.mark.anyio
+
+async def test_hello(shell, api_key, device_name, credentials_file):
+
+    # Connect to Golioth and get device object
+
+    client = Client(api_url = "https://api.golioth.dev",
+                    api_key = api_key)
+    project = (await client.get_projects())[0]
+    device = await project.device_by_name(device_name)
+
+    # Read credentials
+
+    with open(credentials_file, 'r') as f:
+        credentials = yaml.safe_load(f)
+
+    time.sleep(2)
+
+    # Set credentials
+
+    for setting in credentials['settings']:
+        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+
+    shell._device.clear_buffer()
+    shell._device.write('kernel reboot cold\n\n'.encode())
+
+    # Record timestamp and wait for fourth hello mesage
+
+    start = datetime.datetime.utcnow()
+    shell._device.readlines_until(regex=".*Sending hello! 3", timeout=90.0)
+
+    # Check logs for hello messages
+
+    end = datetime.datetime.utcnow()
+
+    logs = await device.get_logs({'start': start.strftime('%Y-%m-%dT%H:%M:%S.%fZ'), 'end': end.strftime('%Y-%m-%dT%H:%M:%S.%fZ')})
+
+    # Test logs received from server
+
+    test_idx = 2
+    test_hits = 0
+    for m in reversed(logs):
+        if m.message == f"Sending hello! {test_idx}":
+            test_hits += 1
+            test_idx -= 1
+            if test_idx < 0:
+                break
+
+    assert test_hits == 3, 'Unable to find all Hello messages on server'

--- a/examples/zephyr/hello/sample.yaml
+++ b/examples/zephyr/hello/sample.yaml
@@ -5,6 +5,7 @@ tests:
   sample.golioth.hello:
     harness: pytest
     tags: golioth socket goliothd
+    timeout: 90
     extra_args: EXTRA_CONF_FILE="../common/runtime_psk.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128

--- a/examples/zephyr/hello/sample.yaml
+++ b/examples/zephyr/hello/sample.yaml
@@ -1,10 +1,22 @@
 sample:
   description: Say Hello to Golioth server
   name: hello
-common:
-  build_only: true
 tests:
+  sample.golioth.hello:
+    harness: pytest
+    tags: golioth socket goliothd
+    extra_args: EXTRA_CONF_FILE="../common/runtime_psk.conf"
+    extra_configs:
+      - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
+      - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
+      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
+    platform_allow: >
+      esp32_devkitc_wrover
+      mimxrt1024_evk
+      nrf52840dk_nrf52840
+      nrf9160dk_nrf9160_ns
   sample.golioth.hello.psk:
+    build_only: true
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk
@@ -12,6 +24,7 @@ tests:
       qemu_x86
       nrf9160dk_nrf9160_ns
   sample.golioth.hello.psk.cid:
+    build_only: true
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk
@@ -20,15 +33,8 @@ tests:
       nrf9160dk_nrf9160_ns
     extra_configs:
       - CONFIG_GOLIOTH_USE_CONNECTION_ID=y
-  sample.golioth.hello.psk.runtime.buildonly:
-    extra_args: EXTRA_CONF_FILE="../common/runtime_psk.conf"
-    platform_allow: >
-      esp32_devkitc_wrover
-      mimxrt1024_evk
-      nrf52840dk_nrf52840
-      nrf9160dk_nrf9160_ns
-      qemu_x86
   sample.golioth.hello.cert.buildonly:
+    build_only: true
     extra_configs:
       - CONFIG_GOLIOTH_AUTH_METHOD_CERT=y
       # Make it build by providing path that can be resolved


### PR DESCRIPTION
Add a pytest-based Twister test to the Hello sample:

* Compile and flash the sample to each HIL board
* Monitor the board's serial connection for the fourth Hello message to be sent
* Query the device logs from Golioth and search them backwards for the first three Hello messages

This test ensures the following:
* By waiting until the fourth message has been sent, we have a built-in 5 second window for the previous Hello message to arrive on the server and be available via the Rest API
* When searching the logs we verify all of the first three Hello messages were received in the order they were sent. 