### PR TITLE
Lightdb state example tests

### DIFF
--- a/examples/zephyr/lightdb/delete/pytest/conftest.py
+++ b/examples/zephyr/lightdb/delete/pytest/conftest.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--api-key", type=str,
+                     help="Golioth API key")
+    parser.addoption("--device-name", type=str,
+                     help="Golioth device name")
+    parser.addoption("--credentials-file", type=str,
+                     help="YAML formatted settings file")
+
+
+@pytest.fixture(scope='session')
+def anyio_backend():
+    return 'trio'
+
+@pytest.fixture(scope="session")
+def api_key(request):
+    if request.config.getoption("--api-key") is not None:
+        return request.config.getoption("--api-key")
+    else:
+        return os.environ['GOLIOTH_API_KEY']
+
+@pytest.fixture(scope="session")
+def credentials_file(request):
+    if request.config.getoption("--credentials-file") is not None:
+        return request.config.getoption("---credentials-file")
+    else:
+        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+
+@pytest.fixture(scope="session")
+def device_name(request):
+    if request.config.getoption("--device-name") is not None:
+        return request.config.getoption("--device-name")
+    else:
+        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -1,0 +1,63 @@
+from golioth import Client, LogLevel, LogEntry
+import contextlib
+import logging
+import pytest
+import time
+import yaml
+import datetime
+
+LOGGER = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.anyio
+
+async def test_lightdb_delete(shell, api_key, device_name, credentials_file):
+
+    # Connect to Golioth and get device object
+
+    client = Client(api_url = "https://api.golioth.dev",
+                    api_key = api_key)
+    project = (await client.get_projects())[0]
+    device = await project.device_by_name(device_name)
+
+    # Set counter in lightdb state
+
+    await device.lightdb.set("counter", 34)
+    counter = await device.lightdb.get("counter")
+    assert counter == 34
+
+    # Read credentials
+
+    with open(credentials_file, 'r') as f:
+        credentials = yaml.safe_load(f)
+
+    time.sleep(2)
+
+    # Set credentials
+
+    for setting in credentials['settings']:
+        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+
+    shell._device.clear_buffer()
+    shell._device.write('kernel reboot cold\n\n'.encode())
+
+    # Wait for Golioth connection
+
+    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=30.0)
+
+    # Verify lightdb delete (async)
+
+    shell._device.readlines_until(regex=".*Counter deleted successfully", timeout=10.0)
+    counter = await device.lightdb.get("counter")
+    assert counter is None
+
+    # Set and verify counter
+
+    await device.lightdb.set("counter", 62)
+    counter = await device.lightdb.get("counter")
+    assert counter == 62
+
+    # Verify lightdb delete (sync)
+
+    shell._device.readlines_until(regex=".*Counter deleted successfully", timeout=10.0)
+    counter = await device.lightdb.get("counter")
+    assert counter is None

--- a/examples/zephyr/lightdb/delete/sample.yaml
+++ b/examples/zephyr/lightdb/delete/sample.yaml
@@ -2,10 +2,16 @@ sample:
   description: Use LightDB delete
   name: lightdb-delete
 common:
+  harness: pytest
   tags: golioth lightdb socket goliothd
 tests:
   sample.golioth.lightdb_delete:
-    build_only: true
+    timeout: 90
+    extra_args: EXTRA_CONF_FILE="../../common/runtime_psk.conf"
+    extra_configs:
+      - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
+      - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
+      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/lightdb/get/pytest/conftest.py
+++ b/examples/zephyr/lightdb/get/pytest/conftest.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--api-key", type=str,
+                     help="Golioth API key")
+    parser.addoption("--device-name", type=str,
+                     help="Golioth device name")
+    parser.addoption("--credentials-file", type=str,
+                     help="YAML formatted settings file")
+
+
+@pytest.fixture(scope='session')
+def anyio_backend():
+    return 'trio'
+
+@pytest.fixture(scope="session")
+def api_key(request):
+    if request.config.getoption("--api-key") is not None:
+        return request.config.getoption("--api-key")
+    else:
+        return os.environ['GOLIOTH_API_KEY']
+
+@pytest.fixture(scope="session")
+def credentials_file(request):
+    if request.config.getoption("--credentials-file") is not None:
+        return request.config.getoption("---credentials-file")
+    else:
+        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+
+@pytest.fixture(scope="session")
+def device_name(request):
+    if request.config.getoption("--device-name") is not None:
+        return request.config.getoption("--device-name")
+    else:
+        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/lightdb/get/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/get/pytest/test_sample.py
@@ -1,0 +1,60 @@
+from golioth import Client, LogLevel, LogEntry
+import contextlib
+import logging
+import pytest
+import time
+import yaml
+import datetime
+
+LOGGER = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.anyio
+
+async def test_lightdb_get(shell, api_key, device_name, credentials_file):
+
+    # Connect to Golioth and get device object
+
+    client = Client(api_url = "https://api.golioth.dev",
+                    api_key = api_key)
+    project = (await client.get_projects())[0]
+    device = await project.device_by_name(device_name)
+
+    # Delete counter in lightdb state
+
+    await device.lightdb.delete("counter")
+
+    # Read credentials
+
+    with open(credentials_file, 'r') as f:
+        credentials = yaml.safe_load(f)
+
+    time.sleep(2)
+
+    # Set credentials
+
+    for setting in credentials['settings']:
+        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+
+    shell._device.clear_buffer()
+    shell._device.write('kernel reboot cold\n\n'.encode())
+
+    # Wait for Golioth connection
+
+    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=30.0)
+
+    # Verify lightdb reads
+
+    shell._device.readlines_until(regex=".*Failed to get counter \(async\): 0", timeout=10.0)
+
+    await device.lightdb.set("counter", 13)
+
+    shell._device.readlines_until(regex=".*Counter \(sync\): 13", timeout=10.0)
+
+    await device.lightdb.set("counter", 27)
+
+    shell._device.readlines_until(regex=".*22 63 6f 75 6e 74 65 72  22 3a 32 37             |\"counter \":27",
+                                  timeout=10.0)
+
+    await device.lightdb.set("counter", 42)
+
+    shell._device.readlines_until(regex=".*Counter \(async\): 42", timeout=10.0)

--- a/examples/zephyr/lightdb/get/sample.yaml
+++ b/examples/zephyr/lightdb/get/sample.yaml
@@ -2,10 +2,16 @@ sample:
   description: Use LightDB get
   name: lightdb-get
 common:
+  harness: pytest
   tags: golioth lightdb socket goliothd
 tests:
   sample.golioth.lightdb_get:
-    build_only: true
+    timeout: 90
+    extra_args: EXTRA_CONF_FILE="../../common/runtime_psk.conf"
+    extra_configs:
+      - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
+      - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
+      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/lightdb/get/src/main.c
+++ b/examples/zephyr/lightdb/get/src/main.c
@@ -34,14 +34,13 @@ static void counter_get_handler(
         const uint8_t* payload,
         size_t payload_size,
         void* arg) {
-    if (response->status != GOLIOTH_OK) {
-        LOG_WRN("Failed to set counter: %d", response->status);
-        return;
+    if ((response->status != GOLIOTH_OK) || golioth_payload_is_null(payload, payload_size)) {
+        LOG_WRN("Failed to get counter (async): %d", response->status);
     }
-
-    LOG_INF("Counter (async): %d", golioth_payload_as_int(payload, payload_size));
-
-    return;
+    else
+    {
+        LOG_INF("Counter (async): %d", golioth_payload_as_int(payload, payload_size));
+    }
 }
 
 static void counter_get_async(golioth_client_t* client) {
@@ -61,8 +60,10 @@ static void counter_get_sync(golioth_client_t* client) {
     if (err) {
         LOG_WRN("failed to get data from LightDB: %d", err);
     }
-
-    LOG_INF("Counter (sync): %d", value);
+    else
+    {
+        LOG_INF("Counter (sync): %d", value);
+    }
 }
 
 static void counter_get_json_sync(golioth_client_t* client) {
@@ -72,12 +73,13 @@ static void counter_get_json_sync(golioth_client_t* client) {
 
     /* Get root of LightDB State, but JSON can be returned for any path */
     err = golioth_lightdb_get_json_sync(client, "", sbuf, len, APP_TIMEOUT_S);
-    if (err) {
+    if (err || (0 == strlen(sbuf))) {
         LOG_WRN("failed to get JSON data from LightDB: %d", err);
-        return;
     }
-
-    LOG_HEXDUMP_INF(sbuf, strlen(sbuf), "LightDB JSON (sync)");
+    else
+    {
+        LOG_HEXDUMP_INF(sbuf, strlen(sbuf), "LightDB JSON (sync)");
+    }
 }
 
 int main(void) {

--- a/examples/zephyr/lightdb/observe/pytest/conftest.py
+++ b/examples/zephyr/lightdb/observe/pytest/conftest.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--api-key", type=str,
+                     help="Golioth API key")
+    parser.addoption("--device-name", type=str,
+                     help="Golioth device name")
+    parser.addoption("--credentials-file", type=str,
+                     help="YAML formatted settings file")
+
+
+@pytest.fixture(scope='session')
+def anyio_backend():
+    return 'trio'
+
+@pytest.fixture(scope="session")
+def api_key(request):
+    if request.config.getoption("--api-key") is not None:
+        return request.config.getoption("--api-key")
+    else:
+        return os.environ['GOLIOTH_API_KEY']
+
+@pytest.fixture(scope="session")
+def credentials_file(request):
+    if request.config.getoption("--credentials-file") is not None:
+        return request.config.getoption("---credentials-file")
+    else:
+        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+
+@pytest.fixture(scope="session")
+def device_name(request):
+    if request.config.getoption("--device-name") is not None:
+        return request.config.getoption("--device-name")
+    else:
+        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/lightdb/observe/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/observe/pytest/test_sample.py
@@ -1,0 +1,53 @@
+from golioth import Client, LogLevel, LogEntry
+import contextlib
+import logging
+import pytest
+import time
+import yaml
+import datetime
+
+LOGGER = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.anyio
+
+async def test_lightdb_observe(shell, api_key, device_name, credentials_file):
+
+    # Connect to Golioth and get device object
+
+    client = Client(api_url = "https://api.golioth.dev",
+                    api_key = api_key)
+    project = (await client.get_projects())[0]
+    device = await project.device_by_name(device_name)
+
+    # Delete counter in lightdb state
+
+    await device.lightdb.delete("counter")
+
+    # Read credentials
+
+    with open(credentials_file, 'r') as f:
+        credentials = yaml.safe_load(f)
+
+    time.sleep(2)
+
+    # Set credentials
+
+    for setting in credentials['settings']:
+        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+
+    shell._device.clear_buffer()
+    shell._device.write('kernel reboot cold\n\n'.encode())
+
+    # Wait for Golioth connection
+
+    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=30.0)
+
+    # Verify lightdb observe
+
+    shell._device.readlines_until(regex=".*lightdb_observe: Counter \(async\)", timeout=10.0)
+    shell._device.readlines_until(regex=".*6e 75 6c 6c\s+|null", timeout=1.0)
+
+    await device.lightdb.set("counter", 87)
+
+    shell._device.readlines_until(regex=".*lightdb_observe: Counter \(async\)", timeout=2.0)
+    shell._device.readlines_until(regex=".*38 37\s+|87", timeout=1.0)

--- a/examples/zephyr/lightdb/observe/sample.yaml
+++ b/examples/zephyr/lightdb/observe/sample.yaml
@@ -2,10 +2,16 @@ sample:
   description: Use LightDB observe
   name: lightdb-observe
 common:
+  harness: pytest
   tags: golioth lightdb socket goliothd
 tests:
   sample.golioth.lightdb_observe:
-    build_only: true
+    timeout: 90
+    extra_args: EXTRA_CONF_FILE="../../common/runtime_psk.conf"
+    extra_configs:
+      - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
+      - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
+      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/lightdb/set/pytest/conftest.py
+++ b/examples/zephyr/lightdb/set/pytest/conftest.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--api-key", type=str,
+                     help="Golioth API key")
+    parser.addoption("--device-name", type=str,
+                     help="Golioth device name")
+    parser.addoption("--credentials-file", type=str,
+                     help="YAML formatted settings file")
+
+
+@pytest.fixture(scope='session')
+def anyio_backend():
+    return 'trio'
+
+@pytest.fixture(scope="session")
+def api_key(request):
+    if request.config.getoption("--api-key") is not None:
+        return request.config.getoption("--api-key")
+    else:
+        return os.environ['GOLIOTH_API_KEY']
+
+@pytest.fixture(scope="session")
+def credentials_file(request):
+    if request.config.getoption("--credentials-file") is not None:
+        return request.config.getoption("---credentials-file")
+    else:
+        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+
+@pytest.fixture(scope="session")
+def device_name(request):
+    if request.config.getoption("--device-name") is not None:
+        return request.config.getoption("--device-name")
+    else:
+        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/lightdb/set/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/set/pytest/test_sample.py
@@ -1,0 +1,50 @@
+from golioth import Client, LogLevel, LogEntry
+import contextlib
+import logging
+import pytest
+import time
+import yaml
+import datetime
+
+LOGGER = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.anyio
+
+async def test_lightdb_set(shell, api_key, device_name, credentials_file):
+
+    # Connect to Golioth and get device object
+
+    client = Client(api_url = "https://api.golioth.dev",
+                    api_key = api_key)
+    project = (await client.get_projects())[0]
+    device = await project.device_by_name(device_name)
+
+    # Delete counter in lightdb state
+
+    await device.lightdb.delete("counter")
+
+    # Read credentials
+
+    with open(credentials_file, 'r') as f:
+        credentials = yaml.safe_load(f)
+
+    time.sleep(2)
+
+    # Set credentials
+
+    for setting in credentials['settings']:
+        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+
+    shell._device.clear_buffer()
+    shell._device.write('kernel reboot cold\n\n'.encode())
+
+    # Wait for Golioth connection
+
+    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=30.0)
+
+    # Verify lightdb writes
+
+    for i in range(0,3):
+        shell._device.readlines_until(regex=f".*Setting counter to {i}", timeout=10.0)
+        counter = await device.lightdb.get("counter")
+        assert counter == i

--- a/examples/zephyr/lightdb/set/sample.yaml
+++ b/examples/zephyr/lightdb/set/sample.yaml
@@ -2,10 +2,16 @@ sample:
   description: Use LightDB set
   name: lightdb-set
 common:
+  harness: pytest
   tags: golioth lightdb socket goliothd
 tests:
   sample.golioth.lightdb_set:
-    build_only: true
+    timeout: 90
+    extra_args: EXTRA_CONF_FILE="../../common/runtime_psk.conf"
+    extra_configs:
+      - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
+      - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
+      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk


### PR DESCRIPTION
Add Twister tests for each of the LightDB State samples. Also includes a little bit of cleanup of error handling in the lightdb/get sample.

Resolves golioth/firmware-issue-tracker#274