### PR TITLE
HIL: reset USB hub before running tests

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: has_${{ inputs.hil_board }}
 
     container:
-      image: golioth/golioth-twister-base:3ad9efa
+      image: golioth/golioth-twister-base:50cb4bc
       env:
         ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
       volumes:
@@ -105,6 +105,8 @@ jobs:
           pip3 install -r zephyr/scripts/requirements-run-test.txt
 
           pip3 install git+https://github.com/golioth/python-golioth-tools@v0.2.0
+      - name: Power Cycle USB Hub
+        run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: has_${{ inputs.hil_board }}
 
     container:
-      image: golioth/golioth-hil-base:ff78585
+      image: golioth/golioth-hil-base:280d655
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials
@@ -54,6 +54,8 @@ jobs:
         run: |
           pip install pytest
           pip install tests/hil/scripts/pytest-hil
+      - name: Power Cycle USB Hub
+        run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: has_${{ inputs.hil_board }}
 
     container:
-      image: golioth/golioth-hil-base:ff78585
+      image: golioth/golioth-hil-base:280d655
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials
@@ -81,6 +81,8 @@ jobs:
         run: |
           pip install pytest
           pip install tests/hil/scripts/pytest-hil
+      - name: Power Cycle USB Hub
+        run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Update Docker images for Twister and HIL base to newest which include USB hub control. Call the script to power cycle the hub before running tests.