### PR TITLE
HIL: use is_active label with runners

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -71,7 +71,7 @@ jobs:
   test:
     if: ${{ inputs.run_tests }}
     needs: build
-    runs-on: has_${{ inputs.hil_board }}
+    runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
 
     container:
       image: golioth/golioth-twister-base:50cb4bc

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -38,7 +38,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: has_${{ inputs.hil_board }}
+    runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
 
     container:
       image: golioth/golioth-hil-base:280d655

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -65,7 +65,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: has_${{ inputs.hil_board }}
+    runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
 
     container:
       image: golioth/golioth-hil-base:280d655

--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -94,7 +94,7 @@ jobs:
   # ---
   hw_flash_and_test:
     needs: build_for_hw_test
-    runs-on: [self-hosted, has_esp32s3_devkitc, mikes_orange_pi]
+    runs-on: [is_active, has_esp32s3_devkitc, mikes_orange_pi]
 
     container:
       image: golioth/golioth-hil-base:ff78585


### PR DESCRIPTION
Require the is_active lable when selecting a self-hosted runner. This label indicates the runner is available for testing. The label will be removed from runners undergoing maintenance.