### PR TITLE
zephyr: add test for rpc sample

### DIFF
--- a/examples/zephyr/rpc/pytest/conftest.py
+++ b/examples/zephyr/rpc/pytest/conftest.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--api-key", type=str,
+                     help="Golioth API key")
+    parser.addoption("--device-name", type=str,
+                     help="Golioth device name")
+    parser.addoption("--credentials-file", type=str,
+                     help="YAML formatted settings file")
+
+
+@pytest.fixture(scope='session')
+def anyio_backend():
+    return 'trio'
+
+@pytest.fixture(scope="session")
+def api_key(request):
+    if request.config.getoption("--api-key") is not None:
+        return request.config.getoption("--api-key")
+    else:
+        return os.environ['GOLIOTH_API_KEY']
+
+@pytest.fixture(scope="session")
+def credentials_file(request):
+    if request.config.getoption("--credentials-file") is not None:
+        return request.config.getoption("---credentials-file")
+    else:
+        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+
+@pytest.fixture(scope="session")
+def device_name(request):
+    if request.config.getoption("--device-name") is not None:
+        return request.config.getoption("--device-name")
+    else:
+        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/rpc/pytest/test_sample.py
+++ b/examples/zephyr/rpc/pytest/test_sample.py
@@ -1,0 +1,60 @@
+from golioth import Client, RPCStatusCode
+import logging
+import pytest
+import time
+import yaml
+
+LOGGER = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.anyio
+
+async def test_logging(shell, api_key, device_name, credentials_file):
+
+    # Connect to Golioth and get device object
+
+    client = Client(api_url = "https://api.golioth.dev",
+                    api_key = api_key)
+    project = (await client.get_projects())[0]
+    device = await project.device_by_name(device_name)
+
+    # Read credentials
+
+    with open(credentials_file, 'r') as f:
+        credentials = yaml.safe_load(f)
+
+    time.sleep(2)
+
+    # Set credentials
+
+    for setting in credentials['settings']:
+        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+
+    shell._device.clear_buffer()
+    shell._device.write('kernel reboot cold\n\n'.encode())
+
+    # Wait for device to reboot and connect
+
+    shell._device.readlines_until(regex=".*rpc_sample: Golioth client connected", timeout=90.0)
+
+    # Test successful RPC
+
+    result = await device.rpc.call("multiply", [ 7, 6 ])
+    LOGGER.info("### Received: {0} Expected: {1}".format(result['value'],  42))
+    assert result['value'] == 42, "Didn't receive correct value"
+
+    # Test successful RPC using float
+
+    result = await device.rpc.call("multiply", [ 11.4, 93.81 ])
+    LOGGER.info("### Received: {0} Expected: {1}".format(result['value'],  1069.434))
+    assert result['value'] == 1069.434, "Didn't receive correct float"
+
+    # Test invalid argument RPC
+
+    error_code = None
+    try:
+        result = await device.rpc.call("multiply", [ 6, 'J' ])
+    except Exception as e:
+        error_code = e
+        pass
+    LOGGER.info("### Received: {0} Expected: {1}".format(error_code.status_code,  RPCStatusCode.INVALID_ARGUMENT))
+    assert error_code.status_code == RPCStatusCode.INVALID_ARGUMENT, "Didn't receive correct error code"

--- a/examples/zephyr/rpc/sample.yaml
+++ b/examples/zephyr/rpc/sample.yaml
@@ -2,10 +2,16 @@ sample:
   description: Golioth RPC Sample
   name: rpc
 common:
+  harness: pytest
   tags: golioth socket goliothd
 tests:
   sample.golioth.rpc:
-    build_only: true
+    timeout: 90
+    extra_args: EXTRA_CONF_FILE="../common/runtime_psk.conf"
+    extra_configs:
+      - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
+      - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
+      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk


### PR DESCRIPTION
Check for successful integer result, float results, and verify error code when an invalid parameter type is supplied.