### PR TITLE
Ensure disabled services fail to link

### DIFF
--- a/src/golioth_rpc.c
+++ b/src/golioth_rpc.c
@@ -213,14 +213,5 @@ golioth_status_t golioth_rpc_register(
     }
     return GOLIOTH_OK;
 }
-#else  // CONFIG_GOLIOTH_RPC
-
-golioth_status_t golioth_rpc_register(
-        golioth_client_t client,
-        const char* method,
-        golioth_rpc_cb_fn callback,
-        void* callback_arg) {
-    return GOLIOTH_ERR_NOT_IMPLEMENTED;
-}
 
 #endif  // CONFIG_GOLIOTH_RPC

--- a/src/golioth_settings.c
+++ b/src/golioth_settings.c
@@ -450,40 +450,4 @@ golioth_status_t golioth_settings_register_float(
     return GOLIOTH_OK;
 }
 
-#else  // CONFIG_GOLIOTH_SETTINGS
-
-golioth_status_t golioth_settings_register_int(
-        golioth_client_t client,
-        const char* setting_name,
-        golioth_int_setting_cb callback,
-        void* callback_arg) {
-    return GOLIOTH_ERR_NOT_IMPLEMENTED;
-}
-
-golioth_status_t golioth_settings_register_int_with_range(
-        golioth_client_t client,
-        const char* setting_name,
-        int32_t min_val,
-        int32_t max_val,
-        golioth_int_setting_cb callback,
-        void* callback_arg) {
-    return GOLIOTH_ERR_NOT_IMPLEMENTED;
-}
-
-golioth_status_t golioth_settings_register_bool(
-        golioth_client_t client,
-        const char* setting_name,
-        golioth_bool_setting_cb callback,
-        void* callback_arg) {
-    return GOLIOTH_ERR_NOT_IMPLEMENTED;
-}
-
-golioth_status_t golioth_settings_register_float(
-        golioth_client_t client,
-        const char* setting_name,
-        golioth_float_setting_cb callback,
-        void* callback_arg) {
-    return GOLIOTH_ERR_NOT_IMPLEMENTED;
-}
-
 #endif  // CONFIG_GOLIOTH_SETTINGS


### PR DESCRIPTION
There's no reason to provide a noop function for a disabled SDK service. Instead, we should not provide implementations for disabled functions at all, so that if a user attempts to call these functions the build will fail at link time.

Fixes golioth/firmware-issue-tracker#355