### PR TITLE
examples: zephyr: lightdb/set: wait for reboot before beginning test

### DIFF
--- a/examples/zephyr/lightdb/set/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/set/pytest/test_sample.py
@@ -28,6 +28,7 @@ async def test_lightdb_set(shell, device, credentials_file):
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())
+    shell._device.readlines_until(regex=".*Booting", timeout=10.0)
 
     # Wait for Golioth connection
 


### PR DESCRIPTION
Sometimes, the board manages to connect to Golioth and start setting values in ligthdb state before the reboot occurs, which can cause the test script to start waiting for input prematurely. Waiting for an explicit "Booting" message before starting the test ensures that the board is in a known state and ready to be tested.

More details about the test run that failed can be found in the ticket description.

Fixes golioth/firmware-issue-tracker#368