### PR TITLE
examples: pytest: use golioth pytest plugin

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -104,7 +104,7 @@ jobs:
           pip3 install -r zephyr/scripts/requirements-build-test.txt
           pip3 install -r zephyr/scripts/requirements-run-test.txt
 
-          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.2.0
+          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.3.0
       - name: Power Cycle USB Hub
         run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build

--- a/examples/zephyr/hello/pytest/conftest.py
+++ b/examples/zephyr/hello/pytest/conftest.py
@@ -2,24 +2,12 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--api-key", type=str,
-                     help="Golioth API key")
-    parser.addoption("--device-name", type=str,
-                     help="Golioth device name")
     parser.addoption("--credentials-file", type=str,
                      help="YAML formatted settings file")
-
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def api_key(request):
-    if request.config.getoption("--api-key") is not None:
-        return request.config.getoption("--api-key")
-    else:
-        return os.environ['GOLIOTH_API_KEY']
 
 @pytest.fixture(scope="session")
 def credentials_file(request):
@@ -27,10 +15,3 @@ def credentials_file(request):
         return request.config.getoption("---credentials-file")
     else:
         return os.environ['GOLIOTH_CREDENTIALS_FILE']
-
-@pytest.fixture(scope="session")
-def device_name(request):
-    if request.config.getoption("--device-name") is not None:
-        return request.config.getoption("--device-name")
-    else:
-        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/hello/pytest/test_sample.py
+++ b/examples/zephyr/hello/pytest/test_sample.py
@@ -1,4 +1,3 @@
-from golioth import Client
 import logging
 import pytest
 import pprint
@@ -11,15 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_hello(shell, api_key, device_name, credentials_file):
-
-    # Connect to Golioth and get device object
-
-    client = Client(api_url = "https://api.golioth.dev",
-                    api_key = api_key)
-    project = (await client.get_projects())[0]
-    device = await project.device_by_name(device_name)
-
+async def test_hello(shell, device, credentials_file):
     # Read credentials
 
     with open(credentials_file, 'r') as f:

--- a/examples/zephyr/lightdb/delete/pytest/conftest.py
+++ b/examples/zephyr/lightdb/delete/pytest/conftest.py
@@ -2,24 +2,12 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--api-key", type=str,
-                     help="Golioth API key")
-    parser.addoption("--device-name", type=str,
-                     help="Golioth device name")
     parser.addoption("--credentials-file", type=str,
                      help="YAML formatted settings file")
-
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def api_key(request):
-    if request.config.getoption("--api-key") is not None:
-        return request.config.getoption("--api-key")
-    else:
-        return os.environ['GOLIOTH_API_KEY']
 
 @pytest.fixture(scope="session")
 def credentials_file(request):
@@ -27,10 +15,3 @@ def credentials_file(request):
         return request.config.getoption("---credentials-file")
     else:
         return os.environ['GOLIOTH_CREDENTIALS_FILE']
-
-@pytest.fixture(scope="session")
-def device_name(request):
-    if request.config.getoption("--device-name") is not None:
-        return request.config.getoption("--device-name")
-    else:
-        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -1,4 +1,3 @@
-from golioth import Client, LogLevel, LogEntry
 import contextlib
 import logging
 import pytest
@@ -10,15 +9,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_lightdb_delete(shell, api_key, device_name, credentials_file):
-
-    # Connect to Golioth and get device object
-
-    client = Client(api_url = "https://api.golioth.dev",
-                    api_key = api_key)
-    project = (await client.get_projects())[0]
-    device = await project.device_by_name(device_name)
-
+async def test_lightdb_delete(shell, device, credentials_file):
     # Set counter in lightdb state
 
     await device.lightdb.set("counter", 34)

--- a/examples/zephyr/lightdb/get/pytest/conftest.py
+++ b/examples/zephyr/lightdb/get/pytest/conftest.py
@@ -2,24 +2,12 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--api-key", type=str,
-                     help="Golioth API key")
-    parser.addoption("--device-name", type=str,
-                     help="Golioth device name")
     parser.addoption("--credentials-file", type=str,
                      help="YAML formatted settings file")
-
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def api_key(request):
-    if request.config.getoption("--api-key") is not None:
-        return request.config.getoption("--api-key")
-    else:
-        return os.environ['GOLIOTH_API_KEY']
 
 @pytest.fixture(scope="session")
 def credentials_file(request):
@@ -27,10 +15,3 @@ def credentials_file(request):
         return request.config.getoption("---credentials-file")
     else:
         return os.environ['GOLIOTH_CREDENTIALS_FILE']
-
-@pytest.fixture(scope="session")
-def device_name(request):
-    if request.config.getoption("--device-name") is not None:
-        return request.config.getoption("--device-name")
-    else:
-        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/lightdb/get/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/get/pytest/test_sample.py
@@ -1,4 +1,3 @@
-from golioth import Client, LogLevel, LogEntry
 import contextlib
 import logging
 import pytest
@@ -10,15 +9,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_lightdb_get(shell, api_key, device_name, credentials_file):
-
-    # Connect to Golioth and get device object
-
-    client = Client(api_url = "https://api.golioth.dev",
-                    api_key = api_key)
-    project = (await client.get_projects())[0]
-    device = await project.device_by_name(device_name)
-
+async def test_lightdb_get(shell, device, credentials_file):
     # Delete counter in lightdb state
 
     await device.lightdb.delete("counter")

--- a/examples/zephyr/lightdb/observe/pytest/conftest.py
+++ b/examples/zephyr/lightdb/observe/pytest/conftest.py
@@ -2,24 +2,12 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--api-key", type=str,
-                     help="Golioth API key")
-    parser.addoption("--device-name", type=str,
-                     help="Golioth device name")
     parser.addoption("--credentials-file", type=str,
                      help="YAML formatted settings file")
-
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def api_key(request):
-    if request.config.getoption("--api-key") is not None:
-        return request.config.getoption("--api-key")
-    else:
-        return os.environ['GOLIOTH_API_KEY']
 
 @pytest.fixture(scope="session")
 def credentials_file(request):
@@ -27,10 +15,3 @@ def credentials_file(request):
         return request.config.getoption("---credentials-file")
     else:
         return os.environ['GOLIOTH_CREDENTIALS_FILE']
-
-@pytest.fixture(scope="session")
-def device_name(request):
-    if request.config.getoption("--device-name") is not None:
-        return request.config.getoption("--device-name")
-    else:
-        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/lightdb/observe/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/observe/pytest/test_sample.py
@@ -1,4 +1,3 @@
-from golioth import Client, LogLevel, LogEntry
 import contextlib
 import logging
 import pytest
@@ -10,15 +9,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_lightdb_observe(shell, api_key, device_name, credentials_file):
-
-    # Connect to Golioth and get device object
-
-    client = Client(api_url = "https://api.golioth.dev",
-                    api_key = api_key)
-    project = (await client.get_projects())[0]
-    device = await project.device_by_name(device_name)
-
+async def test_lightdb_observe(shell, device, credentials_file):
     # Delete counter in lightdb state
 
     await device.lightdb.delete("counter")

--- a/examples/zephyr/lightdb/set/pytest/conftest.py
+++ b/examples/zephyr/lightdb/set/pytest/conftest.py
@@ -2,24 +2,12 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--api-key", type=str,
-                     help="Golioth API key")
-    parser.addoption("--device-name", type=str,
-                     help="Golioth device name")
     parser.addoption("--credentials-file", type=str,
                      help="YAML formatted settings file")
-
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def api_key(request):
-    if request.config.getoption("--api-key") is not None:
-        return request.config.getoption("--api-key")
-    else:
-        return os.environ['GOLIOTH_API_KEY']
 
 @pytest.fixture(scope="session")
 def credentials_file(request):
@@ -27,10 +15,3 @@ def credentials_file(request):
         return request.config.getoption("---credentials-file")
     else:
         return os.environ['GOLIOTH_CREDENTIALS_FILE']
-
-@pytest.fixture(scope="session")
-def device_name(request):
-    if request.config.getoption("--device-name") is not None:
-        return request.config.getoption("--device-name")
-    else:
-        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/lightdb/set/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/set/pytest/test_sample.py
@@ -1,4 +1,3 @@
-from golioth import Client, LogLevel, LogEntry
 import contextlib
 import logging
 import pytest
@@ -10,15 +9,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_lightdb_set(shell, api_key, device_name, credentials_file):
-
-    # Connect to Golioth and get device object
-
-    client = Client(api_url = "https://api.golioth.dev",
-                    api_key = api_key)
-    project = (await client.get_projects())[0]
-    device = await project.device_by_name(device_name)
-
+async def test_lightdb_set(shell, device, credentials_file):
     # Delete counter in lightdb state
 
     await device.lightdb.delete("counter")

--- a/examples/zephyr/lightdb_stream/pytest/conftest.py
+++ b/examples/zephyr/lightdb_stream/pytest/conftest.py
@@ -2,24 +2,12 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--api-key", type=str,
-                     help="Golioth API key")
-    parser.addoption("--device-name", type=str,
-                     help="Golioth device name")
     parser.addoption("--credentials-file", type=str,
                      help="YAML formatted settings file")
-
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def api_key(request):
-    if request.config.getoption("--api-key") is not None:
-        return request.config.getoption("--api-key")
-    else:
-        return os.environ['GOLIOTH_API_KEY']
 
 @pytest.fixture(scope="session")
 def credentials_file(request):
@@ -27,10 +15,3 @@ def credentials_file(request):
         return request.config.getoption("---credentials-file")
     else:
         return os.environ['GOLIOTH_CREDENTIALS_FILE']
-
-@pytest.fixture(scope="session")
-def device_name(request):
-    if request.config.getoption("--device-name") is not None:
-        return request.config.getoption("--device-name")
-    else:
-        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/lightdb_stream/pytest/test_sample.py
+++ b/examples/zephyr/lightdb_stream/pytest/test_sample.py
@@ -1,4 +1,3 @@
-from golioth import Client, LogLevel, LogEntry
 import contextlib
 import logging
 import pytest
@@ -10,15 +9,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_lightdb_stream(shell, api_key, device_name, credentials_file):
-
-    # Connect to Golioth and get device object
-
-    client = Client(api_url = "https://api.golioth.dev",
-                    api_key = api_key)
-    project = (await client.get_projects())[0]
-    device = await project.device_by_name(device_name)
-
+async def test_lightdb_stream(shell, device, credentials_file):
     # Read credentials
 
     with open(credentials_file, 'r') as f:

--- a/examples/zephyr/logging/pytest/conftest.py
+++ b/examples/zephyr/logging/pytest/conftest.py
@@ -2,24 +2,12 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--api-key", type=str,
-                     help="Golioth API key")
-    parser.addoption("--device-name", type=str,
-                     help="Golioth device name")
     parser.addoption("--credentials-file", type=str,
                      help="YAML formatted settings file")
-
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def api_key(request):
-    if request.config.getoption("--api-key") is not None:
-        return request.config.getoption("--api-key")
-    else:
-        return os.environ['GOLIOTH_API_KEY']
 
 @pytest.fixture(scope="session")
 def credentials_file(request):
@@ -27,10 +15,3 @@ def credentials_file(request):
         return request.config.getoption("---credentials-file")
     else:
         return os.environ['GOLIOTH_CREDENTIALS_FILE']
-
-@pytest.fixture(scope="session")
-def device_name(request):
-    if request.config.getoption("--device-name") is not None:
-        return request.config.getoption("--device-name")
-    else:
-        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/logging/pytest/test_sample.py
+++ b/examples/zephyr/logging/pytest/test_sample.py
@@ -1,4 +1,4 @@
-from golioth import Client, LogLevel, LogEntry
+from golioth import LogLevel, LogEntry
 import logging
 import pytest
 import time
@@ -49,15 +49,7 @@ def verify_log_messages(logs):
     assert len(expected_logs) == 0, 'Unable to find all Log messages on server'
 
 
-async def test_logging(shell, api_key, device_name, credentials_file):
-
-    # Connect to Golioth and get device object
-
-    client = Client(api_url = "https://api.golioth.dev",
-                    api_key = api_key)
-    project = (await client.get_projects())[0]
-    device = await project.device_by_name(device_name)
-
+async def test_logging(shell, device, credentials_file):
     # Read credentials
 
     with open(credentials_file, 'r') as f:

--- a/examples/zephyr/rpc/pytest/conftest.py
+++ b/examples/zephyr/rpc/pytest/conftest.py
@@ -2,24 +2,12 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--api-key", type=str,
-                     help="Golioth API key")
-    parser.addoption("--device-name", type=str,
-                     help="Golioth device name")
     parser.addoption("--credentials-file", type=str,
                      help="YAML formatted settings file")
-
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def api_key(request):
-    if request.config.getoption("--api-key") is not None:
-        return request.config.getoption("--api-key")
-    else:
-        return os.environ['GOLIOTH_API_KEY']
 
 @pytest.fixture(scope="session")
 def credentials_file(request):
@@ -27,10 +15,3 @@ def credentials_file(request):
         return request.config.getoption("---credentials-file")
     else:
         return os.environ['GOLIOTH_CREDENTIALS_FILE']
-
-@pytest.fixture(scope="session")
-def device_name(request):
-    if request.config.getoption("--device-name") is not None:
-        return request.config.getoption("--device-name")
-    else:
-        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/rpc/pytest/test_sample.py
+++ b/examples/zephyr/rpc/pytest/test_sample.py
@@ -1,4 +1,4 @@
-from golioth import Client, RPCStatusCode
+from golioth import RPCStatusCode
 import logging
 import pytest
 import time
@@ -8,15 +8,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_logging(shell, api_key, device_name, credentials_file):
-
-    # Connect to Golioth and get device object
-
-    client = Client(api_url = "https://api.golioth.dev",
-                    api_key = api_key)
-    project = (await client.get_projects())[0]
-    device = await project.device_by_name(device_name)
-
+async def test_logging(shell, device, credentials_file):
     # Read credentials
 
     with open(credentials_file, 'r') as f:

--- a/examples/zephyr/settings/pytest/conftest.py
+++ b/examples/zephyr/settings/pytest/conftest.py
@@ -2,24 +2,12 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--api-key", type=str,
-                     help="Golioth API key")
-    parser.addoption("--device-name", type=str,
-                     help="Golioth device name")
     parser.addoption("--credentials-file", type=str,
                      help="YAML formatted settings file")
-
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def api_key(request):
-    if request.config.getoption("--api-key") is not None:
-        return request.config.getoption("--api-key")
-    else:
-        return os.environ['GOLIOTH_API_KEY']
 
 @pytest.fixture(scope="session")
 def credentials_file(request):
@@ -27,10 +15,3 @@ def credentials_file(request):
         return request.config.getoption("---credentials-file")
     else:
         return os.environ['GOLIOTH_CREDENTIALS_FILE']
-
-@pytest.fixture(scope="session")
-def device_name(request):
-    if request.config.getoption("--device-name") is not None:
-        return request.config.getoption("--device-name")
-    else:
-        return os.environ['GOLIOTH_DEVICE_NAME']

--- a/examples/zephyr/settings/pytest/test_sample.py
+++ b/examples/zephyr/settings/pytest/test_sample.py
@@ -1,4 +1,3 @@
-from golioth import Client
 import logging
 import pytest
 import pprint
@@ -7,15 +6,7 @@ import yaml
 
 pytestmark = pytest.mark.anyio
 
-async def test_settings(shell, api_key, device_name, credentials_file):
-
-    # Connect to Golioth and get device object
-
-    client = Client(api_url = "https://api.golioth.dev",
-                    api_key = api_key)
-    project = (await client.get_projects())[0]
-    device = await project.device_by_name(device_name)
-
+async def test_settings(shell, project, device, credentials_file):
     # Delete any existing device-level settings
 
     settings = await device.settings.get_all()


### PR DESCRIPTION
Using the golioth pytest plugin (introduced in https://github.com/golioth/python-golioth-tools/pull/7) reduces the amount of boilerplate code that needs to be copy and pasted
between test cases.

Resolves golioth/firmware-issue-tracker#357