### PR TITLE
Remove unnecessary typedefs

### DIFF
--- a/examples/common/golioth_basics.c
+++ b/examples/common/golioth_basics.c
@@ -46,7 +46,7 @@ static golioth_settings_status_t on_loop_delay_setting(int32_t new_value, void* 
     return GOLIOTH_SETTINGS_SUCCESS;
 }
 
-static golioth_rpc_status_t on_multiply(
+static enum golioth_rpc_status on_multiply(
         zcbor_state_t* request_params_array,
         zcbor_state_t* response_detail_map,
         void* callback_arg) {

--- a/examples/common/golioth_basics.c
+++ b/examples/common/golioth_basics.c
@@ -79,7 +79,7 @@ static golioth_rpc_status_t on_multiply(
 // Callback function for asynchronous get request of LightDB path "my_int"
 static void on_get_my_int(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,
@@ -98,7 +98,7 @@ static void on_get_my_int(
 // Callback function for asynchronous observation of LightDB path "desired/my_config"
 static void on_my_config(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,

--- a/examples/common/golioth_basics.c
+++ b/examples/common/golioth_basics.c
@@ -32,7 +32,7 @@ int32_t _loop_delay_s = 10;
 // Given if/when the we have a connection to Golioth
 static golioth_sys_sem_t _connected_sem;
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         golioth_sys_sem_give(_connected_sem);
@@ -78,7 +78,7 @@ static golioth_rpc_status_t on_multiply(
 
 // Callback function for asynchronous get request of LightDB path "my_int"
 static void on_get_my_int(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -97,7 +97,7 @@ static void on_get_my_int(
 
 // Callback function for asynchronous observation of LightDB path "desired/my_config"
 static void on_my_config(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -119,7 +119,7 @@ static void on_my_config(
 }
 
 
-void golioth_basics(golioth_client_t client) {
+void golioth_basics(struct golioth_client* client) {
     // Register a callback function that will be called by the client thread when
     // connect and disconnect events happen.
     //

--- a/examples/common/golioth_basics.c
+++ b/examples/common/golioth_basics.c
@@ -40,7 +40,7 @@ static void on_client_event(struct golioth_client* client, enum golioth_client_e
     GLTH_LOGI(TAG, "Golioth client %s", is_connected ? "connected" : "disconnected");
 }
 
-static golioth_settings_status_t on_loop_delay_setting(int32_t new_value, void* arg) {
+static enum golioth_settings_status on_loop_delay_setting(int32_t new_value, void* arg) {
     GLTH_LOGI(TAG, "Setting loop delay to %" PRId32 " s", new_value);
     _loop_delay_s = new_value;
     return GOLIOTH_SETTINGS_SUCCESS;

--- a/examples/common/golioth_basics.c
+++ b/examples/common/golioth_basics.c
@@ -32,7 +32,7 @@ int32_t _loop_delay_s = 10;
 // Given if/when the we have a connection to Golioth
 static golioth_sys_sem_t _connected_sem;
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         golioth_sys_sem_give(_connected_sem);

--- a/examples/common/golioth_basics.c
+++ b/examples/common/golioth_basics.c
@@ -177,7 +177,7 @@ void golioth_basics(struct golioth_client* client) {
     // We'll check the return code to know whether a timeout happened.
     //
     // Any function provided by this SDK ending in _sync will have the same meaning.
-    golioth_status_t status = golioth_lightdb_set_string_sync(client, "my_string", "asdf", 4, 5);
+    enum golioth_status status = golioth_lightdb_set_string_sync(client, "my_string", "asdf", 4, 5);
     if (status != GOLIOTH_OK) {
         GLTH_LOGE(TAG, "Error setting string: %s", golioth_status_to_str(status));
     }

--- a/examples/common/golioth_basics.h
+++ b/examples/common/golioth_basics.h
@@ -7,4 +7,4 @@
 
 #include <golioth/client.h>
 
-void golioth_basics(golioth_client_t client);
+void golioth_basics(struct golioth_client* client);

--- a/examples/esp_idf/certificate_auth/main/app_main.c
+++ b/examples/esp_idf/certificate_auth/main/app_main.c
@@ -20,7 +20,7 @@ extern const uint8_t client_pem_end[] asm("_binary_client_crt_der_end");
 extern const uint8_t client_key_start[] asm("_binary_client_key_der_start");
 extern const uint8_t client_key_end[] asm("_binary_client_key_der_end");
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     ESP_LOGI(
             TAG,
             "Golioth client %s",

--- a/examples/esp_idf/certificate_auth/main/app_main.c
+++ b/examples/esp_idf/certificate_auth/main/app_main.c
@@ -43,7 +43,7 @@ void app_main(void) {
     size_t client_pem_len = client_pem_end - client_pem_start;
     size_t client_key_len = client_key_end - client_key_start;
 
-    golioth_client_config_t config = {
+    struct golioth_client_config config = {
             .credentials = {
                     .auth_type = GOLIOTH_TLS_AUTH_TYPE_PKI,
                     .pki = {

--- a/examples/esp_idf/certificate_auth/main/app_main.c
+++ b/examples/esp_idf/certificate_auth/main/app_main.c
@@ -20,7 +20,7 @@ extern const uint8_t client_pem_end[] asm("_binary_client_crt_der_end");
 extern const uint8_t client_key_start[] asm("_binary_client_key_der_start");
 extern const uint8_t client_key_end[] asm("_binary_client_key_der_end");
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     ESP_LOGI(
             TAG,
             "Golioth client %s",
@@ -54,7 +54,7 @@ void app_main(void) {
                             .private_key = client_key_start,
                             .private_key_len = client_key_len,
                     }}};
-    golioth_client_t client = golioth_client_create(&config);
+    struct golioth_client* client = golioth_client_create(&config);
     assert(client);
 
     // Register a callback function that will be called by the client task when

--- a/examples/esp_idf/cpp/main/app_main.cpp
+++ b/examples/esp_idf/cpp/main/app_main.cpp
@@ -41,7 +41,7 @@ extern "C" void app_main(void) {
     config.credentials.psk.psk = psk.c_str();
     config.credentials.psk.psk_len = psk.length();
 
-    golioth_client_t client = golioth_client_create(&config);
+    struct golioth_client* client = golioth_client_create(&config);
 
     int counter = 0;
     while (1) {

--- a/examples/esp_idf/cpp/main/app_main.cpp
+++ b/examples/esp_idf/cpp/main/app_main.cpp
@@ -34,7 +34,7 @@ extern "C" void app_main(void) {
     const std::string psk_id = nvs_read_golioth_psk_id();
     const std::string psk = nvs_read_golioth_psk();
 
-    golioth_client_config_t config = {};
+    struct golioth_client_config config = {};
     config.credentials.auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK;
     config.credentials.psk.psk_id = psk_id.c_str();
     config.credentials.psk.psk_id_len = psk_id.length();

--- a/examples/esp_idf/golioth_basics/main/app_main.c
+++ b/examples/esp_idf/golioth_basics/main/app_main.c
@@ -67,7 +67,7 @@ void app_main(void) {
                             .psk = psk,
                             .psk_len = strlen(psk),
                     }}};
-    golioth_client_t client = golioth_client_create(&config);
+    struct golioth_client* client = golioth_client_create(&config);
     assert(client);
 
     // golioth_basics will interact with each Golioth service and enter an endless loop.

--- a/examples/esp_idf/golioth_basics/main/app_main.c
+++ b/examples/esp_idf/golioth_basics/main/app_main.c
@@ -58,7 +58,7 @@ void app_main(void) {
     const char* psk_id = nvs_read_golioth_psk_id();
     const char* psk = nvs_read_golioth_psk();
 
-    golioth_client_config_t config = {
+    struct golioth_client_config config = {
             .credentials = {
                     .auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
                     .psk = {

--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -198,12 +198,12 @@ static bool _on_get_test_int2_called = false;
 static int32_t _test_int2_value = 0;
 static void on_get_test_int2(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,
         void* arg) {
-    golioth_response_t* arg_response = (golioth_response_t*)arg;
+    struct golioth_response* arg_response = (struct golioth_response*)arg;
     *arg_response = *response;
     _on_get_test_int2_called = true;
     _test_int2_value = golioth_payload_as_int(payload, payload_size);
@@ -212,10 +212,10 @@ static void on_get_test_int2(
 static bool _on_set_test_int2_called = false;
 static void on_set_test_int2(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         void* arg) {
-    golioth_response_t* arg_response = (golioth_response_t*)arg;
+    struct golioth_response* arg_response = (struct golioth_response*)arg;
     *arg_response = *response;
     _on_set_test_int2_called = true;
 }
@@ -223,8 +223,8 @@ static void on_set_test_int2(
 static void test_lightdb_set_get_async(void) {
     _on_set_test_int2_called = false;
     _on_get_test_int2_called = false;
-    golioth_response_t set_async_response = {};
-    golioth_response_t get_async_response = {};
+    struct golioth_response set_async_response = {};
+    struct golioth_response get_async_response = {};
 
     int randint = esp_random();
     TEST_ASSERT_EQUAL(
@@ -275,12 +275,12 @@ static void test_lightdb_set_get_async(void) {
 static bool _on_test_timeout_called = false;
 static void on_test_timeout(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,
         void* arg) {
-    golioth_response_t* arg_response = (golioth_response_t*)arg;
+    struct golioth_response* arg_response = (struct golioth_response*)arg;
     *arg_response = *response;
     _on_test_timeout_called = true;
 }
@@ -299,7 +299,7 @@ static void test_request_timeout_if_packets_dropped(void) {
             GOLIOTH_ERR_TIMEOUT, golioth_lightdb_delete_sync(_client, "expect_timeout", 1));
 
     _on_test_timeout_called = false;
-    golioth_response_t async_response = {};
+    struct golioth_response async_response = {};
     TEST_ASSERT_EQUAL(
             GOLIOTH_OK,
             golioth_lightdb_get_async(_client, "expect_timeout", GOLIOTH_CONTENT_TYPE_JSON,
@@ -379,7 +379,7 @@ static bool _on_get_test_int3_called = false;
 static int32_t _test_int3_value = 0;
 static void on_test_int3(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,

--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -98,7 +98,7 @@ static void test_golioth_client_create(void) {
         const char* psk_id = nvs_read_golioth_psk_id();
         const char* psk = nvs_read_golioth_psk();
 
-        golioth_client_config_t config = {
+        struct golioth_client_config config = {
                 .credentials = {
                         .auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
                         .psk = {

--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -78,7 +78,7 @@ static enum golioth_rpc_status on_double(
     return GOLIOTH_RPC_OK;
 }
 
-static golioth_settings_status_t on_test_setting(int32_t new_value, void* arg) {
+static enum golioth_settings_status on_test_setting(int32_t new_value, void* arg) {
     GLTH_LOGI(TAG, "Setting LightDB TEST_SETTING to %" PRId32, new_value);
     golioth_lightdb_set_int_async(_client, "TEST_SETTING", new_value, NULL, NULL);
     return GOLIOTH_SETTINGS_SUCCESS;

--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -33,7 +33,7 @@ static const char* _current_version = "1.2.3";
 
 static SemaphoreHandle_t _connected_sem;
 static SemaphoreHandle_t _disconnected_sem;
-static golioth_client_t _client;
+static struct golioth_client* _client;
 static uint32_t _initial_free_heap;
 static bool _wifi_connected;
 
@@ -43,7 +43,7 @@ static bool _wifi_connected;
 // I'm not sure exactly why this happens, but I suspect it's related to
 // Unity's UNITY_FAIL_AND_BAIL macro that gets called on failing assertions.
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     ESP_LOGI(TAG, "Golioth %s", is_connected ? "connected" : "disconnected");
     if (is_connected) {
@@ -197,7 +197,7 @@ static void test_lightdb_set_get_sync(void) {
 static bool _on_get_test_int2_called = false;
 static int32_t _test_int2_value = 0;
 static void on_get_test_int2(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -211,7 +211,7 @@ static void on_get_test_int2(
 
 static bool _on_set_test_int2_called = false;
 static void on_set_test_int2(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         void* arg) {
@@ -274,7 +274,7 @@ static void test_lightdb_set_get_async(void) {
 
 static bool _on_test_timeout_called = false;
 static void on_test_timeout(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -378,7 +378,7 @@ static void test_client_destroy(void) {
 static bool _on_get_test_int3_called = false;
 static int32_t _test_int3_value = 0;
 static void on_test_int3(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,

--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -43,7 +43,7 @@ static bool _wifi_connected;
 // I'm not sure exactly why this happens, but I suspect it's related to
 // Unity's UNITY_FAIL_AND_BAIL macro that gets called on failing assertions.
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     ESP_LOGI(TAG, "Golioth %s", is_connected ? "connected" : "disconnected");
     if (is_connected) {

--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -53,7 +53,7 @@ static void on_client_event(struct golioth_client* client, enum golioth_client_e
     }
 }
 
-static golioth_rpc_status_t on_double(
+static enum golioth_rpc_status on_double(
         zcbor_state_t* request_params_array,
         zcbor_state_t* response_detail_map,
         void* callback_arg) {

--- a/examples/linux/certificate_auth/main.c
+++ b/examples/linux/certificate_auth/main.c
@@ -39,7 +39,7 @@ int main(void) {
         return 1;
     }
 
-    golioth_client_config_t config = {
+    struct golioth_client_config config = {
             .credentials = {
                     .auth_type = GOLIOTH_TLS_AUTH_TYPE_PKI,
                     .pki = {

--- a/examples/linux/certificate_auth/main.c
+++ b/examples/linux/certificate_auth/main.c
@@ -51,7 +51,7 @@ int main(void) {
                             .private_key_len = client_key_len,
                     }}};
 
-    golioth_client_t client = golioth_client_create(&config);
+    struct golioth_client* client = golioth_client_create(&config);
     assert(client);
 
     bool connected = golioth_client_wait_for_connect(client, 1000);

--- a/examples/linux/golioth_basics/main.c
+++ b/examples/linux/golioth_basics/main.c
@@ -25,7 +25,7 @@ int main(void) {
         return 1;
     }
 
-    golioth_client_config_t config = {
+    struct golioth_client_config config = {
             .credentials = {
                     .auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
                     .psk = {

--- a/examples/linux/golioth_basics/main.c
+++ b/examples/linux/golioth_basics/main.c
@@ -35,7 +35,7 @@ int main(void) {
                             .psk_len = strlen(golioth_psk),
                     }}};
 
-    golioth_client_t client = golioth_client_create(&config);
+    struct golioth_client* client = golioth_client_create(&config);
     assert(client);
     golioth_basics(client);
 

--- a/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.c
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.c
@@ -160,7 +160,7 @@ void golioth_main_task(void* arg) {
                             .psk = psk,
                             .psk_len = strlen(psk),
                     }}};
-    golioth_client_t client = golioth_client_create(&config);
+    struct golioth_client* client = golioth_client_create(&config);
     assert(client);
 
     // golioth_basics will interact with each Golioth service and enter an endless loop.

--- a/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.c
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_main.c
@@ -151,7 +151,7 @@ void golioth_main_task(void* arg) {
     const char* psk_id = GOLIOTH_SAMPLE_PSK_ID;
     const char* psk = GOLIOTH_SAMPLE_PSK;
 
-    golioth_client_config_t config = {
+    struct golioth_client_config config = {
             .credentials = {
                     .auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
                     .psk = {

--- a/examples/zephyr/certificate_provisioning/src/main.c
+++ b/examples/zephyr/certificate_provisioning/src/main.c
@@ -31,10 +31,10 @@ static struct fs_mount_t littlefs_mnt = {
     .fs_data = &cstorage,
     .storage_dev = (void*)STORAGE_PARTITION_ID,
     .mnt_point = "/lfs1"};
-golioth_client_t client;
+struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/certificate_provisioning/src/main.c
+++ b/examples/zephyr/certificate_provisioning/src/main.c
@@ -126,7 +126,7 @@ int main(void) {
     if (tls_client_crt != NULL && tls_client_key != NULL) {
         net_connect();
 
-        golioth_client_config_t client_config = {
+        struct golioth_client_config client_config = {
             .credentials = {
                 .auth_type = GOLIOTH_TLS_AUTH_TYPE_PKI,
                 .pki = {

--- a/examples/zephyr/certificate_provisioning/src/main.c
+++ b/examples/zephyr/certificate_provisioning/src/main.c
@@ -34,7 +34,7 @@ static struct fs_mount_t littlefs_mnt = {
 struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/common/hardcoded_credentials.c
+++ b/examples/zephyr/common/hardcoded_credentials.c
@@ -23,7 +23,7 @@ static const uint8_t tls_ca_crt[] = {
 #include "golioth-systemclient-ca_crt.inc"
 };
 
-static const golioth_client_config_t _golioth_client_config_psk = {
+static const struct golioth_client_config _golioth_client_config_psk = {
         .credentials = {
                 .auth_type = GOLIOTH_TLS_AUTH_TYPE_PKI,
                 .pki = {
@@ -37,7 +37,7 @@ static const golioth_client_config_t _golioth_client_config_psk = {
 
 #else /* Using PSK Authentication */
 
-static const golioth_client_config_t _golioth_client_config_psk = {
+static const struct golioth_client_config _golioth_client_config_psk = {
         .credentials = {
                 .auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
                 .psk = {
@@ -48,6 +48,6 @@ static const golioth_client_config_t _golioth_client_config_psk = {
                 }}};
 #endif
 
-const golioth_client_config_t* golioth_sample_credentials_get(void) {
+const struct golioth_client_config* golioth_sample_credentials_get(void) {
     return &_golioth_client_config_psk;
 }

--- a/examples/zephyr/common/include/samples/common/sample_credentials.h
+++ b/examples/zephyr/common/include/samples/common/sample_credentials.h
@@ -19,7 +19,7 @@
  * The function is defined in both hardcoded_credentials.c and settings_golioth.c and will be
  * automatically added to the build based on Kconfig symbols.
  *
- * @return golioth_client_config_t configuration to use when creating a golioth_client_t
+ * @return golioth_client_config_t configuration to use when creating a struct golioth_client*
  */
 const golioth_client_config_t* golioth_sample_credentials_get(void);
 

--- a/examples/zephyr/common/include/samples/common/sample_credentials.h
+++ b/examples/zephyr/common/include/samples/common/sample_credentials.h
@@ -19,8 +19,8 @@
  * The function is defined in both hardcoded_credentials.c and settings_golioth.c and will be
  * automatically added to the build based on Kconfig symbols.
  *
- * @return golioth_client_config_t configuration to use when creating a struct golioth_client*
+ * @return struct golioth_client_config configuration to use when creating a struct golioth_client*
  */
-const golioth_client_config_t* golioth_sample_credentials_get(void);
+const struct golioth_client_config* golioth_sample_credentials_get(void);
 
 #endif /* __GOLIOTH_INCLUDE_SAMPLE_CREDENTIALS_H__ */

--- a/examples/zephyr/common/settings_golioth.c
+++ b/examples/zephyr/common/settings_golioth.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(golioth_sample_settings, CONFIG_GOLIOTH_DEBUG_DEFAULT_LOG_LE
 static uint8_t golioth_dtls_psk[CONFIG_GOLIOTH_SAMPLE_PSK_MAX_LEN + 1];
 static uint8_t golioth_dtls_psk_id[CONFIG_GOLIOTH_SAMPLE_PSK_ID_MAX_LEN + 1];
 
-static golioth_client_config_t client_config = {
+static struct golioth_client_config client_config = {
 	.credentials = {
 		.auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
 		.psk = {
@@ -109,6 +109,6 @@ SETTINGS_STATIC_HANDLER_DEFINE(golioth, "golioth",
 	IS_ENABLED(CONFIG_SETTINGS_RUNTIME) ? golioth_settings_get : NULL,
 	golioth_settings_set, NULL, NULL);
 
-const golioth_client_config_t* golioth_sample_credentials_get(void) {
+const struct golioth_client_config* golioth_sample_credentials_get(void) {
 	return &client_config;
 }

--- a/examples/zephyr/fw_update/src/main.c
+++ b/examples/zephyr/fw_update/src/main.c
@@ -20,7 +20,7 @@ static const char* _current_version = CONFIG_GOLIOTH_SAMPLE_FW_VERSION;
 
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/fw_update/src/main.c
+++ b/examples/zephyr/fw_update/src/main.c
@@ -37,7 +37,7 @@ int main(void) {
      * device. For simplicity, we provide a utility to hardcode credentials as
      * kconfig options in the samples.
      */
-    const golioth_client_config_t* client_config = golioth_sample_credentials_get();
+    const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     struct golioth_client* client = golioth_client_create(client_config);
 

--- a/examples/zephyr/fw_update/src/main.c
+++ b/examples/zephyr/fw_update/src/main.c
@@ -20,7 +20,7 @@ static const char* _current_version = CONFIG_GOLIOTH_SAMPLE_FW_VERSION;
 
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);
@@ -39,7 +39,7 @@ int main(void) {
      */
     const golioth_client_config_t* client_config = golioth_sample_credentials_get();
 
-    golioth_client_t client = golioth_client_create(client_config);
+    struct golioth_client* client = golioth_client_create(client_config);
 
     golioth_client_register_event_callback(client, on_client_event, NULL);
 

--- a/examples/zephyr/golioth_basics/main.c
+++ b/examples/zephyr/golioth_basics/main.c
@@ -24,7 +24,7 @@ int main(void) {
 
     net_connect();
 
-    golioth_client_t client = golioth_client_create(&config);
+    struct golioth_client* client = golioth_client_create(&config);
     assert(client);
     golioth_basics(client);
 

--- a/examples/zephyr/golioth_basics/main.c
+++ b/examples/zephyr/golioth_basics/main.c
@@ -12,7 +12,7 @@
 #include <samples/common/net_connect.h>
 
 int main(void) {
-    golioth_client_config_t config = {
+    struct golioth_client_config config = {
             .credentials = {
                     .auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
                     .psk = {

--- a/examples/zephyr/hello/src/main.c
+++ b/examples/zephyr/hello/src/main.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(hello_zephyr, LOG_LEVEL_DBG);
 struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/hello/src/main.c
+++ b/examples/zephyr/hello/src/main.c
@@ -36,7 +36,7 @@ int main(void) {
      * device. For simplicity, we provide a utility to hardcode credentials as
      * kconfig options in the samples.
      */
-    const golioth_client_config_t* client_config = golioth_sample_credentials_get();
+    const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     client = golioth_client_create(client_config);
 

--- a/examples/zephyr/hello/src/main.c
+++ b/examples/zephyr/hello/src/main.c
@@ -14,10 +14,10 @@ LOG_MODULE_REGISTER(hello_zephyr, LOG_LEVEL_DBG);
 
 #include <samples/common/net_connect.h>
 
-golioth_client_t client;
+struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/lightdb/delete/src/main.c
+++ b/examples/zephyr/lightdb/delete/src/main.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(lightdb_delete, LOG_LEVEL_DBG);
 struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/lightdb/delete/src/main.c
+++ b/examples/zephyr/lightdb/delete/src/main.c
@@ -30,7 +30,7 @@ static void on_client_event(struct golioth_client* client, enum golioth_client_e
 
 static void counter_handler(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         void* arg) {
     if (response->status != GOLIOTH_OK) {

--- a/examples/zephyr/lightdb/delete/src/main.c
+++ b/examples/zephyr/lightdb/delete/src/main.c
@@ -17,10 +17,10 @@ LOG_MODULE_REGISTER(lightdb_delete, LOG_LEVEL_DBG);
 
 #define APP_TIMEOUT_S 1
 
-golioth_client_t client;
+struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);
@@ -29,7 +29,7 @@ static void on_client_event(golioth_client_t client, golioth_client_event_t even
 }
 
 static void counter_handler(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         void* arg) {
@@ -43,7 +43,7 @@ static void counter_handler(
     return;
 }
 
-static void counter_delete_async(golioth_client_t* client) {
+static void counter_delete_async(struct golioth_client* client) {
     int err;
 
     err = golioth_lightdb_delete_async(client, "counter", counter_handler, NULL);
@@ -52,7 +52,7 @@ static void counter_delete_async(golioth_client_t* client) {
     }
 }
 
-static void counter_delete_sync(golioth_client_t* client) {
+static void counter_delete_sync(struct golioth_client* client) {
     int err;
 
     err = golioth_lightdb_delete_sync(client, "counter", APP_TIMEOUT_S);

--- a/examples/zephyr/lightdb/delete/src/main.c
+++ b/examples/zephyr/lightdb/delete/src/main.c
@@ -72,7 +72,7 @@ int main(void) {
      * device. For simplicity, we provide a utility to hardcode credentials as
      * kconfig options in the samples.
      */
-    const golioth_client_config_t* client_config = golioth_sample_credentials_get();
+    const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     client = golioth_client_create(client_config);
     golioth_client_register_event_callback(client, on_client_event, NULL);

--- a/examples/zephyr/lightdb/get/src/main.c
+++ b/examples/zephyr/lightdb/get/src/main.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(lightdb_get, LOG_LEVEL_DBG);
 struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/lightdb/get/src/main.c
+++ b/examples/zephyr/lightdb/get/src/main.c
@@ -20,10 +20,10 @@ LOG_MODULE_REGISTER(lightdb_get, LOG_LEVEL_DBG);
 
 #define APP_TIMEOUT_S 1
 
-golioth_client_t client;
+struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);
@@ -32,7 +32,7 @@ static void on_client_event(golioth_client_t client, golioth_client_event_t even
 }
 
 static void counter_get_handler(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -47,7 +47,7 @@ static void counter_get_handler(
     }
 }
 
-static void counter_get_async(golioth_client_t* client) {
+static void counter_get_async(struct golioth_client* client) {
     int err;
 
     err = golioth_lightdb_get_async(client, "counter", GOLIOTH_CONTENT_TYPE_JSON,
@@ -57,7 +57,7 @@ static void counter_get_async(golioth_client_t* client) {
     }
 }
 
-static void counter_get_sync(golioth_client_t* client) {
+static void counter_get_sync(struct golioth_client* client) {
     int32_t value;
     int err;
 
@@ -71,7 +71,7 @@ static void counter_get_sync(golioth_client_t* client) {
     }
 }
 
-static void counter_get_json_sync(golioth_client_t* client) {
+static void counter_get_json_sync(struct golioth_client* client) {
     uint8_t sbuf[128];
     size_t len = sizeof(sbuf);
     int err;
@@ -88,7 +88,7 @@ static void counter_get_json_sync(golioth_client_t* client) {
     }
 }
 
-static void counter_get_cbor_handler(golioth_client_t client,
+static void counter_get_cbor_handler(struct golioth_client* client,
                                      const golioth_response_t* response,
                                      const char* path,
                                      const uint8_t* payload,
@@ -114,7 +114,7 @@ static void counter_get_cbor_handler(golioth_client_t client,
     LOG_INF("Counter (CBOR async): %d", (uint32_t) counter);
 }
 
-static void counter_get_cbor_async(golioth_client_t* client)
+static void counter_get_cbor_async(struct golioth_client* client)
 {
     int err = golioth_lightdb_get_async(client,
                                         "",

--- a/examples/zephyr/lightdb/get/src/main.c
+++ b/examples/zephyr/lightdb/get/src/main.c
@@ -136,7 +136,7 @@ int main(void) {
      * device. For simplicity, we provide a utility to hardcode credentials as
      * kconfig options in the samples.
      */
-    const golioth_client_config_t* client_config = golioth_sample_credentials_get();
+    const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     client = golioth_client_create(client_config);
     golioth_client_register_event_callback(client, on_client_event, NULL);

--- a/examples/zephyr/lightdb/get/src/main.c
+++ b/examples/zephyr/lightdb/get/src/main.c
@@ -33,7 +33,7 @@ static void on_client_event(struct golioth_client* client, enum golioth_client_e
 
 static void counter_get_handler(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,
@@ -89,7 +89,7 @@ static void counter_get_json_sync(struct golioth_client* client) {
 }
 
 static void counter_get_cbor_handler(struct golioth_client* client,
-                                     const golioth_response_t* response,
+                                     const struct golioth_response* response,
                                      const char* path,
                                      const uint8_t* payload,
                                      size_t payload_size,

--- a/examples/zephyr/lightdb/observe/src/main.c
+++ b/examples/zephyr/lightdb/observe/src/main.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(lightdb_observe, LOG_LEVEL_DBG);
 struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/lightdb/observe/src/main.c
+++ b/examples/zephyr/lightdb/observe/src/main.c
@@ -30,7 +30,7 @@ static void on_client_event(struct golioth_client* client, enum golioth_client_e
 
 static void counter_observe_handler(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,

--- a/examples/zephyr/lightdb/observe/src/main.c
+++ b/examples/zephyr/lightdb/observe/src/main.c
@@ -54,7 +54,7 @@ int main(void) {
      * device. For simplicity, we provide a utility to hardcode credentials as
      * kconfig options in the samples.
      */
-    const golioth_client_config_t* client_config = golioth_sample_credentials_get();
+    const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     client = golioth_client_create(client_config);
     golioth_client_register_event_callback(client, on_client_event, NULL);

--- a/examples/zephyr/lightdb/observe/src/main.c
+++ b/examples/zephyr/lightdb/observe/src/main.c
@@ -17,10 +17,10 @@ LOG_MODULE_REGISTER(lightdb_observe, LOG_LEVEL_DBG);
 
 #define APP_TIMEOUT_S 1
 
-golioth_client_t client;
+struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);
@@ -29,7 +29,7 @@ static void on_client_event(golioth_client_t client, golioth_client_event_t even
 }
 
 static void counter_observe_handler(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,

--- a/examples/zephyr/lightdb/set/src/main.c
+++ b/examples/zephyr/lightdb/set/src/main.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(lightdb_set, LOG_LEVEL_DBG);
 struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/lightdb/set/src/main.c
+++ b/examples/zephyr/lightdb/set/src/main.c
@@ -139,7 +139,7 @@ int main(void) {
      * device. For simplicity, we provide a utility to hardcode credentials as
      * kconfig options in the samples.
      */
-    const golioth_client_config_t* client_config = golioth_sample_credentials_get();
+    const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     client = golioth_client_create(client_config);
     golioth_client_register_event_callback(client, on_client_event, NULL);

--- a/examples/zephyr/lightdb/set/src/main.c
+++ b/examples/zephyr/lightdb/set/src/main.c
@@ -18,10 +18,10 @@ LOG_MODULE_REGISTER(lightdb_set, LOG_LEVEL_DBG);
 
 #define APP_TIMEOUT_S 1
 
-golioth_client_t client;
+struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);
@@ -30,7 +30,7 @@ static void on_client_event(golioth_client_t client, golioth_client_event_t even
 }
 
 static void counter_set_handler(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         void* arg) {

--- a/examples/zephyr/lightdb/set/src/main.c
+++ b/examples/zephyr/lightdb/set/src/main.c
@@ -31,7 +31,7 @@ static void on_client_event(struct golioth_client* client, enum golioth_client_e
 
 static void counter_set_handler(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         void* arg) {
     if (response->status != GOLIOTH_OK) {

--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -144,7 +144,7 @@ int main(void) {
      * device. For simplicity, we provide a utility to hardcode credentials as
      * kconfig options in the samples.
      */
-    const golioth_client_config_t* client_config = golioth_sample_credentials_get();
+    const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     client = golioth_client_create(client_config);
     golioth_client_register_event_callback(client, on_client_event, NULL);

--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(lightdb_stream, LOG_LEVEL_DBG);
 struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -16,10 +16,10 @@ LOG_MODULE_REGISTER(lightdb_stream, LOG_LEVEL_DBG);
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
 
-golioth_client_t client;
+struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);
@@ -76,7 +76,7 @@ static int get_temperature(struct sensor_value* val) {
 #endif
 
 static void temperature_push_handler(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         void* arg) {

--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -77,7 +77,7 @@ static int get_temperature(struct sensor_value* val) {
 
 static void temperature_push_handler(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         void* arg) {
     if (response->status != GOLIOTH_OK) {

--- a/examples/zephyr/logging/src/main.c
+++ b/examples/zephyr/logging/src/main.c
@@ -47,7 +47,7 @@ int main(void) {
      * device. For simplicity, we provide a utility to hardcode credentials as
      * kconfig options in the samples.
      */
-    const golioth_client_config_t* client_config = golioth_sample_credentials_get();
+    const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     client = golioth_client_create(client_config);
 

--- a/examples/zephyr/logging/src/main.c
+++ b/examples/zephyr/logging/src/main.c
@@ -15,10 +15,10 @@ LOG_MODULE_REGISTER(golioth_logging, LOG_LEVEL_DBG);
 
 #include <samples/common/net_connect.h>
 
-golioth_client_t client;
+struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/logging/src/main.c
+++ b/examples/zephyr/logging/src/main.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(golioth_logging, LOG_LEVEL_DBG);
 struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/rpc/src/main.c
+++ b/examples/zephyr/rpc/src/main.c
@@ -45,7 +45,7 @@ static golioth_rpc_status_t on_multiply(
     return GOLIOTH_RPC_OK;
 }
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/rpc/src/main.c
+++ b/examples/zephyr/rpc/src/main.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(rpc_sample, LOG_LEVEL_DBG);
 
 static K_SEM_DEFINE(connected, 0, 1);
 
-static golioth_rpc_status_t on_multiply(
+static enum golioth_rpc_status on_multiply(
     zcbor_state_t* request_params_array,
     zcbor_state_t* response_detail_map,
     void* callback_arg) {

--- a/examples/zephyr/rpc/src/main.c
+++ b/examples/zephyr/rpc/src/main.c
@@ -62,7 +62,7 @@ int main(void) {
      * device. For simplicity, we provide a utility to hardcode credentials as
      * kconfig options in the samples.
      */
-    const golioth_client_config_t* client_config = golioth_sample_credentials_get();
+    const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     struct golioth_client* client = golioth_client_create(client_config);
 

--- a/examples/zephyr/rpc/src/main.c
+++ b/examples/zephyr/rpc/src/main.c
@@ -45,7 +45,7 @@ static golioth_rpc_status_t on_multiply(
     return GOLIOTH_RPC_OK;
 }
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);
@@ -64,7 +64,7 @@ int main(void) {
      */
     const golioth_client_config_t* client_config = golioth_sample_credentials_get();
 
-    golioth_client_t client = golioth_client_create(client_config);
+    struct golioth_client* client = golioth_client_create(client_config);
 
     golioth_client_register_event_callback(client, on_client_event, NULL);
 

--- a/examples/zephyr/settings/src/main.c
+++ b/examples/zephyr/settings/src/main.c
@@ -24,7 +24,7 @@ int32_t _loop_delay_s = 10;
 struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
-static golioth_settings_status_t on_loop_delay_setting(int32_t new_value, void* arg) {
+static enum golioth_settings_status on_loop_delay_setting(int32_t new_value, void* arg) {
     LOG_INF("Setting loop delay to %" PRId32 " s", new_value);
     _loop_delay_s = new_value;
     return GOLIOTH_SETTINGS_SUCCESS;

--- a/examples/zephyr/settings/src/main.c
+++ b/examples/zephyr/settings/src/main.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(device_settings, LOG_LEVEL_DBG);
 // Configurable via Settings service, key = "LOOP_DELAY_S"
 int32_t _loop_delay_s = 10;
 
-golioth_client_t client;
+struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
 static golioth_settings_status_t on_loop_delay_setting(int32_t new_value, void* arg) {
@@ -30,7 +30,7 @@ static golioth_settings_status_t on_loop_delay_setting(int32_t new_value, void* 
     return GOLIOTH_SETTINGS_SUCCESS;
 }
 
-static void on_client_event(golioth_client_t client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/settings/src/main.c
+++ b/examples/zephyr/settings/src/main.c
@@ -30,7 +30,7 @@ static golioth_settings_status_t on_loop_delay_setting(int32_t new_value, void* 
     return GOLIOTH_SETTINGS_SUCCESS;
 }
 
-static void on_client_event(struct golioth_client* client, golioth_client_event_t event, void* arg) {
+static void on_client_event(struct golioth_client* client, enum golioth_client_event event, void* arg) {
     bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
     if (is_connected) {
         k_sem_give(&connected);

--- a/examples/zephyr/settings/src/main.c
+++ b/examples/zephyr/settings/src/main.c
@@ -49,7 +49,7 @@ int main(void) {
      * device. For simplicity, we provide a utility to hardcode credentials as
      * kconfig options in the samples.
      */
-    const golioth_client_config_t* client_config = golioth_sample_credentials_get();
+    const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     client = golioth_client_create(client_config);
 

--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -97,18 +97,18 @@ struct golioth_pki_credential {
     size_t private_key_len;
 };
 
-/// TLS Authentication Credentials
-typedef struct {
+/// TLS Authentication Credential
+struct golioth_credential {
     enum golioth_auth_type auth_type;
     union {
         struct golioth_psk_credential psk;
         struct golioth_pki_credential pki;
     };
-} golioth_tls_credentials_t;
+};
 
 /// Golioth client configuration, passed into golioth_client_create
 typedef struct {
-    golioth_tls_credentials_t credentials;
+    struct golioth_credential credentials;
 } golioth_client_config_t;
 
 /// Callback function type for client events

--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -50,7 +50,7 @@ struct golioth_response {
     ///      GOLIOTH_ERR_TIMEOUT (no response received from server)
     ///      GOLIOTH_OK (2.XX)
     ///      GOLIOTH_ERR_FAIL (anything other than 2.XX)
-    golioth_status_t status;
+    enum golioth_status status;
     /// the 2 in 2.XX
     uint8_t status_class;
     /// the 03 in 4.03
@@ -199,7 +199,7 @@ bool golioth_client_wait_for_connect(struct golioth_client* client, int timeout_
 ///
 /// @return GOLIOTH_OK Client started
 /// @return GOLIOTH_ERR_NULL Client handle invalid
-golioth_status_t golioth_client_start(struct golioth_client* client);
+enum golioth_status golioth_client_start(struct golioth_client* client);
 
 /// Stop the Golioth client
 ///
@@ -215,7 +215,7 @@ golioth_status_t golioth_client_start(struct golioth_client* client);
 ///
 /// @return GOLIOTH_OK Client stopped
 /// @return GOLIOTH_ERR_NULL Client handle invalid
-golioth_status_t golioth_client_stop(struct golioth_client* client);
+enum golioth_status golioth_client_stop(struct golioth_client* client);
 
 /// Destroy a Golioth client
 ///

--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -79,11 +79,11 @@ struct golioth_psk_credential {
     size_t psk_len;
 };
 
-/// Public Key Infrastructure (PKI) credentials (aka "certificates").
+/// Public Key Infrastructure (PKI) credential (aka "certificate").
 ///
 /// All memory is owned by user and must persist for the lifetime
 /// of the golioth client.
-typedef struct {
+struct golioth_pki_credential {
     // DER Common CA cert
     const uint8_t* ca_cert;
     size_t ca_cert_len;
@@ -95,14 +95,14 @@ typedef struct {
     /// DER Private client key
     const uint8_t* private_key;
     size_t private_key_len;
-} golioth_pki_credentials_t;
+};
 
 /// TLS Authentication Credentials
 typedef struct {
     enum golioth_auth_type auth_type;
     union {
         struct golioth_psk_credential psk;
-        golioth_pki_credentials_t pki;
+        struct golioth_pki_credential pki;
     };
 } golioth_tls_credentials_t;
 

--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -57,13 +57,13 @@ struct golioth_response {
     uint8_t status_code;
 };
 
-/// TLS authentication type
-typedef enum {
+/// Authentication type
+enum golioth_auth_type {
     /// Authenticate with pre-shared key (psk-id and psk)
     GOLIOTH_TLS_AUTH_TYPE_PSK,
     /// Authenticate with PKI certificates (CA cert, public client cert, private client key)
     GOLIOTH_TLS_AUTH_TYPE_PKI,
-} golioth_tls_auth_type_t;
+};
 
 /// Pre-Shared Key (PSK) credentials.
 ///
@@ -99,7 +99,7 @@ typedef struct {
 
 /// TLS Authentication Credentials
 typedef struct {
-    golioth_tls_auth_type_t auth_type;
+    enum golioth_auth_type auth_type;
     union {
         golioth_psk_credentials_t psk;
         golioth_pki_credentials_t pki;

--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -43,7 +43,7 @@ enum golioth_content_type
 };
 
 /// Response status and CoAP class/code
-typedef struct {
+struct golioth_response {
     /// Status to indicate whether a response was received
     ///
     /// One of:
@@ -55,7 +55,7 @@ typedef struct {
     uint8_t status_class;
     /// the 03 in 4.03
     uint8_t status_code;
-} golioth_response_t;
+};
 
 /// TLS authentication type
 typedef enum {
@@ -135,14 +135,14 @@ typedef void (*golioth_client_event_cb_fn)(
 /// @param arg User argument, copied from the original request. Can be NULL.
 typedef void (*golioth_get_cb_fn)(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,
         void* arg);
 typedef void (*golioth_get_block_cb_fn)(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,
@@ -162,7 +162,7 @@ typedef void (*golioth_get_block_cb_fn)(
 /// @param arg User argument, copied from the original request. Can be NULL.
 typedef void (*golioth_set_cb_fn)(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         void* arg);
 

--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -107,9 +107,9 @@ struct golioth_credential {
 };
 
 /// Golioth client configuration, passed into golioth_client_create
-typedef struct {
+struct golioth_client_config {
     struct golioth_credential credentials;
-} golioth_client_config_t;
+};
 
 /// Callback function type for client events
 ///
@@ -178,7 +178,7 @@ typedef void (*golioth_set_cb_fn)(
 ///
 /// @return Non-NULL The client handle (success)
 /// @return NULL There was an error creating the client
-struct golioth_client* golioth_client_create(const golioth_client_config_t* config);
+struct golioth_client* golioth_client_create(const struct golioth_client_config* config);
 
 /// Wait (block) until connected to Golioth, or timeout occurs.
 ///

--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -65,11 +65,11 @@ enum golioth_auth_type {
     GOLIOTH_TLS_AUTH_TYPE_PKI,
 };
 
-/// Pre-Shared Key (PSK) credentials.
+/// Pre-Shared Key (PSK) credential.
 ///
 /// All memory is owned by user and must persist for the lifetime
 /// of the golioth client.
-typedef struct {
+struct golioth_psk_credential {
     /// PSK Identifier (e.g. "devicename@projectname")
     const char* psk_id;
     size_t psk_id_len;
@@ -77,7 +77,7 @@ typedef struct {
     /// Pre-shared key, secret password
     const char* psk;
     size_t psk_len;
-} golioth_psk_credentials_t;
+};
 
 /// Public Key Infrastructure (PKI) credentials (aka "certificates").
 ///
@@ -101,7 +101,7 @@ typedef struct {
 typedef struct {
     enum golioth_auth_type auth_type;
     union {
-        golioth_psk_credentials_t psk;
+        struct golioth_psk_credential psk;
         golioth_pki_credentials_t pki;
     };
 } golioth_tls_credentials_t;

--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -24,8 +24,8 @@
 /// https://docs.golioth.io/reference/protocols/device-auth
 /// @{
 
-/// @brief Opaque handle to the Golioth client
-typedef void* golioth_client_t;
+/// @brief Opaque Golioth client
+struct golioth_client;
 
 /// Golioth client events
 typedef enum {
@@ -117,7 +117,7 @@ typedef struct {
 /// @param event The event that occurred
 /// @param arg User argument, copied from @ref golioth_client_register_event_callback. Can be NULL.
 typedef void (*golioth_client_event_cb_fn)(
-        golioth_client_t client,
+        struct golioth_client* client,
         golioth_client_event_t event,
         void* arg);
 
@@ -134,14 +134,14 @@ typedef void (*golioth_client_event_cb_fn)(
 /// @param payload_size The size of payload, in bytes
 /// @param arg User argument, copied from the original request. Can be NULL.
 typedef void (*golioth_get_cb_fn)(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,
         void* arg);
 typedef void (*golioth_get_block_cb_fn)(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -161,7 +161,7 @@ typedef void (*golioth_get_block_cb_fn)(
 /// @param path The path from the original request
 /// @param arg User argument, copied from the original request. Can be NULL.
 typedef void (*golioth_set_cb_fn)(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         void* arg);
@@ -178,7 +178,7 @@ typedef void (*golioth_set_cb_fn)(
 ///
 /// @return Non-NULL The client handle (success)
 /// @return NULL There was an error creating the client
-golioth_client_t golioth_client_create(const golioth_client_config_t* config);
+struct golioth_client* golioth_client_create(const golioth_client_config_t* config);
 
 /// Wait (block) until connected to Golioth, or timeout occurs.
 ///
@@ -188,7 +188,7 @@ golioth_client_t golioth_client_create(const golioth_client_config_t* config);
 /// @param timeout_ms How long to wait, in milliseconds, or -1 to wait forever
 ///
 /// @return True, if connected, false otherwise.
-bool golioth_client_wait_for_connect(golioth_client_t client, int timeout_ms);
+bool golioth_client_wait_for_connect(struct golioth_client* client, int timeout_ms);
 
 /// Start the Golioth client
 ///
@@ -199,7 +199,7 @@ bool golioth_client_wait_for_connect(golioth_client_t client, int timeout_ms);
 ///
 /// @return GOLIOTH_OK Client started
 /// @return GOLIOTH_ERR_NULL Client handle invalid
-golioth_status_t golioth_client_start(golioth_client_t client);
+golioth_status_t golioth_client_start(struct golioth_client* client);
 
 /// Stop the Golioth client
 ///
@@ -215,14 +215,14 @@ golioth_status_t golioth_client_start(golioth_client_t client);
 ///
 /// @return GOLIOTH_OK Client stopped
 /// @return GOLIOTH_ERR_NULL Client handle invalid
-golioth_status_t golioth_client_stop(golioth_client_t client);
+golioth_status_t golioth_client_stop(struct golioth_client* client);
 
 /// Destroy a Golioth client
 ///
 /// Frees dynamically created resources from @ref golioth_client_create.
 ///
 /// @param client The handle of the client to destroy
-void golioth_client_destroy(golioth_client_t client);
+void golioth_client_destroy(struct golioth_client* client);
 
 /// Returns whether the client is currently running
 ///
@@ -230,7 +230,7 @@ void golioth_client_destroy(golioth_client_t client);
 ///
 /// @return true The client is running
 /// @return false The client is not running, or the client handle is not valid
-bool golioth_client_is_running(golioth_client_t client);
+bool golioth_client_is_running(struct golioth_client* client);
 
 /// Returns whether the client is currently connected to Golioth servers.
 ///
@@ -241,7 +241,7 @@ bool golioth_client_is_running(golioth_client_t client);
 ///
 /// @return true The client is connected to Golioth
 /// @return false The client is not connected, or the client handle is not valid
-bool golioth_client_is_connected(golioth_client_t client);
+bool golioth_client_is_connected(struct golioth_client* client);
 
 /// Register a callback that will be called on client events (e.g. connected, disconnected)
 ///
@@ -249,7 +249,7 @@ bool golioth_client_is_connected(golioth_client_t client);
 /// @param callback Callback function to register
 /// @param arg Optional argument, forwarded directly to the callback when invoked. Can be NULL.
 void golioth_client_register_event_callback(
-        golioth_client_t client,
+        struct golioth_client* client,
         golioth_client_event_cb_fn callback,
         void* arg);
 
@@ -260,7 +260,7 @@ void golioth_client_register_event_callback(
 /// @param client The client handle
 ///
 /// @return The number of items currently in the client thread request queue.
-uint32_t golioth_client_num_items_in_request_queue(golioth_client_t client);
+uint32_t golioth_client_num_items_in_request_queue(struct golioth_client* client);
 
 /// Simulate packet loss at a particular percentage (0 to 100).
 ///
@@ -275,6 +275,6 @@ void golioth_client_set_packet_loss_percent(uint8_t percent);
 /// @param client The client handle
 ///
 /// @return The thread handle of the client thread
-golioth_sys_thread_t golioth_client_get_thread(golioth_client_t client);
+golioth_sys_thread_t golioth_client_get_thread(struct golioth_client* client);
 
 /// @}

--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -28,12 +28,12 @@
 struct golioth_client;
 
 /// Golioth client events
-typedef enum {
+enum golioth_client_event {
     /// Client was previously not connected, and is now connected
     GOLIOTH_CLIENT_EVENT_CONNECTED,
     /// Client was previously connected, and is now disconnected
     GOLIOTH_CLIENT_EVENT_DISCONNECTED,
-} golioth_client_event_t;
+};
 
 /// Golioth Content Type
 enum golioth_content_type
@@ -118,7 +118,7 @@ typedef struct {
 /// @param arg User argument, copied from @ref golioth_client_register_event_callback. Can be NULL.
 typedef void (*golioth_client_event_cb_fn)(
         struct golioth_client* client,
-        golioth_client_event_t event,
+        enum golioth_client_event event,
         void* arg);
 
 /// Callback function type for all asynchronous get and observe requests

--- a/include/golioth/fw_update.h
+++ b/include/golioth/fw_update.h
@@ -41,14 +41,14 @@ typedef struct {
 /// @param client The client handle from @ref golioth_client_create
 /// @param current_version The current firmware version (e.g. "1.2.3"), shallow copy, must be
 ///     NULL-terminated
-void golioth_fw_update_init(golioth_client_t client, const char* current_version);
+void golioth_fw_update_init(struct golioth_client* client, const char* current_version);
 
 /// Same as golioth_fw_update_init, but with additional configuration specified via struct.
 ///
 /// @param client The client handle from @ref golioth_client_create
 /// @param config The configuration struct (see @ref golioth_fw_update_config_t).
 void golioth_fw_update_init_with_config(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_fw_update_config_t* config);
 
 /// Function callback type, for FW update state change listeners

--- a/include/golioth/fw_update.h
+++ b/include/golioth/fw_update.h
@@ -11,13 +11,13 @@
 
 #define GOLIOTH_FW_UPDATE_DEFAULT_PACKAGE_NAME "main"
 
-typedef struct {
+struct golioth_fw_update_config {
     /// The current firmware version, NULL-terminated, shallow-copied from user. (e.g. "1.2.3")
     const char* current_version;
     /// The name of the package in the manifest for the main firmware, NULL-terminated,
     /// shallow-copied from user (e.g. "main").
     const char* fw_package_name;
-} golioth_fw_update_config_t;
+};
 
 /// @defgroup golioth_fw_update golioth_fw_update
 /// Create a background thread that will execute Over-the-Air (OTA) updates
@@ -46,10 +46,10 @@ void golioth_fw_update_init(struct golioth_client* client, const char* current_v
 /// Same as golioth_fw_update_init, but with additional configuration specified via struct.
 ///
 /// @param client The client handle from @ref golioth_client_create
-/// @param config The configuration struct (see @ref golioth_fw_update_config_t).
+/// @param config The configuration struct (see @ref golioth_fw_update_config).
 void golioth_fw_update_init_with_config(
         struct golioth_client* client,
-        const golioth_fw_update_config_t* config);
+        const struct golioth_fw_update_config* config);
 
 /// Function callback type, for FW update state change listeners
 ///

--- a/include/golioth/fw_update.h
+++ b/include/golioth/fw_update.h
@@ -105,7 +105,7 @@ void fw_update_cancel_rollback(void);
 ///
 /// @return GOLIOTH_OK - Block handled
 /// @return Otherwise - error handling block, abort firmware update
-golioth_status_t fw_update_handle_block(
+enum golioth_status fw_update_handle_block(
         const uint8_t* block,
         size_t block_size,
         size_t offset,
@@ -123,7 +123,7 @@ golioth_status_t fw_update_handle_block(
 ///
 /// @return GOLIOTH_OK - copied bufsize bytes into buf
 /// @return Otherwise - error copying bytes, abort firmware update
-golioth_status_t fw_update_read_current_image_at_offset(
+enum golioth_status fw_update_read_current_image_at_offset(
         uint8_t* buf,
         size_t bufsize,
         size_t offset);
@@ -142,14 +142,14 @@ void fw_update_post_download(void);
 ///
 /// @return GOLIOTH_OK - image validated
 /// @return Otherwise - error in validation, abort firmware update
-golioth_status_t fw_update_validate(void);
+enum golioth_status fw_update_validate(void);
 
 /// Switch to the new boot image. This will cause the new image
 /// to be booted next time.
 ///
 /// @return GOLIOTH_OK - changed boot image
 /// @return Otherwise - Error changing boot image, abort firmware update
-golioth_status_t fw_update_change_boot_image(void);
+enum golioth_status fw_update_change_boot_image(void);
 
 /// Called when firmware update aborted
 ///

--- a/include/golioth/fw_update.h
+++ b/include/golioth/fw_update.h
@@ -57,8 +57,8 @@ void golioth_fw_update_init_with_config(
 /// @param reason The reason the state transition is happening
 /// @param user_arg Arbitraty user argument, can be NULL.
 typedef void (*golioth_fw_update_state_change_callback)(
-        golioth_ota_state_t state,
-        golioth_ota_reason_t reason,
+        enum golioth_ota_state state,
+        enum golioth_ota_reason reason,
         void* user_arg);
 
 /// Register listener for FW update state changes.

--- a/include/golioth/golioth_debug.h
+++ b/include/golioth/golioth_debug.h
@@ -23,23 +23,23 @@
 
 struct golioth_client;
 
-typedef enum {
+enum golioth_debug_log_level {
     GOLIOTH_DEBUG_LOG_LEVEL_NONE,
     GOLIOTH_DEBUG_LOG_LEVEL_ERROR,
     GOLIOTH_DEBUG_LOG_LEVEL_WARN,
     GOLIOTH_DEBUG_LOG_LEVEL_INFO,
     GOLIOTH_DEBUG_LOG_LEVEL_DEBUG,
     GOLIOTH_DEBUG_LOG_LEVEL_VERBOSE,
-} golioth_debug_log_level_t;
+};
 
-void golioth_debug_set_log_level(golioth_debug_log_level_t level);
-golioth_debug_log_level_t golioth_debug_get_log_level(void);
+void golioth_debug_set_log_level(enum golioth_debug_log_level level);
+enum golioth_debug_log_level golioth_debug_get_log_level(void);
 void golioth_debug_hexdump(const char* tag, const void* addr, int len);
 void golioth_debug_set_client(struct golioth_client* client);
 void golioth_debug_set_cloud_log_enabled(bool enable);
 void golioth_debug_printf(
         uint64_t tstamp_ms,
-        golioth_debug_log_level_t level,
+        enum golioth_debug_log_level level,
         const char* tag,
         const char* format,
         ...);

--- a/include/golioth/golioth_debug.h
+++ b/include/golioth/golioth_debug.h
@@ -21,7 +21,7 @@
 #define LOG_TAG_DEFINE(tag) static __UNUSED const char* TAG = #tag
 #endif
 
-typedef void* golioth_client_t;
+struct golioth_client;
 
 typedef enum {
     GOLIOTH_DEBUG_LOG_LEVEL_NONE,
@@ -35,7 +35,7 @@ typedef enum {
 void golioth_debug_set_log_level(golioth_debug_log_level_t level);
 golioth_debug_log_level_t golioth_debug_get_log_level(void);
 void golioth_debug_hexdump(const char* tag, const void* addr, int len);
-void golioth_debug_set_client(golioth_client_t client);
+void golioth_debug_set_client(struct golioth_client* client);
 void golioth_debug_set_cloud_log_enabled(bool enable);
 void golioth_debug_printf(
         uint64_t tstamp_ms,

--- a/include/golioth/golioth_status.h
+++ b/include/golioth/golioth_status.h
@@ -23,23 +23,23 @@
     STATUS(GOLIOTH_ERR_NO_MORE_DATA)
 
 #define GENERATE_GOLIOTH_STATUS_ENUM(code) code,
-typedef enum {
+enum golioth_status {
     FOREACH_GOLIOTH_STATUS(GENERATE_GOLIOTH_STATUS_ENUM) NUM_GOLIOTH_STATUS_CODES
-} golioth_status_t;
+};
 
 /// Convert status code to human-readable string
 ///
 /// @param status status code to convert to string
 ///
 /// @return static string representation of status code
-const char* golioth_status_to_str(golioth_status_t status);
+const char* golioth_status_to_str(enum golioth_status status);
 
-/// Helper macro, for functions that return type golioth_status_t,
+/// Helper macro, for functions that return type enum golioth_status,
 /// if they want to return early when an expression returns something
 /// other than GOLIOTH_OK.
 #define GOLIOTH_STATUS_RETURN_IF_ERROR(expr) \
     do { \
-        golioth_status_t status = (expr); \
+        enum golioth_status status = (expr); \
         if (status != GOLIOTH_OK) { \
             return status; \
         } \

--- a/include/golioth/golioth_sys.h
+++ b/include/golioth/golioth_sys.h
@@ -43,14 +43,14 @@ typedef void* golioth_sys_timer_t;
 
 typedef void (*golioth_sys_timer_fn_t)(golioth_sys_timer_t timer, void* user_arg);
 
-typedef struct {
+struct golioth_timer_config {
     const char* name;
     uint32_t expiration_ms;
     golioth_sys_timer_fn_t fn;
     void* user_arg;
-} golioth_sys_timer_config_t;
+};
 
-golioth_sys_timer_t golioth_sys_timer_create(const golioth_sys_timer_config_t *config);
+golioth_sys_timer_t golioth_sys_timer_create(const struct golioth_timer_config *config);
 bool golioth_sys_timer_start(golioth_sys_timer_t timer);
 bool golioth_sys_timer_reset(golioth_sys_timer_t timer);
 void golioth_sys_timer_destroy(golioth_sys_timer_t timer);

--- a/include/golioth/golioth_sys.h
+++ b/include/golioth/golioth_sys.h
@@ -64,15 +64,15 @@ typedef void* golioth_sys_thread_t;
 
 typedef void (*golioth_sys_thread_fn_t)(void* user_arg);
 
-typedef struct {
+struct golioth_thread_config {
     const char* name;
     golioth_sys_thread_fn_t fn;
     void* user_arg;
     int32_t stack_size;  // in bytes
     int32_t prio;        // large numbers == high priority
-} golioth_sys_thread_config_t;
+};
 
-golioth_sys_thread_t golioth_sys_thread_create(const golioth_sys_thread_config_t *config);
+golioth_sys_thread_t golioth_sys_thread_create(const struct golioth_thread_config *config);
 void golioth_sys_thread_destroy(golioth_sys_thread_t thread);
 
 /*--------------------------------------------------

--- a/include/golioth/lightdb_state.h
+++ b/include/golioth/lightdb_state.h
@@ -38,7 +38,7 @@
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 golioth_status_t golioth_lightdb_set_int_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t value,
         golioth_set_cb_fn callback,
@@ -64,7 +64,7 @@ golioth_status_t golioth_lightdb_set_int_async(
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
 golioth_status_t golioth_lightdb_set_int_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t value,
         int32_t timeout_s);
@@ -73,7 +73,7 @@ golioth_status_t golioth_lightdb_set_int_sync(
 ///
 /// Same as @ref golioth_lightdb_set_int_async, but for type bool
 golioth_status_t golioth_lightdb_set_bool_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         bool value,
         golioth_set_cb_fn callback,
@@ -83,7 +83,7 @@ golioth_status_t golioth_lightdb_set_bool_async(
 ///
 /// Same as @ref golioth_lightdb_set_int_sync, but for type bool
 golioth_status_t golioth_lightdb_set_bool_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         bool value,
         int32_t timeout_s);
@@ -92,14 +92,14 @@ golioth_status_t golioth_lightdb_set_bool_sync(
 ///
 /// Same as @ref golioth_lightdb_set_int_async, but for type float
 golioth_status_t golioth_lightdb_set_float_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         float value,
         golioth_set_cb_fn callback,
         void* callback_arg);
 
 golioth_status_t golioth_lightdb_set_float_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         float value,
         int32_t timeout_s);
@@ -108,7 +108,7 @@ golioth_status_t golioth_lightdb_set_float_sync(
 ///
 /// Same as @ref golioth_lightdb_set_int_async, but for type string
 golioth_status_t golioth_lightdb_set_string_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* str,
         size_t str_len,
@@ -116,7 +116,7 @@ golioth_status_t golioth_lightdb_set_string_async(
         void* callback_arg);
 
 golioth_status_t golioth_lightdb_set_string_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* str,
         size_t str_len,
@@ -143,7 +143,7 @@ golioth_status_t golioth_lightdb_set_string_sync(
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 golioth_status_t golioth_lightdb_set_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
         const uint8_t* buf,
@@ -165,7 +165,7 @@ golioth_status_t golioth_lightdb_set_async(
 /// @param buf_len Length of buf
 /// @param timeout_s The timeout, in seconds, for receiving a server response
 golioth_status_t golioth_lightdb_set_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
         const uint8_t* buf,
@@ -189,7 +189,7 @@ golioth_status_t golioth_lightdb_set_sync(
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
 golioth_status_t golioth_lightdb_get_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
         golioth_get_cb_fn callback,
@@ -214,28 +214,28 @@ golioth_status_t golioth_lightdb_get_async(
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
 golioth_status_t golioth_lightdb_get_int_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t* value,
         int32_t timeout_s);
 
 /// Similar to @ref golioth_lightdb_get_int_sync, but for type bool
 golioth_status_t golioth_lightdb_get_bool_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         bool* value,
         int32_t timeout_s);
 
 /// Similar to @ref golioth_lightdb_get_int_sync, but for type float
 golioth_status_t golioth_lightdb_get_float_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         float* value,
         int32_t timeout_s);
 
 /// Similar to @ref golioth_lightdb_get_int_sync, but for type string
 golioth_status_t golioth_lightdb_get_string_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         char* strbuf,
         size_t strbuf_size,
@@ -243,7 +243,7 @@ golioth_status_t golioth_lightdb_get_string_sync(
 
 /// Similar to @ref golioth_lightdb_get_int_sync, but for objects
 golioth_status_t golioth_lightdb_get_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
         uint8_t* buf,
@@ -269,7 +269,7 @@ golioth_status_t golioth_lightdb_get_sync(
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 golioth_status_t golioth_lightdb_delete_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         golioth_set_cb_fn callback,
         void* callback_arg);
@@ -292,7 +292,7 @@ golioth_status_t golioth_lightdb_delete_async(
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
 golioth_status_t golioth_lightdb_delete_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t timeout_s);
 
@@ -321,7 +321,7 @@ golioth_status_t golioth_lightdb_delete_sync(
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 golioth_status_t golioth_lightdb_observe_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         golioth_get_cb_fn callback,
         void* callback_arg);

--- a/include/golioth/lightdb_state.h
+++ b/include/golioth/lightdb_state.h
@@ -37,7 +37,7 @@
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-golioth_status_t golioth_lightdb_set_int_async(
+enum golioth_status golioth_lightdb_set_int_async(
         struct golioth_client* client,
         const char* path,
         int32_t value,
@@ -63,7 +63,7 @@ golioth_status_t golioth_lightdb_set_int_async(
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
-golioth_status_t golioth_lightdb_set_int_sync(
+enum golioth_status golioth_lightdb_set_int_sync(
         struct golioth_client* client,
         const char* path,
         int32_t value,
@@ -72,7 +72,7 @@ golioth_status_t golioth_lightdb_set_int_sync(
 /// Set a bool in LightDB state at a particular path asynchronously
 ///
 /// Same as @ref golioth_lightdb_set_int_async, but for type bool
-golioth_status_t golioth_lightdb_set_bool_async(
+enum golioth_status golioth_lightdb_set_bool_async(
         struct golioth_client* client,
         const char* path,
         bool value,
@@ -82,7 +82,7 @@ golioth_status_t golioth_lightdb_set_bool_async(
 /// Set a bool in LightDB state at a particular path synchronously
 ///
 /// Same as @ref golioth_lightdb_set_int_sync, but for type bool
-golioth_status_t golioth_lightdb_set_bool_sync(
+enum golioth_status golioth_lightdb_set_bool_sync(
         struct golioth_client* client,
         const char* path,
         bool value,
@@ -91,14 +91,14 @@ golioth_status_t golioth_lightdb_set_bool_sync(
 /// Set a float in LightDB state at a particular path asynchronously
 ///
 /// Same as @ref golioth_lightdb_set_int_async, but for type float
-golioth_status_t golioth_lightdb_set_float_async(
+enum golioth_status golioth_lightdb_set_float_async(
         struct golioth_client* client,
         const char* path,
         float value,
         golioth_set_cb_fn callback,
         void* callback_arg);
 
-golioth_status_t golioth_lightdb_set_float_sync(
+enum golioth_status golioth_lightdb_set_float_sync(
         struct golioth_client* client,
         const char* path,
         float value,
@@ -107,7 +107,7 @@ golioth_status_t golioth_lightdb_set_float_sync(
 /// Set a string in LightDB state at a particular path asynchronously
 ///
 /// Same as @ref golioth_lightdb_set_int_async, but for type string
-golioth_status_t golioth_lightdb_set_string_async(
+enum golioth_status golioth_lightdb_set_string_async(
         struct golioth_client* client,
         const char* path,
         const char* str,
@@ -115,7 +115,7 @@ golioth_status_t golioth_lightdb_set_string_async(
         golioth_set_cb_fn callback,
         void* callback_arg);
 
-golioth_status_t golioth_lightdb_set_string_sync(
+enum golioth_status golioth_lightdb_set_string_sync(
         struct golioth_client* client,
         const char* path,
         const char* str,
@@ -142,7 +142,7 @@ golioth_status_t golioth_lightdb_set_string_sync(
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-golioth_status_t golioth_lightdb_set_async(
+enum golioth_status golioth_lightdb_set_async(
         struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
@@ -164,7 +164,7 @@ golioth_status_t golioth_lightdb_set_async(
 /// @param buf A buffer containing the object to send
 /// @param buf_len Length of buf
 /// @param timeout_s The timeout, in seconds, for receiving a server response
-golioth_status_t golioth_lightdb_set_sync(
+enum golioth_status golioth_lightdb_set_sync(
         struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
@@ -188,7 +188,7 @@ golioth_status_t golioth_lightdb_set_sync(
 /// @param content_type The serialization format to request for the path
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
-golioth_status_t golioth_lightdb_get_async(
+enum golioth_status golioth_lightdb_get_async(
         struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
@@ -213,28 +213,28 @@ golioth_status_t golioth_lightdb_get_async(
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
-golioth_status_t golioth_lightdb_get_int_sync(
+enum golioth_status golioth_lightdb_get_int_sync(
         struct golioth_client* client,
         const char* path,
         int32_t* value,
         int32_t timeout_s);
 
 /// Similar to @ref golioth_lightdb_get_int_sync, but for type bool
-golioth_status_t golioth_lightdb_get_bool_sync(
+enum golioth_status golioth_lightdb_get_bool_sync(
         struct golioth_client* client,
         const char* path,
         bool* value,
         int32_t timeout_s);
 
 /// Similar to @ref golioth_lightdb_get_int_sync, but for type float
-golioth_status_t golioth_lightdb_get_float_sync(
+enum golioth_status golioth_lightdb_get_float_sync(
         struct golioth_client* client,
         const char* path,
         float* value,
         int32_t timeout_s);
 
 /// Similar to @ref golioth_lightdb_get_int_sync, but for type string
-golioth_status_t golioth_lightdb_get_string_sync(
+enum golioth_status golioth_lightdb_get_string_sync(
         struct golioth_client* client,
         const char* path,
         char* strbuf,
@@ -242,7 +242,7 @@ golioth_status_t golioth_lightdb_get_string_sync(
         int32_t timeout_s);
 
 /// Similar to @ref golioth_lightdb_get_int_sync, but for objects
-golioth_status_t golioth_lightdb_get_sync(
+enum golioth_status golioth_lightdb_get_sync(
         struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
@@ -268,7 +268,7 @@ golioth_status_t golioth_lightdb_get_sync(
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-golioth_status_t golioth_lightdb_delete_async(
+enum golioth_status golioth_lightdb_delete_async(
         struct golioth_client* client,
         const char* path,
         golioth_set_cb_fn callback,
@@ -291,7 +291,7 @@ golioth_status_t golioth_lightdb_delete_async(
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
-golioth_status_t golioth_lightdb_delete_sync(
+enum golioth_status golioth_lightdb_delete_sync(
         struct golioth_client* client,
         const char* path,
         int32_t timeout_s);
@@ -320,7 +320,7 @@ golioth_status_t golioth_lightdb_delete_sync(
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-golioth_status_t golioth_lightdb_observe_async(
+enum golioth_status golioth_lightdb_observe_async(
         struct golioth_client* client,
         const char* path,
         golioth_get_cb_fn callback,

--- a/include/golioth/lightdb_stream.h
+++ b/include/golioth/lightdb_stream.h
@@ -34,7 +34,7 @@
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 golioth_status_t golioth_lightdb_stream_set_int_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t value,
         golioth_set_cb_fn callback,
@@ -60,7 +60,7 @@ golioth_status_t golioth_lightdb_stream_set_int_async(
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
 golioth_status_t golioth_lightdb_stream_set_int_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t value,
         int32_t timeout_s);
@@ -69,7 +69,7 @@ golioth_status_t golioth_lightdb_stream_set_int_sync(
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_async, but for type bool
 golioth_status_t golioth_lightdb_stream_set_bool_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         bool value,
         golioth_set_cb_fn callback,
@@ -79,7 +79,7 @@ golioth_status_t golioth_lightdb_stream_set_bool_async(
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_sync, but for type bool
 golioth_status_t golioth_lightdb_stream_set_bool_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         bool value,
         int32_t timeout_s);
@@ -88,7 +88,7 @@ golioth_status_t golioth_lightdb_stream_set_bool_sync(
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_async, but for type float
 golioth_status_t golioth_lightdb_stream_set_float_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         float value,
         golioth_set_cb_fn callback,
@@ -98,7 +98,7 @@ golioth_status_t golioth_lightdb_stream_set_float_async(
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_sync, but for type float
 golioth_status_t golioth_lightdb_stream_set_float_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         float value,
         int32_t timeout_s);
@@ -107,7 +107,7 @@ golioth_status_t golioth_lightdb_stream_set_float_sync(
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_async, but for type string
 golioth_status_t golioth_lightdb_stream_set_string_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* str,
         size_t str_len,
@@ -118,7 +118,7 @@ golioth_status_t golioth_lightdb_stream_set_string_async(
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_sync, but for type string
 golioth_status_t golioth_lightdb_stream_set_string_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* str,
         size_t str_len,
@@ -141,7 +141,7 @@ golioth_status_t golioth_lightdb_stream_set_string_sync(
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 golioth_status_t golioth_lightdb_stream_set_json_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* json_str,
         size_t json_str_len,
@@ -158,7 +158,7 @@ golioth_status_t golioth_lightdb_stream_set_json_async(
 /// @param json_str_len Length of json_str, not including NULL terminator
 /// @param timeout_s The timeout, in seconds, for receiving a server response
 golioth_status_t golioth_lightdb_stream_set_json_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* json_str,
         size_t json_str_len,
@@ -166,7 +166,7 @@ golioth_status_t golioth_lightdb_stream_set_json_sync(
 
 /// Similar to @ref golioth_lightdb_stream_set_json_async, but for CBOR
 golioth_status_t golioth_lightdb_stream_set_cbor_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const uint8_t* cbor_data,
         size_t cbor_data_len,
@@ -175,7 +175,7 @@ golioth_status_t golioth_lightdb_stream_set_cbor_async(
 
 /// Similar to @ref golioth_lightdb_stream_set_json_sync, but for CBOR
 golioth_status_t golioth_lightdb_stream_set_cbor_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const uint8_t* cbor_data,
         size_t cbor_data_len,

--- a/include/golioth/lightdb_stream.h
+++ b/include/golioth/lightdb_stream.h
@@ -33,7 +33,7 @@
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-golioth_status_t golioth_lightdb_stream_set_int_async(
+enum golioth_status golioth_lightdb_stream_set_int_async(
         struct golioth_client* client,
         const char* path,
         int32_t value,
@@ -59,7 +59,7 @@ golioth_status_t golioth_lightdb_stream_set_int_async(
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
-golioth_status_t golioth_lightdb_stream_set_int_sync(
+enum golioth_status golioth_lightdb_stream_set_int_sync(
         struct golioth_client* client,
         const char* path,
         int32_t value,
@@ -68,7 +68,7 @@ golioth_status_t golioth_lightdb_stream_set_int_sync(
 /// Set a bool in LightDB stream at a particular path asynchronously
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_async, but for type bool
-golioth_status_t golioth_lightdb_stream_set_bool_async(
+enum golioth_status golioth_lightdb_stream_set_bool_async(
         struct golioth_client* client,
         const char* path,
         bool value,
@@ -78,7 +78,7 @@ golioth_status_t golioth_lightdb_stream_set_bool_async(
 /// Set a bool in LightDB state at a particular path synchronously
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_sync, but for type bool
-golioth_status_t golioth_lightdb_stream_set_bool_sync(
+enum golioth_status golioth_lightdb_stream_set_bool_sync(
         struct golioth_client* client,
         const char* path,
         bool value,
@@ -87,7 +87,7 @@ golioth_status_t golioth_lightdb_stream_set_bool_sync(
 /// Set a float in LightDB strean at a particular path asynchronously
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_async, but for type float
-golioth_status_t golioth_lightdb_stream_set_float_async(
+enum golioth_status golioth_lightdb_stream_set_float_async(
         struct golioth_client* client,
         const char* path,
         float value,
@@ -97,7 +97,7 @@ golioth_status_t golioth_lightdb_stream_set_float_async(
 /// Set a float in LightDB strean at a particular path synchronously
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_sync, but for type float
-golioth_status_t golioth_lightdb_stream_set_float_sync(
+enum golioth_status golioth_lightdb_stream_set_float_sync(
         struct golioth_client* client,
         const char* path,
         float value,
@@ -106,7 +106,7 @@ golioth_status_t golioth_lightdb_stream_set_float_sync(
 /// Set a string in LightDB stream at a particular path asynchronously
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_async, but for type string
-golioth_status_t golioth_lightdb_stream_set_string_async(
+enum golioth_status golioth_lightdb_stream_set_string_async(
         struct golioth_client* client,
         const char* path,
         const char* str,
@@ -117,7 +117,7 @@ golioth_status_t golioth_lightdb_stream_set_string_async(
 /// Set a string in LightDB stream at a particular path synchronously
 ///
 /// Same as @ref golioth_lightdb_stream_set_int_sync, but for type string
-golioth_status_t golioth_lightdb_stream_set_string_sync(
+enum golioth_status golioth_lightdb_stream_set_string_sync(
         struct golioth_client* client,
         const char* path,
         const char* str,
@@ -140,7 +140,7 @@ golioth_status_t golioth_lightdb_stream_set_string_sync(
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-golioth_status_t golioth_lightdb_stream_set_json_async(
+enum golioth_status golioth_lightdb_stream_set_json_async(
         struct golioth_client* client,
         const char* path,
         const char* json_str,
@@ -157,7 +157,7 @@ golioth_status_t golioth_lightdb_stream_set_json_async(
 /// @param json_str A JSON object encoded as a string (e.g. "{ \"string_key\": \"value\"}")
 /// @param json_str_len Length of json_str, not including NULL terminator
 /// @param timeout_s The timeout, in seconds, for receiving a server response
-golioth_status_t golioth_lightdb_stream_set_json_sync(
+enum golioth_status golioth_lightdb_stream_set_json_sync(
         struct golioth_client* client,
         const char* path,
         const char* json_str,
@@ -165,7 +165,7 @@ golioth_status_t golioth_lightdb_stream_set_json_sync(
         int32_t timeout_s);
 
 /// Similar to @ref golioth_lightdb_stream_set_json_async, but for CBOR
-golioth_status_t golioth_lightdb_stream_set_cbor_async(
+enum golioth_status golioth_lightdb_stream_set_cbor_async(
         struct golioth_client* client,
         const char* path,
         const uint8_t* cbor_data,
@@ -174,7 +174,7 @@ golioth_status_t golioth_lightdb_stream_set_cbor_async(
         void* callback_arg);
 
 /// Similar to @ref golioth_lightdb_stream_set_json_sync, but for CBOR
-golioth_status_t golioth_lightdb_stream_set_cbor_sync(
+enum golioth_status golioth_lightdb_stream_set_cbor_sync(
         struct golioth_client* client,
         const char* path,
         const uint8_t* cbor_data,

--- a/include/golioth/log.h
+++ b/include/golioth/log.h
@@ -25,7 +25,7 @@
 /// @param log_message String to log. Must be NULL-terminated.
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
-golioth_status_t golioth_log_error_async(
+enum golioth_status golioth_log_error_async(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -33,7 +33,7 @@ golioth_status_t golioth_log_error_async(
         void* callback_arg);
 
 /// Same as @ref golioth_log_error_async, but for warning level
-golioth_status_t golioth_log_warn_async(
+enum golioth_status golioth_log_warn_async(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -41,7 +41,7 @@ golioth_status_t golioth_log_warn_async(
         void* callback_arg);
 
 /// Same as @ref golioth_log_error_async, but for info level
-golioth_status_t golioth_log_info_async(
+enum golioth_status golioth_log_info_async(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -49,7 +49,7 @@ golioth_status_t golioth_log_info_async(
         void* callback_arg);
 
 /// Same as @ref golioth_log_error_async, but for debug level
-golioth_status_t golioth_log_debug_async(
+enum golioth_status golioth_log_debug_async(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -68,28 +68,28 @@ golioth_status_t golioth_log_debug_async(
 /// @param tag A free-form string to identify/tag the message
 /// @param log_message String to log. Must be NULL-terminated.
 /// @param timeout_s The timeout, in seconds, for receiving a server response
-golioth_status_t golioth_log_error_sync(
+enum golioth_status golioth_log_error_sync(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s);
 
 /// Same as @ref golioth_log_error_sync, but for warning level
-golioth_status_t golioth_log_warn_sync(
+enum golioth_status golioth_log_warn_sync(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s);
 
 /// Same as @ref golioth_log_error_sync, but for info level
-golioth_status_t golioth_log_info_sync(
+enum golioth_status golioth_log_info_sync(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s);
 
 /// Same as @ref golioth_log_error_sync, but for debug level
-golioth_status_t golioth_log_debug_sync(
+enum golioth_status golioth_log_debug_sync(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,

--- a/include/golioth/log.h
+++ b/include/golioth/log.h
@@ -26,7 +26,7 @@
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
 golioth_status_t golioth_log_error_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         golioth_set_cb_fn callback,
@@ -34,7 +34,7 @@ golioth_status_t golioth_log_error_async(
 
 /// Same as @ref golioth_log_error_async, but for warning level
 golioth_status_t golioth_log_warn_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         golioth_set_cb_fn callback,
@@ -42,7 +42,7 @@ golioth_status_t golioth_log_warn_async(
 
 /// Same as @ref golioth_log_error_async, but for info level
 golioth_status_t golioth_log_info_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         golioth_set_cb_fn callback,
@@ -50,7 +50,7 @@ golioth_status_t golioth_log_info_async(
 
 /// Same as @ref golioth_log_error_async, but for debug level
 golioth_status_t golioth_log_debug_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         golioth_set_cb_fn callback,
@@ -69,28 +69,28 @@ golioth_status_t golioth_log_debug_async(
 /// @param log_message String to log. Must be NULL-terminated.
 /// @param timeout_s The timeout, in seconds, for receiving a server response
 golioth_status_t golioth_log_error_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s);
 
 /// Same as @ref golioth_log_error_sync, but for warning level
 golioth_status_t golioth_log_warn_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s);
 
 /// Same as @ref golioth_log_error_sync, but for info level
 golioth_status_t golioth_log_info_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s);
 
 /// Same as @ref golioth_log_error_sync, but for debug level
 golioth_status_t golioth_log_debug_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s);

--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -110,7 +110,7 @@ const golioth_ota_component_t* golioth_ota_find_component(
 /// waiting for a response from the server. The callback will be invoked whenever
 /// the manifest is changed on the Golioth server.
 golioth_status_t golioth_ota_observe_manifest_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         golioth_get_cb_fn callback,
         void* arg);
 
@@ -143,7 +143,7 @@ golioth_status_t golioth_ota_observe_manifest_async(
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
 golioth_status_t golioth_ota_get_block_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* package,
         const char* version,
         size_t block_index,
@@ -168,7 +168,7 @@ golioth_status_t golioth_ota_get_block_sync(
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
 golioth_status_t golioth_ota_report_state_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         golioth_ota_state_t state,
         golioth_ota_reason_t reason,
         const char* package,

--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -85,7 +85,7 @@ typedef struct {
 ///
 /// @return GOLIOTH_OK - payload converted to golioth_ota_manifest_t
 /// @return GOLIOTH_ERR_INVALID_FORMAT - failed to parse manifest
-golioth_status_t golioth_ota_payload_as_manifest(
+enum golioth_status golioth_ota_payload_as_manifest(
         const uint8_t* payload,
         size_t payload_size,
         golioth_ota_manifest_t* manifest);
@@ -109,7 +109,7 @@ const golioth_ota_component_t* golioth_ota_find_component(
 /// This function will enqueue a request and return immediately without
 /// waiting for a response from the server. The callback will be invoked whenever
 /// the manifest is changed on the Golioth server.
-golioth_status_t golioth_ota_observe_manifest_async(
+enum golioth_status golioth_ota_observe_manifest_async(
         struct golioth_client* client,
         golioth_get_cb_fn callback,
         void* arg);
@@ -142,7 +142,7 @@ golioth_status_t golioth_ota_observe_manifest_async(
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
-golioth_status_t golioth_ota_get_block_sync(
+enum golioth_status golioth_ota_get_block_sync(
         struct golioth_client* client,
         const char* package,
         const char* version,
@@ -167,7 +167,7 @@ golioth_status_t golioth_ota_get_block_sync(
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
-golioth_status_t golioth_ota_report_state_sync(
+enum golioth_status golioth_ota_report_state_sync(
         struct golioth_client* client,
         golioth_ota_state_t state,
         golioth_ota_reason_t reason,

--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -20,7 +20,7 @@
 #define GOLIOTH_OTA_BLOCKSIZE 1024
 
 /// State of OTA update, reported to Golioth server
-typedef enum {
+enum golioth_ota_state {
     /// No OTA update in progress
     GOLIOTH_OTA_STATE_IDLE,
     /// OTA is being downloaded and written to flash
@@ -29,10 +29,10 @@ typedef enum {
     GOLIOTH_OTA_STATE_DOWNLOADED,
     /// OTA is being applied to the system, but is not yet complete
     GOLIOTH_OTA_STATE_UPDATING,
-} golioth_ota_state_t;
+};
 
 /// A reason associated with state changes
-typedef enum {
+enum golioth_ota_reason {
     /// OTA update is ready to go. Also used for "no reason".
     GOLIOTH_OTA_REASON_READY,
     /// Firmware update was successful
@@ -53,10 +53,10 @@ typedef enum {
     GOLIOTH_OTA_REASON_FIRMWARE_UPDATE_FAILED,
     /// Protocol not supported
     GOLIOTH_OTA_REASON_UNSUPPORTED_PROTOCOL,
-} golioth_ota_reason_t;
+};
 
 /// A component/artifact within an OTA manifest
-typedef struct {
+struct golioth_ota_component {
     /// Artifact package name (e.g. "main")
     char package[CONFIG_GOLIOTH_OTA_MAX_PACKAGE_NAME_LEN + 1];
     /// Artifact version (e.g. "1.0.0")
@@ -65,30 +65,30 @@ typedef struct {
     int32_t size;
     /// True, if the component is compressed and requires decompression
     bool is_compressed;
-} golioth_ota_component_t;
+};
 
 /// An OTA manifest, composed of multiple components/artifacts
-typedef struct {
+struct golioth_ota_manifest {
     /// OTA release sequence number
     int32_t seqnum;
     /// An array of artifacts
-    golioth_ota_component_t components[CONFIG_GOLIOTH_OTA_MAX_NUM_COMPONENTS];
+    struct golioth_ota_component components[CONFIG_GOLIOTH_OTA_MAX_NUM_COMPONENTS];
     /// Number of artifacts
     size_t num_components;
-} golioth_ota_manifest_t;
+};
 
-/// Convert raw byte payload into a @ref golioth_ota_manifest_t
+/// Convert raw byte payload into a @ref golioth_ota_manifest
 ///
 /// @param payload Pointer to payload data
 /// @param payload_size Size of payload, in bytes
 /// @param manifest Output param, memory allocated by caller, populated with manifest
 ///
-/// @return GOLIOTH_OK - payload converted to golioth_ota_manifest_t
+/// @return GOLIOTH_OK - payload converted to struct golioth_ota_manifest
 /// @return GOLIOTH_ERR_INVALID_FORMAT - failed to parse manifest
 enum golioth_status golioth_ota_payload_as_manifest(
         const uint8_t* payload,
         size_t payload_size,
-        golioth_ota_manifest_t* manifest);
+        struct golioth_ota_manifest* manifest);
 
 /// Convert a size in bytes to the number of blocks required (of size up to GOLIOTH_OTA_BLOCKSIZE)
 size_t golioth_ota_size_to_nblocks(size_t component_size);
@@ -100,8 +100,8 @@ size_t golioth_ota_size_to_nblocks(size_t component_size);
 ///
 /// @return if found - pointer to component
 /// @return if not found - NULL
-const golioth_ota_component_t* golioth_ota_find_component(
-        const golioth_ota_manifest_t* manifest,
+const struct golioth_ota_component* golioth_ota_find_component(
+        const struct golioth_ota_manifest* manifest,
         const char* package);
 
 /// Observe for the OTA manifest asynchronously
@@ -169,8 +169,8 @@ enum golioth_status golioth_ota_get_block_sync(
 /// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
 enum golioth_status golioth_ota_report_state_sync(
         struct golioth_client* client,
-        golioth_ota_state_t state,
-        golioth_ota_reason_t reason,
+        enum golioth_ota_state state,
+        enum golioth_ota_reason reason,
         const char* package,
         const char* current_version,
         const char* target_version,
@@ -179,6 +179,6 @@ enum golioth_status golioth_ota_report_state_sync(
 /// Get the current state of OTA update
 ///
 /// @return The current OTA update state
-golioth_ota_state_t golioth_ota_get_state(void);
+enum golioth_ota_state golioth_ota_get_state(void);
 
 /// @}

--- a/include/golioth/rpc.h
+++ b/include/golioth/rpc.h
@@ -92,7 +92,7 @@ typedef golioth_rpc_status_t (*golioth_rpc_cb_fn)(
 ///
 /// @return GOLIOTH_OK - RPC method successfully registered
 /// @return otherwise - Error registering RPC method
-golioth_status_t golioth_rpc_register(
+enum golioth_status golioth_rpc_register(
         struct golioth_client* client,
         const char* method,
         golioth_rpc_cb_fn callback,

--- a/include/golioth/rpc.h
+++ b/include/golioth/rpc.h
@@ -16,7 +16,7 @@
 /// @{
 
 /// Enumeration of RPC status codes, sent in the RPC response
-typedef enum {
+enum golioth_rpc_status {
     GOLIOTH_RPC_OK = 0,
     GOLIOTH_RPC_CANCELED = 1,
     GOLIOTH_RPC_UNKNOWN = 2,
@@ -34,7 +34,7 @@ typedef enum {
     GOLIOTH_RPC_UNAVAILABLE = 14,
     GOLIOTH_RPC_DATA_LOSS = 15,
     GOLIOTH_RPC_UNAUTHENTICATED = 16,
-} golioth_rpc_status_t;
+};
 
 /// Callback function type for remote procedure call
 ///
@@ -42,7 +42,7 @@ typedef enum {
 /// takes two float parameters, and multiplies them:
 ///
 /// @code{.c}
-/// static golioth_rpc_status_t on_multiply(zcbor_state_t *request_params_array,
+/// static enum golioth_rpc_status on_multiply(zcbor_state_t *request_params_array,
 ///                                         zcbor_state_t *response_detail_map,
 ///                                         void *callback_arg)
 /// {
@@ -77,7 +77,7 @@ typedef enum {
 /// @return GOLIOTH_RPC_OK - if method was called successfully
 /// @return GOLIOTH_RPC_INVALID_ARGUMENT - if params were invalid
 /// @return otherwise - method failure
-typedef golioth_rpc_status_t (*golioth_rpc_cb_fn)(
+typedef enum golioth_rpc_status (*golioth_rpc_cb_fn)(
         zcbor_state_t* request_params_array,
         zcbor_state_t* response_detail_map,
         void* callback_arg);
@@ -99,17 +99,17 @@ enum golioth_status golioth_rpc_register(
         void* callback_arg);
 
 /// Private struct to contain data about a single registered method
-typedef struct {
+struct golioth_rpc_method {
     const char* method;
     golioth_rpc_cb_fn callback;
     void* callback_arg;
-} golioth_rpc_method_t;
+};
 
 /// Private struct to contain RPC state data, stored in
 /// the golioth_coap_client_t struct.
-typedef struct {
-    golioth_rpc_method_t rpcs[CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS];
+struct golioth_rpc {
+    struct golioth_rpc_method rpcs[CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS];
     int num_rpcs;
-} golioth_rpc_t;
+};
 
 /// @}

--- a/include/golioth/rpc.h
+++ b/include/golioth/rpc.h
@@ -93,7 +93,7 @@ typedef golioth_rpc_status_t (*golioth_rpc_cb_fn)(
 /// @return GOLIOTH_OK - RPC method successfully registered
 /// @return otherwise - Error registering RPC method
 golioth_status_t golioth_rpc_register(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* method,
         golioth_rpc_cb_fn callback,
         void* callback_arg);

--- a/include/golioth/settings.h
+++ b/include/golioth/settings.h
@@ -116,7 +116,7 @@ typedef struct {
 /// @return GOLIOTH_ERR_MEM_ALLOC - Max number of registered settings exceeded
 /// @return GOLIOTH_ERR_NOT_IMPLEMENTED - If Golioth settings are disabled in config
 /// @return GOLIOTH_ERR_NULL - callback is NULL
-golioth_status_t golioth_settings_register_int(
+enum golioth_status golioth_settings_register_int(
         struct golioth_client* client,
         const char* setting_name,
         golioth_int_setting_cb callback,
@@ -124,7 +124,7 @@ golioth_status_t golioth_settings_register_int(
 
 /// Same as @ref golioth_settings_register_int, but with specific min and
 /// max value which will be checked by this library.
-golioth_status_t golioth_settings_register_int_with_range(
+enum golioth_status golioth_settings_register_int_with_range(
         struct golioth_client* client,
         const char* setting_name,
         int32_t min_val,
@@ -133,14 +133,14 @@ golioth_status_t golioth_settings_register_int_with_range(
         void* callback_arg);
 
 /// Same as @ref golioth_settings_register_int, but for type bool.
-golioth_status_t golioth_settings_register_bool(
+enum golioth_status golioth_settings_register_bool(
         struct golioth_client* client,
         const char* setting_name,
         golioth_bool_setting_cb callback,
         void* callback_arg);
 
 /// Same as @ref golioth_settings_register_int, but for type float.
-golioth_status_t golioth_settings_register_float(
+enum golioth_status golioth_settings_register_float(
         struct golioth_client* client,
         const char* setting_name,
         golioth_float_setting_cb callback,

--- a/include/golioth/settings.h
+++ b/include/golioth/settings.h
@@ -39,7 +39,7 @@
 /// @{
 
 /// Enumeration of Settings status codes
-typedef enum {
+enum golioth_settings_status {
     /// Setting applied successfully to the device, stored in NVS
     GOLIOTH_SETTINGS_SUCCESS = 0,
     /// The setting key is not recognized, this setting is unknown
@@ -54,16 +54,16 @@ typedef enum {
     GOLIOTH_SETTINGS_VALUE_STRING_TOO_LONG = 5,
     /// Other general error (e.g. I/O error)
     GOLIOTH_SETTINGS_GENERAL_ERROR = 6,
-} golioth_settings_status_t;
+};
 
 /// Different types of setting values
-typedef enum {
+enum golioth_settings_value_type {
     GOLIOTH_SETTINGS_VALUE_TYPE_UNKNOWN,
     GOLIOTH_SETTINGS_VALUE_TYPE_INT,
     GOLIOTH_SETTINGS_VALUE_TYPE_BOOL,
     GOLIOTH_SETTINGS_VALUE_TYPE_FLOAT,
     GOLIOTH_SETTINGS_VALUE_TYPE_STRING,
-} golioth_settings_value_type_t;
+};
 
 /// Callback function types for golioth_settings_register_*
 ///
@@ -72,17 +72,17 @@ typedef enum {
 ///
 /// @return GOLIOTH_SETTINGS_OK - the setting was applied successfully
 /// @return Otherwise - there was an error applying the setting
-typedef golioth_settings_status_t (*golioth_int_setting_cb)(int32_t new_value, void* arg);
-typedef golioth_settings_status_t (*golioth_bool_setting_cb)(bool new_value, void* arg);
-typedef golioth_settings_status_t (*golioth_float_setting_cb)(float new_value, void* arg);
-typedef golioth_settings_status_t (
+typedef enum golioth_settings_status (*golioth_int_setting_cb)(int32_t new_value, void* arg);
+typedef enum golioth_settings_status (*golioth_bool_setting_cb)(bool new_value, void* arg);
+typedef enum golioth_settings_status (*golioth_float_setting_cb)(float new_value, void* arg);
+typedef enum golioth_settings_status (
         *golioth_string_setting_cb)(const char* new_value, size_t new_value_len, void* arg);
 
 /// Private struct for storing a single setting
-typedef struct {
+struct golioth_setting {
     bool is_valid;
     const char* key;  // aka name
-    golioth_settings_value_type_t type;
+    enum golioth_settings_value_type type;
     union {
         golioth_int_setting_cb int_cb;
         golioth_bool_setting_cb bool_cb;
@@ -92,15 +92,15 @@ typedef struct {
     int32_t int_min_val;  // applies only to integers
     int32_t int_max_val;  // applies only to integers
     void* cb_arg;
-} golioth_setting_t;
+};
 
 /// Private struct to contain settings state data, stored in
 /// the golioth_coap_client_t struct.
-typedef struct {
+struct golioth_settings {
     bool initialized;
-    golioth_setting_t settings[CONFIG_GOLIOTH_MAX_NUM_SETTINGS];
+    struct golioth_setting settings[CONFIG_GOLIOTH_MAX_NUM_SETTINGS];
     size_t num_settings;
-} golioth_settings_t;
+};
 
 /// Register a specific setting of type int
 ///

--- a/include/golioth/settings.h
+++ b/include/golioth/settings.h
@@ -117,7 +117,7 @@ typedef struct {
 /// @return GOLIOTH_ERR_NOT_IMPLEMENTED - If Golioth settings are disabled in config
 /// @return GOLIOTH_ERR_NULL - callback is NULL
 golioth_status_t golioth_settings_register_int(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* setting_name,
         golioth_int_setting_cb callback,
         void* callback_arg);
@@ -125,7 +125,7 @@ golioth_status_t golioth_settings_register_int(
 /// Same as @ref golioth_settings_register_int, but with specific min and
 /// max value which will be checked by this library.
 golioth_status_t golioth_settings_register_int_with_range(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* setting_name,
         int32_t min_val,
         int32_t max_val,
@@ -134,14 +134,14 @@ golioth_status_t golioth_settings_register_int_with_range(
 
 /// Same as @ref golioth_settings_register_int, but for type bool.
 golioth_status_t golioth_settings_register_bool(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* setting_name,
         golioth_bool_setting_cb callback,
         void* callback_arg);
 
 /// Same as @ref golioth_settings_register_int, but for type float.
 golioth_status_t golioth_settings_register_float(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* setting_name,
         golioth_float_setting_cb callback,
         void* callback_arg);

--- a/port/esp_idf/fw_update_esp_idf.c
+++ b/port/esp_idf/fw_update_esp_idf.c
@@ -40,7 +40,7 @@ void fw_update_cancel_rollback(void) {
     esp_ota_mark_app_valid_cancel_rollback();
 }
 
-golioth_status_t fw_update_handle_block(
+enum golioth_status fw_update_handle_block(
         const uint8_t* block,
         size_t block_size,
         size_t offset,
@@ -79,7 +79,7 @@ void fw_update_post_download(void) {
     // Nothing to do
 }
 
-golioth_status_t fw_update_validate(void) {
+enum golioth_status fw_update_validate(void) {
     assert(_update_handle);
     esp_err_t err = esp_ota_end(_update_handle);
     if (err != ESP_OK) {
@@ -95,7 +95,7 @@ golioth_status_t fw_update_validate(void) {
     return GOLIOTH_OK;
 }
 
-golioth_status_t fw_update_change_boot_image(void) {
+enum golioth_status fw_update_change_boot_image(void) {
     assert(_update_partition);
 
     GLTH_LOGI(TAG, "Setting boot partition");
@@ -113,7 +113,7 @@ void fw_update_end(void) {
     }
 }
 
-golioth_status_t fw_update_read_current_image_at_offset(
+enum golioth_status fw_update_read_current_image_at_offset(
         uint8_t* buf,
         size_t bufsize,
         size_t offset) {

--- a/port/freertos/golioth_sys_freertos.c
+++ b/port/freertos/golioth_sys_freertos.c
@@ -81,7 +81,7 @@ static TickType_t ms_to_ticks(uint32_t ms) {
     return (rounded_ms / portTICK_PERIOD_MS);
 }
 
-golioth_sys_timer_t golioth_sys_timer_create(const golioth_sys_timer_config_t *config) {
+golioth_sys_timer_t golioth_sys_timer_create(const struct golioth_timer_config *config) {
     assert(config->fn);  // timer callback function is required
 
     wrapped_timer_t* wrapped_timer = (wrapped_timer_t*)golioth_sys_malloc(sizeof(wrapped_timer_t));

--- a/port/freertos/golioth_sys_freertos.c
+++ b/port/freertos/golioth_sys_freertos.c
@@ -130,7 +130,7 @@ void golioth_sys_timer_destroy(golioth_sys_timer_t timer) {
  * Threads
  *------------------------------------------------*/
 
-golioth_sys_thread_t golioth_sys_thread_create(const golioth_sys_thread_config_t *config) {
+golioth_sys_thread_t golioth_sys_thread_create(const struct golioth_thread_config *config) {
     TaskHandle_t task_handle = NULL;
     xTaskCreate(config->fn,
                 config->name,

--- a/port/linux/fw_update_linux.c
+++ b/port/linux/fw_update_linux.c
@@ -39,7 +39,7 @@ void fw_update_reboot(void) {}
 void fw_update_cancel_rollback(void) {}
 
 #if ENABLE_DOWNLOAD_TO_FILE
-golioth_status_t fw_update_handle_block(
+enum golioth_status fw_update_handle_block(
         const uint8_t* block,
         size_t block_size,
         size_t offset,
@@ -57,7 +57,7 @@ golioth_status_t fw_update_handle_block(
     return GOLIOTH_OK;
 }
 #else
-golioth_status_t fw_update_handle_block(
+enum golioth_status fw_update_handle_block(
         const uint8_t* block,
         size_t block_size,
         size_t offset,
@@ -77,11 +77,11 @@ void fw_update_post_download(void) {
     }
 }
 
-golioth_status_t fw_update_validate(void) {
+enum golioth_status fw_update_validate(void) {
     return GOLIOTH_OK;
 }
 
-golioth_status_t fw_update_change_boot_image(void) {
+enum golioth_status fw_update_change_boot_image(void) {
     return GOLIOTH_OK;
 }
 
@@ -123,7 +123,7 @@ int read_file(const char* filepath, uint8_t** filebuf) {
     return bytes_read;
 }
 
-golioth_status_t fw_update_read_current_image_at_offset(
+enum golioth_status fw_update_read_current_image_at_offset(
         uint8_t* buf,
         size_t bufsize,
         size_t offset) {

--- a/port/linux/golioth_sys_linux.c
+++ b/port/linux/golioth_sys_linux.c
@@ -118,7 +118,7 @@ int golioth_sys_sem_get_fd(golioth_sys_sem_t sem) {
 // Wrap timer_t to also capture user's config
 typedef struct {
     timer_t timer;
-    golioth_sys_timer_config_t config;
+    struct golioth_timer_config config;
 } wrapped_timer_t;
 
 static void on_timer(int sig, siginfo_t* si, void* uc) {
@@ -128,7 +128,7 @@ static void on_timer(int sig, siginfo_t* si, void* uc) {
     }
 }
 
-golioth_sys_timer_t golioth_sys_timer_create(const golioth_sys_timer_config_t *config) {
+golioth_sys_timer_t golioth_sys_timer_create(const struct golioth_timer_config *config) {
     static bool initialized = false;
     const int signo = SIGRTMIN;
 

--- a/port/linux/golioth_sys_linux.c
+++ b/port/linux/golioth_sys_linux.c
@@ -257,7 +257,7 @@ static void* pthread_callback(void* arg) {
     wt->fn(wt->user_arg);
 }
 
-golioth_sys_thread_t golioth_sys_thread_create(const golioth_sys_thread_config_t *config) {
+golioth_sys_thread_t golioth_sys_thread_create(const struct golioth_thread_config *config) {
     // Intentionally ignoring from config:
     //      name
     //      stack_size

--- a/port/modus_toolbox/fw_update_mcuboot.c
+++ b/port/modus_toolbox/fw_update_mcuboot.c
@@ -39,7 +39,7 @@ void fw_update_cancel_rollback(void) {
     boot_set_confirmed();
 }
 
-golioth_status_t fw_update_handle_block(
+enum golioth_status fw_update_handle_block(
         const uint8_t* block,
         size_t block_size,
         size_t offset,
@@ -101,12 +101,12 @@ void fw_update_post_download(void) {
     }
 }
 
-golioth_status_t fw_update_validate(void) {
+enum golioth_status fw_update_validate(void) {
     // Nothing to do
     return GOLIOTH_OK;
 }
 
-golioth_status_t fw_update_change_boot_image(void) {
+enum golioth_status fw_update_change_boot_image(void) {
     GLTH_LOGD(TAG, "boot_set_pending");
     int status = boot_set_pending(0);
     if (status != 0) {
@@ -130,7 +130,7 @@ void fw_update_end(void) {
     // Nothing to do
 }
 
-golioth_status_t fw_update_read_current_image_at_offset(
+enum golioth_status fw_update_read_current_image_at_offset(
         uint8_t* buf,
         size_t bufsize,
         size_t offset) {

--- a/port/zephyr/golioth_fw_zephyr.c
+++ b/port/zephyr/golioth_fw_zephyr.c
@@ -165,7 +165,7 @@ void fw_update_cancel_rollback(void) {
     boot_write_img_confirmed();
 }
 
-golioth_status_t fw_update_handle_block(
+enum golioth_status fw_update_handle_block(
         const uint8_t* block,
         size_t block_size,
         size_t offset,
@@ -205,11 +205,11 @@ void fw_update_post_download(void) {
     }
 }
 
-golioth_status_t fw_update_validate(void) {
+enum golioth_status fw_update_validate(void) {
     return GOLIOTH_OK;
 }
 
-golioth_status_t fw_update_change_boot_image(void) {
+enum golioth_status fw_update_change_boot_image(void) {
     int err;
 
     if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT)) {
@@ -226,7 +226,7 @@ golioth_status_t fw_update_change_boot_image(void) {
 
 void fw_update_end(void) {}
 
-golioth_status_t fw_update_read_current_image_at_offset(
+enum golioth_status fw_update_read_current_image_at_offset(
         uint8_t* buf,
         size_t bufsize,
         size_t offset) {

--- a/port/zephyr/golioth_log_zephyr.c
+++ b/port/zephyr/golioth_log_zephyr.c
@@ -28,17 +28,17 @@ struct cbpprintf_ctx {
 };
 
 struct golioth_log_ctx {
-    golioth_client_t client;
+    struct golioth_client* client;
     bool panic_mode;
     struct cbpprintf_ctx print_ctx;
 };
 
 static struct golioth_log_ctx log_ctx;
 
-typedef golioth_status_t (*glth_log_fn)(golioth_client_t, const char*, const char*, int32_t);
+typedef golioth_status_t (*glth_log_fn)(struct golioth_client*, const char*, const char*, int32_t);
 
 static golioth_status_t golioth_log_drop(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s) {

--- a/port/zephyr/golioth_log_zephyr.c
+++ b/port/zephyr/golioth_log_zephyr.c
@@ -35,9 +35,9 @@ struct golioth_log_ctx {
 
 static struct golioth_log_ctx log_ctx;
 
-typedef golioth_status_t (*glth_log_fn)(struct golioth_client*, const char*, const char*, int32_t);
+typedef enum golioth_status (*glth_log_fn)(struct golioth_client*, const char*, const char*, int32_t);
 
-static golioth_status_t golioth_log_drop(
+static enum golioth_status golioth_log_drop(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,

--- a/port/zephyr/golioth_sys_zephyr.c
+++ b/port/zephyr/golioth_sys_zephyr.c
@@ -97,7 +97,7 @@ int golioth_sys_sem_get_fd(golioth_sys_sem_t sem) {
 struct golioth_timer {
     struct k_timer timer;
     struct k_work work;
-    golioth_sys_timer_config_t config;
+    struct golioth_timer_config config;
 };
 
 static void timer_handler_worker(struct k_work *work)
@@ -115,7 +115,7 @@ static void on_timer(struct k_timer* ztimer) {
     k_work_submit(&timer->work);
 }
 
-golioth_sys_timer_t golioth_sys_timer_create(const golioth_sys_timer_config_t *config) {
+golioth_sys_timer_t golioth_sys_timer_create(const struct golioth_timer_config *config) {
     struct golioth_timer* timer;
 
     timer = golioth_sys_malloc(sizeof(*timer));

--- a/port/zephyr/golioth_sys_zephyr.c
+++ b/port/zephyr/golioth_sys_zephyr.c
@@ -187,7 +187,7 @@ static void golioth_thread_main(void* p1, void* p2, void* p3) {
     fn(user_arg);
 }
 
-golioth_sys_thread_t golioth_sys_thread_create(const golioth_sys_thread_config_t *config) {
+golioth_sys_thread_t golioth_sys_thread_create(const struct golioth_thread_config *config) {
     // Intentionally ignoring from config:
     //      name
     //      stack_size

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -50,7 +50,7 @@ static void notify_observers(
         struct golioth_client* client,
         const uint8_t* data,
         size_t data_len,
-        const golioth_response_t* response) {
+        const struct golioth_response* response) {
     // scan observations, check for token match
     for (int i = 0; i < CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS; i++) {
         const golioth_coap_observe_info_t* obs_info = &client->observations[i];
@@ -90,7 +90,7 @@ static coap_response_t coap_response_handler(
         return COAP_RESPONSE_OK;
     }
 
-    golioth_response_t response = {
+    struct golioth_response response = {
             .status = (class == 2 ? GOLIOTH_OK : GOLIOTH_ERR_FAIL),
             .status_class = class,
             .status_code = code,
@@ -823,7 +823,7 @@ static golioth_status_t coap_io_loop_once(
 
         // Call user's callback with GOLIOTH_ERR_TIMEOUT
         // TODO - simplify, put callback directly in request which removes if/else branches
-        golioth_response_t response = {};
+        struct golioth_response response = {};
         response.status = GOLIOTH_ERR_TIMEOUT;
         if (request_msg.type == GOLIOTH_COAP_REQUEST_GET && request_msg.get.callback) {
             request_msg.get.callback(

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -1020,7 +1020,7 @@ struct golioth_client* golioth_client_create(const struct golioth_client_config*
         goto error;
     }
 
-    golioth_sys_timer_config_t keepalive_timer_cfg =
+    struct golioth_timer_config keepalive_timer_cfg =
     {
         .name = "keepalive",
         .expiration_ms = max(1000, 1000 * CONFIG_GOLIOTH_COAP_KEEPALIVE_INTERVAL_S),

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -255,7 +255,7 @@ static void coap_log_handler(coap_log_t level, const char* message) {
 #endif /* GOLIOTH_OVERRIDE_LIBCOAP_LOG_HANDLER */
 
 // DNS lookup of host_uri
-static golioth_status_t get_coap_dst_address(const coap_uri_t* host_uri, coap_address_t* dst_addr) {
+static enum golioth_status get_coap_dst_address(const coap_uri_t* host_uri, coap_address_t* dst_addr) {
     struct addrinfo hints = {
             .ai_socktype = SOCK_DGRAM,
             .ai_family = AF_UNSPEC,
@@ -519,7 +519,7 @@ static void reestablish_observations(struct golioth_client* client, coap_session
     }
 }
 
-static golioth_status_t create_context(struct golioth_client* client, coap_context_t** context) {
+static enum golioth_status create_context(struct golioth_client* client, coap_context_t** context) {
     *context = coap_new_context(NULL);
     if (!*context) {
         GLTH_LOGE(TAG, "Failed to create CoAP context");
@@ -555,7 +555,7 @@ static int validate_cn_call_back(
     return 1;
 }
 
-static golioth_status_t create_session(
+static enum golioth_status create_session(
         struct golioth_client* client,
         coap_context_t* context,
         coap_session_t** session) {
@@ -654,7 +654,7 @@ static void purge_request_mbox(golioth_mbox_t request_mbox) {
     }
 }
 
-static golioth_status_t coap_io_loop_once(
+static enum golioth_status coap_io_loop_once(
         struct golioth_client* client,
         coap_context_t* context,
         coap_session_t* session) {
@@ -1052,7 +1052,7 @@ error:
     return NULL;
 }
 
-golioth_status_t golioth_client_start(struct golioth_client* client) {
+enum golioth_status golioth_client_start(struct golioth_client* client) {
     if (!client) {
         return GOLIOTH_ERR_NULL;
     }
@@ -1060,7 +1060,7 @@ golioth_status_t golioth_client_start(struct golioth_client* client) {
     return GOLIOTH_OK;
 }
 
-golioth_status_t golioth_client_stop(struct golioth_client* client) {
+enum golioth_status golioth_client_stop(struct golioth_client* client) {
     if (!client) {
         return GOLIOTH_ERR_NULL;
     }
@@ -1103,7 +1103,7 @@ bool golioth_client_is_connected(struct golioth_client* client) {
     return client->session_connected;
 }
 
-golioth_status_t golioth_coap_client_empty(
+enum golioth_status golioth_coap_client_empty(
         struct golioth_client* client,
         bool is_synchronous,
         int32_t timeout_s) {
@@ -1163,7 +1163,7 @@ golioth_status_t golioth_coap_client_empty(
     return GOLIOTH_OK;
 }
 
-golioth_status_t golioth_coap_client_set(
+enum golioth_status golioth_coap_client_set(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,
@@ -1260,7 +1260,7 @@ golioth_status_t golioth_coap_client_set(
     return GOLIOTH_OK;
 }
 
-golioth_status_t golioth_coap_client_delete(
+enum golioth_status golioth_coap_client_delete(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,
@@ -1331,7 +1331,7 @@ golioth_status_t golioth_coap_client_delete(
     return GOLIOTH_OK;
 }
 
-static golioth_status_t golioth_coap_client_get_internal(
+static enum golioth_status golioth_coap_client_get_internal(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,
@@ -1401,7 +1401,7 @@ static golioth_status_t golioth_coap_client_get_internal(
     return GOLIOTH_OK;
 }
 
-golioth_status_t golioth_coap_client_get(
+enum golioth_status golioth_coap_client_get(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,
@@ -1425,7 +1425,7 @@ golioth_status_t golioth_coap_client_get(
             timeout_s);
 }
 
-golioth_status_t golioth_coap_client_get_block(
+enum golioth_status golioth_coap_client_get_block(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,
@@ -1453,7 +1453,7 @@ golioth_status_t golioth_coap_client_get_block(
             timeout_s);
 }
 
-golioth_status_t golioth_coap_client_observe_async(
+enum golioth_status golioth_coap_client_observe_async(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -582,7 +582,7 @@ static golioth_status_t create_session(
     enum golioth_auth_type auth_type = client->config.credentials.auth_type;
 
     if (auth_type == GOLIOTH_TLS_AUTH_TYPE_PSK) {
-        golioth_psk_credentials_t psk_creds = client->config.credentials.psk;
+        struct golioth_psk_credential psk_creds = client->config.credentials.psk;
 
         GLTH_LOGI(TAG, "Session PSK-ID: %.*s", (int)psk_creds.psk_id_len, psk_creds.psk_id);
 

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -597,7 +597,7 @@ static golioth_status_t create_session(
         *session =
                 coap_new_client_session_psk2(context, NULL, &dst_addr, COAP_PROTO_DTLS, &dtls_psk);
     } else if (auth_type == GOLIOTH_TLS_AUTH_TYPE_PKI) {
-        golioth_pki_credentials_t pki_creds = client->config.credentials.pki;
+        struct golioth_pki_credential pki_creds = client->config.credentials.pki;
 
         coap_dtls_pki_t dtls_pki = {
                 .version = COAP_DTLS_PKI_SETUP_VERSION,

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -35,7 +35,7 @@ struct golioth_client {
     size_t block_token_len;
     golioth_client_event_cb_fn event_callback;
     void* event_callback_arg;
-    golioth_settings_t settings;
+    struct golioth_settings settings;
     struct golioth_rpc rpc;
 };
 
@@ -1520,7 +1520,7 @@ uint32_t golioth_client_num_items_in_request_queue(struct golioth_client* client
     return golioth_mbox_num_messages(client->request_queue);
 }
 
-golioth_settings_t* golioth_coap_client_get_settings(struct golioth_client* client) {
+struct golioth_settings* golioth_coap_client_get_settings(struct golioth_client* client) {
     return &client->settings;
 }
 

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -1005,7 +1005,7 @@ struct golioth_client* golioth_client_create(const struct golioth_client_config*
         goto error;
     }
 
-    golioth_sys_thread_config_t thread_cfg =
+    struct golioth_thread_config thread_cfg =
     {
         .name = "coap_client",
         .fn = golioth_coap_client_thread,

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -27,7 +27,7 @@ struct golioth_client {
     bool is_running;
     bool end_session;
     bool session_connected;
-    golioth_client_config_t config;
+    struct golioth_client_config config;
     golioth_coap_request_msg_t* pending_req;
     golioth_coap_observe_info_t observations[CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS];
     // token to use for block GETs (must use same token for all blocks)
@@ -964,7 +964,7 @@ static void golioth_coap_client_thread(void* arg) {
     }
 }
 
-struct golioth_client* golioth_client_create(const golioth_client_config_t* config) {
+struct golioth_client* golioth_client_create(const struct golioth_client_config* config) {
     if (!_initialized) {
         // Initialize libcoap prior to any coap_* function calls.
         coap_startup();

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -579,7 +579,7 @@ static golioth_status_t create_session(
     char client_sni[256] = {};
     memcpy(client_sni, host_uri.host.s, MIN(host_uri.host.length, sizeof(client_sni) - 1));
 
-    golioth_tls_auth_type_t auth_type = client->config.credentials.auth_type;
+    enum golioth_auth_type auth_type = client->config.credentials.auth_type;
 
     if (auth_type == GOLIOTH_TLS_AUTH_TYPE_PSK) {
         golioth_psk_credentials_t psk_creds = client->config.credentials.psk;

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -36,7 +36,7 @@ struct golioth_client {
     golioth_client_event_cb_fn event_callback;
     void* event_callback_arg;
     golioth_settings_t settings;
-    golioth_rpc_t rpc;
+    struct golioth_rpc rpc;
 };
 
 static bool token_matches_request(const golioth_coap_request_msg_t* req, const coap_pdu_t* pdu) {
@@ -1524,7 +1524,7 @@ golioth_settings_t* golioth_coap_client_get_settings(struct golioth_client* clie
     return &client->settings;
 }
 
-golioth_rpc_t* golioth_coap_client_get_rpc(struct golioth_client* client) {
+struct golioth_rpc* golioth_coap_client_get_rpc(struct golioth_client* client) {
     return &client->rpc;
 }
 

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -107,12 +107,12 @@ typedef struct {
     golioth_coap_request_msg_t req;
 } golioth_coap_observe_info_t;
 
-golioth_status_t golioth_coap_client_empty(
+enum golioth_status golioth_coap_client_empty(
         struct golioth_client* client,
         bool is_synchronous,
         int32_t timeout_s);
 
-golioth_status_t golioth_coap_client_set(
+enum golioth_status golioth_coap_client_set(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,
@@ -124,7 +124,7 @@ golioth_status_t golioth_coap_client_set(
         bool is_synchronous,
         int32_t timeout_s);
 
-golioth_status_t golioth_coap_client_delete(
+enum golioth_status golioth_coap_client_delete(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,
@@ -133,7 +133,7 @@ golioth_status_t golioth_coap_client_delete(
         bool is_synchronous,
         int32_t timeout_s);
 
-golioth_status_t golioth_coap_client_get(
+enum golioth_status golioth_coap_client_get(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,
@@ -143,7 +143,7 @@ golioth_status_t golioth_coap_client_get(
         bool is_synchronous,
         int32_t timeout_s);
 
-golioth_status_t golioth_coap_client_get_block(
+enum golioth_status golioth_coap_client_get_block(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,
@@ -155,7 +155,7 @@ golioth_status_t golioth_coap_client_get_block(
         bool is_synchronous,
         int32_t timeout_s);
 
-golioth_status_t golioth_coap_client_observe_async(
+enum golioth_status golioth_coap_client_observe_async(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -108,12 +108,12 @@ typedef struct {
 } golioth_coap_observe_info_t;
 
 golioth_status_t golioth_coap_client_empty(
-        golioth_client_t client,
+        struct golioth_client* client,
         bool is_synchronous,
         int32_t timeout_s);
 
 golioth_status_t golioth_coap_client_set(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path_prefix,
         const char* path,
         enum golioth_content_type content_type,
@@ -125,7 +125,7 @@ golioth_status_t golioth_coap_client_set(
         int32_t timeout_s);
 
 golioth_status_t golioth_coap_client_delete(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path_prefix,
         const char* path,
         golioth_set_cb_fn callback,
@@ -134,7 +134,7 @@ golioth_status_t golioth_coap_client_delete(
         int32_t timeout_s);
 
 golioth_status_t golioth_coap_client_get(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path_prefix,
         const char* path,
         enum golioth_content_type content_type,
@@ -144,7 +144,7 @@ golioth_status_t golioth_coap_client_get(
         int32_t timeout_s);
 
 golioth_status_t golioth_coap_client_get_block(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path_prefix,
         const char* path,
         enum golioth_content_type content_type,
@@ -156,7 +156,7 @@ golioth_status_t golioth_coap_client_get_block(
         int32_t timeout_s);
 
 golioth_status_t golioth_coap_client_observe_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path_prefix,
         const char* path,
         enum golioth_content_type content_type,
@@ -165,6 +165,6 @@ golioth_status_t golioth_coap_client_observe_async(
 
 /// Getters, for internal SDK code to access data within the
 /// coap client struct.
-golioth_settings_t* golioth_coap_client_get_settings(golioth_client_t client);
-golioth_rpc_t* golioth_coap_client_get_rpc(golioth_client_t client);
-golioth_sys_thread_t golioth_coap_client_get_thread(golioth_client_t client);
+golioth_settings_t* golioth_coap_client_get_settings(struct golioth_client* client);
+golioth_rpc_t* golioth_coap_client_get_rpc(struct golioth_client* client);
+golioth_sys_thread_t golioth_coap_client_get_thread(struct golioth_client* client);

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -165,6 +165,6 @@ enum golioth_status golioth_coap_client_observe_async(
 
 /// Getters, for internal SDK code to access data within the
 /// coap client struct.
-golioth_settings_t* golioth_coap_client_get_settings(struct golioth_client* client);
+struct golioth_settings* golioth_coap_client_get_settings(struct golioth_client* client);
 struct golioth_rpc* golioth_coap_client_get_rpc(struct golioth_client* client);
 golioth_sys_thread_t golioth_coap_client_get_thread(struct golioth_client* client);

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -166,5 +166,5 @@ enum golioth_status golioth_coap_client_observe_async(
 /// Getters, for internal SDK code to access data within the
 /// coap client struct.
 golioth_settings_t* golioth_coap_client_get_settings(struct golioth_client* client);
-golioth_rpc_t* golioth_coap_client_get_rpc(struct golioth_client* client);
+struct golioth_rpc* golioth_coap_client_get_rpc(struct golioth_client* client);
 golioth_sys_thread_t golioth_coap_client_get_thread(struct golioth_client* client);

--- a/src/fw_block_processor.c
+++ b/src/fw_block_processor.c
@@ -28,7 +28,7 @@ static void block_stats_update(block_latency_stats_t* stats, uint32_t block_late
 
 static void download_init(
         download_ctx_t* ctx,
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_ota_component_t* ota_component,
         uint8_t* download_buf) {
     memset(ctx, 0, sizeof(*ctx));
@@ -277,7 +277,7 @@ static golioth_status_t patch(const uint8_t* in_data, size_t in_data_size, void*
 
 void fw_block_processor_init(
         fw_block_processor_ctx_t* ctx,
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_ota_component_t* component,
         uint8_t* download_buf) {
     memset(ctx, 0, sizeof(*ctx));

--- a/src/fw_block_processor.c
+++ b/src/fw_block_processor.c
@@ -29,7 +29,7 @@ static void block_stats_update(block_latency_stats_t* stats, uint32_t block_late
 static void download_init(
         download_ctx_t* ctx,
         struct golioth_client* client,
-        const golioth_ota_component_t* ota_component,
+        const struct golioth_ota_component* ota_component,
         uint8_t* download_buf) {
     memset(ctx, 0, sizeof(*ctx));
     block_stats_init(&ctx->block_stats);
@@ -278,7 +278,7 @@ static enum golioth_status patch(const uint8_t* in_data, size_t in_data_size, vo
 void fw_block_processor_init(
         fw_block_processor_ctx_t* ctx,
         struct golioth_client* client,
-        const golioth_ota_component_t* component,
+        const struct golioth_ota_component* component,
         uint8_t* download_buf) {
     memset(ctx, 0, sizeof(*ctx));
 

--- a/src/fw_block_processor.c
+++ b/src/fw_block_processor.c
@@ -47,7 +47,7 @@ static void download_init(
     ctx->total_num_blocks = golioth_ota_size_to_nblocks(ota_component->size);
 }
 
-static golioth_status_t download_block(download_ctx_t* ctx) {
+static enum golioth_status download_block(download_ctx_t* ctx) {
     if (ctx->is_last_block) {
         // We've already downloaded the last block
         return GOLIOTH_ERR_NO_MORE_DATA;
@@ -94,7 +94,7 @@ static void decompress_init(decompress_ctx_t* ctx) {
 }
 
 static int patch_old_read(const struct bspatch_stream_i* stream, void* buffer, int pos, int len) {
-    golioth_status_t status = fw_update_read_current_image_at_offset(buffer, len, pos);
+    enum golioth_status status = fw_update_read_current_image_at_offset(buffer, len, pos);
     if (status != GOLIOTH_OK) {
         return -1;
     }
@@ -104,7 +104,7 @@ static int patch_old_read(const struct bspatch_stream_i* stream, void* buffer, i
 static int patch_new_write(const struct bspatch_stream_n* stream, const void* buffer, int length) {
     patch_ctx_t* ctx = (patch_ctx_t*)stream->opaque;
     assert(ctx->output_fn);
-    golioth_status_t status = ctx->output_fn(buffer, length, ctx->output_fn_arg);
+    enum golioth_status status = ctx->output_fn(buffer, length, ctx->output_fn_arg);
     if (status != GOLIOTH_OK) {
         return -1;
     }
@@ -129,10 +129,10 @@ static void handle_block_init(handle_block_ctx_t* ctx, size_t component_size) {
     ctx->component_size = component_size;
 }
 
-static golioth_status_t handle_block(const uint8_t* in_data, size_t in_data_size, void* arg) {
+static enum golioth_status handle_block(const uint8_t* in_data, size_t in_data_size, void* arg) {
     handle_block_ctx_t* ctx = (handle_block_ctx_t*)arg;
 
-    golioth_status_t status = fw_update_handle_block(
+    enum golioth_status status = fw_update_handle_block(
             in_data,
             in_data_size,
             ctx->bytes_handled,  // offset
@@ -143,7 +143,7 @@ static golioth_status_t handle_block(const uint8_t* in_data, size_t in_data_size
 }
 
 #if CONFIG_GOLIOTH_OTA_DECOMPRESS_METHOD_HEATSHRINK
-static golioth_status_t decompress_heatshrink(
+static enum golioth_status decompress_heatshrink(
         decompress_ctx_t* ctx,
         const uint8_t* in_data,
         size_t in_data_size) {
@@ -182,7 +182,7 @@ static golioth_status_t decompress_heatshrink(
 #endif
 
 #if CONFIG_GOLIOTH_OTA_DECOMPRESS_METHOD_ZLIB
-static golioth_status_t decompress_zlib(
+static enum golioth_status decompress_zlib(
         decompress_ctx_t* ctx,
         const uint8_t* in_data,
         size_t in_data_size) {
@@ -229,7 +229,7 @@ static golioth_status_t decompress_zlib(
 }
 #endif
 
-static golioth_status_t decompress_none(
+static enum golioth_status decompress_none(
         decompress_ctx_t* ctx,
         const uint8_t* in_data,
         size_t in_data_size) {
@@ -238,7 +238,7 @@ static golioth_status_t decompress_none(
     return GOLIOTH_OK;
 }
 
-static golioth_status_t decompress(const uint8_t* in_data, size_t in_data_size, void* arg) {
+static enum golioth_status decompress(const uint8_t* in_data, size_t in_data_size, void* arg) {
     decompress_ctx_t* ctx = (decompress_ctx_t*)arg;
     assert(ctx->output_fn);
 
@@ -256,7 +256,7 @@ static golioth_status_t decompress(const uint8_t* in_data, size_t in_data_size, 
     // TODO - compute sha256 of decompressed image and verify it matches manifest
 }
 
-static golioth_status_t patch(const uint8_t* in_data, size_t in_data_size, void* arg) {
+static enum golioth_status patch(const uint8_t* in_data, size_t in_data_size, void* arg) {
     patch_ctx_t* ctx = (patch_ctx_t*)arg;
     assert(ctx->output_fn);
 
@@ -300,7 +300,7 @@ void fw_block_processor_init(
     ctx->patch.output_fn_arg = &ctx->handle_block;
 }
 
-golioth_status_t fw_block_processor_process(fw_block_processor_ctx_t* ctx) {
+enum golioth_status fw_block_processor_process(fw_block_processor_ctx_t* ctx) {
     // Call the first function in the block processing chain.
     return download_block(&ctx->download);
 }

--- a/src/fw_block_processor.h
+++ b/src/fw_block_processor.h
@@ -13,7 +13,7 @@
 #include <miniz_tinfl.h>
 #include <stdint.h>
 
-typedef golioth_status_t (*process_fn)(const uint8_t* in, size_t in_size, void* arg);
+typedef enum golioth_status (*process_fn)(const uint8_t* in, size_t in_size, void* arg);
 
 typedef struct {
     uint32_t block_min_ms;
@@ -96,5 +96,5 @@ void fw_block_processor_init(
         struct golioth_client* client,
         const golioth_ota_component_t* component,
         uint8_t* download_buf);
-golioth_status_t fw_block_processor_process(fw_block_processor_ctx_t* ctx);
+enum golioth_status fw_block_processor_process(fw_block_processor_ctx_t* ctx);
 void fw_block_processor_log_results(const fw_block_processor_ctx_t* ctx);

--- a/src/fw_block_processor.h
+++ b/src/fw_block_processor.h
@@ -35,7 +35,7 @@ typedef struct {
     /// Statistics to measure block download latency
     block_latency_stats_t block_stats;
     /// OTA component to download
-    const golioth_ota_component_t* ota_component;
+    const struct golioth_ota_component* ota_component;
     /// Buffer where downloaded blocks will be copied to
     uint8_t* download_buf;
     /// Function to call when output is available
@@ -94,7 +94,7 @@ typedef struct {
 void fw_block_processor_init(
         fw_block_processor_ctx_t* ctx,
         struct golioth_client* client,
-        const golioth_ota_component_t* component,
+        const struct golioth_ota_component* component,
         uint8_t* download_buf);
 enum golioth_status fw_block_processor_process(fw_block_processor_ctx_t* ctx);
 void fw_block_processor_log_results(const fw_block_processor_ctx_t* ctx);

--- a/src/fw_block_processor.h
+++ b/src/fw_block_processor.h
@@ -23,7 +23,7 @@ typedef struct {
 
 typedef struct {
     /// Golioth client used for downloading
-    golioth_client_t client;
+    struct golioth_client* client;
     /// Estimate of the total number blocks to download
     size_t total_num_blocks;
     /// Index of current block to download
@@ -93,7 +93,7 @@ typedef struct {
 
 void fw_block_processor_init(
         fw_block_processor_ctx_t* ctx,
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_ota_component_t* component,
         uint8_t* download_buf);
 golioth_status_t fw_block_processor_process(fw_block_processor_ctx_t* ctx);

--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -17,7 +17,7 @@
 
 LOG_TAG_DEFINE(golioth_fw_update);
 
-static golioth_client_t _client;
+static struct golioth_client* _client;
 static golioth_sys_sem_t _manifest_rcvd;
 static golioth_ota_manifest_t _ota_manifest;
 static uint8_t _ota_block_buffer[GOLIOTH_OTA_BLOCKSIZE + 1];
@@ -51,7 +51,7 @@ static golioth_status_t download_and_write_flash(void) {
 }
 
 static golioth_status_t golioth_fw_update_report_state_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         golioth_ota_state_t state,
         golioth_ota_reason_t reason,
         const char* package,
@@ -67,7 +67,7 @@ static golioth_status_t golioth_fw_update_report_state_sync(
 }
 
 static void on_ota_manifest(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -250,7 +250,7 @@ static void fw_update_thread(void* arg) {
     }
 }
 
-void golioth_fw_update_init(golioth_client_t client, const char* current_version) {
+void golioth_fw_update_init(struct golioth_client* client, const char* current_version) {
     golioth_fw_update_config_t config = {
             .current_version = current_version,
             .fw_package_name = GOLIOTH_FW_UPDATE_DEFAULT_PACKAGE_NAME,
@@ -259,7 +259,7 @@ void golioth_fw_update_init(golioth_client_t client, const char* current_version
 }
 
 void golioth_fw_update_init_with_config(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_fw_update_config_t* config) {
     static bool initialized = false;
 

--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -68,7 +68,7 @@ static golioth_status_t golioth_fw_update_report_state_sync(
 
 static void on_ota_manifest(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,

--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -24,7 +24,7 @@ static uint8_t _ota_block_buffer[GOLIOTH_OTA_BLOCKSIZE + 1];
 static const golioth_ota_component_t* _main_component;
 static golioth_fw_update_state_change_callback _state_callback;
 static void* _state_callback_arg;
-static golioth_fw_update_config_t _config;
+static struct golioth_fw_update_config _config;
 static fw_block_processor_ctx_t _fw_block_processor;
 
 static enum golioth_status download_and_write_flash(void) {
@@ -251,7 +251,7 @@ static void fw_update_thread(void* arg) {
 }
 
 void golioth_fw_update_init(struct golioth_client* client, const char* current_version) {
-    golioth_fw_update_config_t config = {
+    struct golioth_fw_update_config config = {
             .current_version = current_version,
             .fw_package_name = GOLIOTH_FW_UPDATE_DEFAULT_PACKAGE_NAME,
     };
@@ -260,7 +260,7 @@ void golioth_fw_update_init(struct golioth_client* client, const char* current_v
 
 void golioth_fw_update_init_with_config(
         struct golioth_client* client,
-        const golioth_fw_update_config_t* config) {
+        const struct golioth_fw_update_config* config) {
     static bool initialized = false;
 
     _client = client;

--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -19,9 +19,9 @@ LOG_TAG_DEFINE(golioth_fw_update);
 
 static struct golioth_client* _client;
 static golioth_sys_sem_t _manifest_rcvd;
-static golioth_ota_manifest_t _ota_manifest;
+static struct golioth_ota_manifest _ota_manifest;
 static uint8_t _ota_block_buffer[GOLIOTH_OTA_BLOCKSIZE + 1];
-static const golioth_ota_component_t* _main_component;
+static const struct golioth_ota_component* _main_component;
 static golioth_fw_update_state_change_callback _state_callback;
 static void* _state_callback_arg;
 static struct golioth_fw_update_config _config;
@@ -52,8 +52,8 @@ static enum golioth_status download_and_write_flash(void) {
 
 static enum golioth_status golioth_fw_update_report_state_sync(
         struct golioth_client* client,
-        golioth_ota_state_t state,
-        golioth_ota_reason_t reason,
+        enum golioth_ota_state state,
+        enum golioth_ota_reason reason,
         const char* package,
         const char* current_version,
         const char* target_version,
@@ -79,7 +79,7 @@ static void on_ota_manifest(
 
     GLTH_LOGD(TAG, "Received OTA manifest: %.*s", (int)payload_size, payload);
 
-    golioth_ota_state_t state = golioth_ota_get_state();
+    enum golioth_ota_state state = golioth_ota_get_state();
     if (state == GOLIOTH_OTA_STATE_DOWNLOADING) {
         GLTH_LOGW(TAG, "Ignoring manifest while download in progress");
         return;
@@ -94,7 +94,7 @@ static void on_ota_manifest(
     golioth_sys_sem_give(_manifest_rcvd);
 }
 
-static bool manifest_version_is_different(const golioth_ota_manifest_t* manifest) {
+static bool manifest_version_is_different(const struct golioth_ota_manifest* manifest) {
     _main_component = golioth_ota_find_component(manifest, _config.fw_package_name);
     if (_main_component) {
         if (0 != strcmp(_config.current_version, _main_component->version)) {

--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -274,7 +274,7 @@ void golioth_fw_update_init_with_config(
             _config.current_version);
 
     if (!initialized) {
-        golioth_sys_thread_config_t thread_cfg =
+        struct golioth_thread_config thread_cfg =
         {
             .name = "fw_update",
             .fn = fw_update_thread,

--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -27,7 +27,7 @@ static void* _state_callback_arg;
 static golioth_fw_update_config_t _config;
 static fw_block_processor_ctx_t _fw_block_processor;
 
-static golioth_status_t download_and_write_flash(void) {
+static enum golioth_status download_and_write_flash(void) {
     assert(_main_component);
 
     GLTH_LOGI(TAG, "Image size = %" PRIu32, _main_component->size);
@@ -50,7 +50,7 @@ static golioth_status_t download_and_write_flash(void) {
     return GOLIOTH_OK;
 }
 
-static golioth_status_t golioth_fw_update_report_state_sync(
+static enum golioth_status golioth_fw_update_report_state_sync(
         struct golioth_client* client,
         golioth_ota_state_t state,
         golioth_ota_reason_t reason,
@@ -85,7 +85,7 @@ static void on_ota_manifest(
         return;
     }
 
-    golioth_status_t status =
+    enum golioth_status status =
             golioth_ota_payload_as_manifest(payload, payload_size, &_ota_manifest);
     if (status != GOLIOTH_OK) {
         GLTH_LOGE(TAG, "Failed to parse manifest: %s", golioth_status_to_str(status));

--- a/src/golioth_debug.c
+++ b/src/golioth_debug.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 
 static golioth_debug_log_level_t _level = CONFIG_GOLIOTH_DEBUG_DEFAULT_LOG_LEVEL;
-static golioth_client_t _client = NULL;
+static struct golioth_client* _client = NULL;
 static bool _cloud_log_enabled = CONFIG_GOLIOTH_AUTO_LOG_TO_CLOUD;
 
 void golioth_debug_set_log_level(golioth_debug_log_level_t level) {
@@ -151,7 +151,7 @@ void golioth_debug_printf(
     golioth_sys_free(msg_buffer);
 }
 
-void golioth_debug_set_client(golioth_client_t client) {
+void golioth_debug_set_client(struct golioth_client* client) {
     _client = client;
 }
 

--- a/src/golioth_debug.c
+++ b/src/golioth_debug.c
@@ -9,15 +9,15 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
-static golioth_debug_log_level_t _level = CONFIG_GOLIOTH_DEBUG_DEFAULT_LOG_LEVEL;
+static enum golioth_debug_log_level _level = CONFIG_GOLIOTH_DEBUG_DEFAULT_LOG_LEVEL;
 static struct golioth_client* _client = NULL;
 static bool _cloud_log_enabled = CONFIG_GOLIOTH_AUTO_LOG_TO_CLOUD;
 
-void golioth_debug_set_log_level(golioth_debug_log_level_t level) {
+void golioth_debug_set_log_level(enum golioth_debug_log_level level) {
     _level = level;
 }
 
-golioth_debug_log_level_t golioth_debug_get_log_level(void) {
+enum golioth_debug_log_level golioth_debug_get_log_level(void) {
     return _level;
 }
 
@@ -82,7 +82,7 @@ void golioth_debug_hexdump(const char* tag, const void* addr, int len) {
 // If you must log, use printf instead.
 void golioth_debug_printf(
         uint64_t tstamp_ms,
-        golioth_debug_log_level_t level,
+        enum golioth_debug_log_level level,
         const char* tag,
         const char* format,
         ...) {

--- a/src/golioth_status.c
+++ b/src/golioth_status.c
@@ -10,7 +10,7 @@
 static const char* _status_strings[NUM_GOLIOTH_STATUS_CODES] = {
         FOREACH_GOLIOTH_STATUS(GENERATE_GOLIOTH_STATUS_STR)};
 
-const char* golioth_status_to_str(golioth_status_t status) {
+const char* golioth_status_to_str(enum golioth_status status) {
     assert(status < NUM_GOLIOTH_STATUS_CODES);
     return _status_strings[status];
 }

--- a/src/lightdb_state.c
+++ b/src/lightdb_state.c
@@ -309,7 +309,7 @@ golioth_status_t golioth_lightdb_set_sync(
 
 static void on_payload(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,

--- a/src/lightdb_state.c
+++ b/src/lightdb_state.c
@@ -35,7 +35,7 @@ typedef struct {
 } lightdb_get_response_t;
 
 golioth_status_t golioth_lightdb_set_int_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t value,
         golioth_set_cb_fn callback,
@@ -56,7 +56,7 @@ golioth_status_t golioth_lightdb_set_int_async(
 }
 
 golioth_status_t golioth_lightdb_set_bool_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         bool value,
         golioth_set_cb_fn callback,
@@ -76,7 +76,7 @@ golioth_status_t golioth_lightdb_set_bool_async(
 }
 
 golioth_status_t golioth_lightdb_set_float_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         float value,
         golioth_set_cb_fn callback,
@@ -97,7 +97,7 @@ golioth_status_t golioth_lightdb_set_float_async(
 }
 
 golioth_status_t golioth_lightdb_set_string_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* str,
         size_t str_len,
@@ -130,7 +130,7 @@ golioth_status_t golioth_lightdb_set_string_async(
 }
 
 golioth_status_t golioth_lightdb_set_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
         const uint8_t* buf,
@@ -151,7 +151,7 @@ golioth_status_t golioth_lightdb_set_async(
 }
 
 golioth_status_t golioth_lightdb_get_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
         golioth_get_cb_fn callback,
@@ -168,7 +168,7 @@ golioth_status_t golioth_lightdb_get_async(
 }
 
 golioth_status_t golioth_lightdb_delete_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         golioth_set_cb_fn callback,
         void* callback_arg) {
@@ -183,7 +183,7 @@ golioth_status_t golioth_lightdb_delete_async(
 }
 
 golioth_status_t golioth_lightdb_observe_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         golioth_get_cb_fn callback,
         void* arg) {
@@ -197,7 +197,7 @@ golioth_status_t golioth_lightdb_observe_async(
 }
 
 golioth_status_t golioth_lightdb_set_int_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t value,
         int32_t timeout_s) {
@@ -217,7 +217,7 @@ golioth_status_t golioth_lightdb_set_int_sync(
 }
 
 golioth_status_t golioth_lightdb_set_bool_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         bool value,
         int32_t timeout_s) {
@@ -236,7 +236,7 @@ golioth_status_t golioth_lightdb_set_bool_sync(
 }
 
 golioth_status_t golioth_lightdb_set_float_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         float value,
         int32_t timeout_s) {
@@ -256,7 +256,7 @@ golioth_status_t golioth_lightdb_set_float_sync(
 }
 
 golioth_status_t golioth_lightdb_set_string_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* str,
         size_t str_len,
@@ -288,7 +288,7 @@ golioth_status_t golioth_lightdb_set_string_sync(
 }
 
 golioth_status_t golioth_lightdb_set_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
         const uint8_t* buf,
@@ -308,7 +308,7 @@ golioth_status_t golioth_lightdb_set_sync(
 }
 
 static void on_payload(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -352,7 +352,7 @@ static void on_payload(
 }
 
 golioth_status_t golioth_lightdb_get_int_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t* value,
         int32_t timeout_s) {
@@ -376,7 +376,7 @@ golioth_status_t golioth_lightdb_get_int_sync(
 }
 
 golioth_status_t golioth_lightdb_get_bool_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         bool* value,
         int32_t timeout_s) {
@@ -400,7 +400,7 @@ golioth_status_t golioth_lightdb_get_bool_sync(
 }
 
 golioth_status_t golioth_lightdb_get_float_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         float* value,
         int32_t timeout_s) {
@@ -424,7 +424,7 @@ golioth_status_t golioth_lightdb_get_float_sync(
 }
 
 golioth_status_t golioth_lightdb_get_string_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         char* strbuf,
         size_t strbuf_size,
@@ -450,7 +450,7 @@ golioth_status_t golioth_lightdb_get_string_sync(
 }
 
 golioth_status_t golioth_lightdb_get_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
         uint8_t* buf,
@@ -480,7 +480,7 @@ golioth_status_t golioth_lightdb_get_sync(
 }
 
 golioth_status_t golioth_lightdb_delete_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t timeout_s) {
     return golioth_coap_client_delete(

--- a/src/lightdb_state.c
+++ b/src/lightdb_state.c
@@ -34,7 +34,7 @@ typedef struct {
     bool is_null;
 } lightdb_get_response_t;
 
-golioth_status_t golioth_lightdb_set_int_async(
+enum golioth_status golioth_lightdb_set_int_async(
         struct golioth_client* client,
         const char* path,
         int32_t value,
@@ -55,7 +55,7 @@ golioth_status_t golioth_lightdb_set_int_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_set_bool_async(
+enum golioth_status golioth_lightdb_set_bool_async(
         struct golioth_client* client,
         const char* path,
         bool value,
@@ -75,7 +75,7 @@ golioth_status_t golioth_lightdb_set_bool_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_set_float_async(
+enum golioth_status golioth_lightdb_set_float_async(
         struct golioth_client* client,
         const char* path,
         float value,
@@ -96,7 +96,7 @@ golioth_status_t golioth_lightdb_set_float_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_set_string_async(
+enum golioth_status golioth_lightdb_set_string_async(
         struct golioth_client* client,
         const char* path,
         const char* str,
@@ -113,7 +113,7 @@ golioth_status_t golioth_lightdb_set_string_async(
     memset(buf, 0, bufsize);
     snprintf(buf, bufsize, "\"%s\"", str);
 
-    golioth_status_t status = golioth_coap_client_set(
+    enum golioth_status status = golioth_coap_client_set(
             client,
             GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
             path,
@@ -129,7 +129,7 @@ golioth_status_t golioth_lightdb_set_string_async(
     return status;
 }
 
-golioth_status_t golioth_lightdb_set_async(
+enum golioth_status golioth_lightdb_set_async(
         struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
@@ -150,7 +150,7 @@ golioth_status_t golioth_lightdb_set_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_get_async(
+enum golioth_status golioth_lightdb_get_async(
         struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
@@ -167,7 +167,7 @@ golioth_status_t golioth_lightdb_get_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_delete_async(
+enum golioth_status golioth_lightdb_delete_async(
         struct golioth_client* client,
         const char* path,
         golioth_set_cb_fn callback,
@@ -182,7 +182,7 @@ golioth_status_t golioth_lightdb_delete_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_observe_async(
+enum golioth_status golioth_lightdb_observe_async(
         struct golioth_client* client,
         const char* path,
         golioth_get_cb_fn callback,
@@ -196,7 +196,7 @@ golioth_status_t golioth_lightdb_observe_async(
             arg);
 }
 
-golioth_status_t golioth_lightdb_set_int_sync(
+enum golioth_status golioth_lightdb_set_int_sync(
         struct golioth_client* client,
         const char* path,
         int32_t value,
@@ -216,7 +216,7 @@ golioth_status_t golioth_lightdb_set_int_sync(
             timeout_s);
 }
 
-golioth_status_t golioth_lightdb_set_bool_sync(
+enum golioth_status golioth_lightdb_set_bool_sync(
         struct golioth_client* client,
         const char* path,
         bool value,
@@ -235,7 +235,7 @@ golioth_status_t golioth_lightdb_set_bool_sync(
             timeout_s);
 }
 
-golioth_status_t golioth_lightdb_set_float_sync(
+enum golioth_status golioth_lightdb_set_float_sync(
         struct golioth_client* client,
         const char* path,
         float value,
@@ -255,7 +255,7 @@ golioth_status_t golioth_lightdb_set_float_sync(
             timeout_s);
 }
 
-golioth_status_t golioth_lightdb_set_string_sync(
+enum golioth_status golioth_lightdb_set_string_sync(
         struct golioth_client* client,
         const char* path,
         const char* str,
@@ -271,7 +271,7 @@ golioth_status_t golioth_lightdb_set_string_sync(
     memset(buf, 0, bufsize);
     snprintf(buf, bufsize, "\"%s\"", str);
 
-    golioth_status_t status = golioth_coap_client_set(
+    enum golioth_status status = golioth_coap_client_set(
             client,
             GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
             path,
@@ -287,7 +287,7 @@ golioth_status_t golioth_lightdb_set_string_sync(
     return status;
 }
 
-golioth_status_t golioth_lightdb_set_sync(
+enum golioth_status golioth_lightdb_set_sync(
         struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
@@ -351,7 +351,7 @@ static void on_payload(
     }
 }
 
-golioth_status_t golioth_lightdb_get_int_sync(
+enum golioth_status golioth_lightdb_get_int_sync(
         struct golioth_client* client,
         const char* path,
         int32_t* value,
@@ -360,7 +360,7 @@ golioth_status_t golioth_lightdb_get_int_sync(
             .type = LIGHTDB_GET_TYPE_INT,
             .i = value,
     };
-    golioth_status_t status = golioth_coap_client_get(
+    enum golioth_status status = golioth_coap_client_get(
             client,
             GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
             path,
@@ -375,7 +375,7 @@ golioth_status_t golioth_lightdb_get_int_sync(
     return status;
 }
 
-golioth_status_t golioth_lightdb_get_bool_sync(
+enum golioth_status golioth_lightdb_get_bool_sync(
         struct golioth_client* client,
         const char* path,
         bool* value,
@@ -384,7 +384,7 @@ golioth_status_t golioth_lightdb_get_bool_sync(
             .type = LIGHTDB_GET_TYPE_BOOL,
             .b = value,
     };
-    golioth_status_t status = golioth_coap_client_get(
+    enum golioth_status status = golioth_coap_client_get(
             client,
             GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
             path,
@@ -399,7 +399,7 @@ golioth_status_t golioth_lightdb_get_bool_sync(
     return status;
 }
 
-golioth_status_t golioth_lightdb_get_float_sync(
+enum golioth_status golioth_lightdb_get_float_sync(
         struct golioth_client* client,
         const char* path,
         float* value,
@@ -408,7 +408,7 @@ golioth_status_t golioth_lightdb_get_float_sync(
             .type = LIGHTDB_GET_TYPE_FLOAT,
             .f = value,
     };
-    golioth_status_t status = golioth_coap_client_get(
+    enum golioth_status status = golioth_coap_client_get(
             client,
             GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
             path,
@@ -423,7 +423,7 @@ golioth_status_t golioth_lightdb_get_float_sync(
     return status;
 }
 
-golioth_status_t golioth_lightdb_get_string_sync(
+enum golioth_status golioth_lightdb_get_string_sync(
         struct golioth_client* client,
         const char* path,
         char* strbuf,
@@ -434,7 +434,7 @@ golioth_status_t golioth_lightdb_get_string_sync(
             .buf = (uint8_t *) strbuf,
             .buf_size = strbuf_size,
     };
-    golioth_status_t status = golioth_coap_client_get(
+    enum golioth_status status = golioth_coap_client_get(
             client,
             GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
             path,
@@ -449,7 +449,7 @@ golioth_status_t golioth_lightdb_get_string_sync(
     return status;
 }
 
-golioth_status_t golioth_lightdb_get_sync(
+enum golioth_status golioth_lightdb_get_sync(
         struct golioth_client* client,
         const char* path,
         enum golioth_content_type content_type,
@@ -463,7 +463,7 @@ golioth_status_t golioth_lightdb_get_sync(
             .buf = buf,
             .buf_size = *buf_size,
     };
-    golioth_status_t status = golioth_coap_client_get(
+    enum golioth_status status = golioth_coap_client_get(
             client,
             GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
             path,
@@ -479,7 +479,7 @@ golioth_status_t golioth_lightdb_get_sync(
     return status;
 }
 
-golioth_status_t golioth_lightdb_delete_sync(
+enum golioth_status golioth_lightdb_delete_sync(
         struct golioth_client* client,
         const char* path,
         int32_t timeout_s) {

--- a/src/lightdb_stream.c
+++ b/src/lightdb_stream.c
@@ -12,7 +12,7 @@
 
 #define GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX ".s/"
 
-golioth_status_t golioth_lightdb_stream_set_int_async(
+enum golioth_status golioth_lightdb_stream_set_int_async(
         struct golioth_client* client,
         const char* path,
         int32_t value,
@@ -34,7 +34,7 @@ golioth_status_t golioth_lightdb_stream_set_int_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_stream_set_bool_async(
+enum golioth_status golioth_lightdb_stream_set_bool_async(
         struct golioth_client* client,
         const char* path,
         bool value,
@@ -55,7 +55,7 @@ golioth_status_t golioth_lightdb_stream_set_bool_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_stream_set_float_async(
+enum golioth_status golioth_lightdb_stream_set_float_async(
         struct golioth_client* client,
         const char* path,
         float value,
@@ -77,7 +77,7 @@ golioth_status_t golioth_lightdb_stream_set_float_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_stream_set_string_async(
+enum golioth_status golioth_lightdb_stream_set_string_async(
         struct golioth_client* client,
         const char* path,
         const char* str,
@@ -100,7 +100,7 @@ golioth_status_t golioth_lightdb_stream_set_string_async(
     memset(buf, 0, bufsize);
     snprintf(buf, bufsize, "\"%s\"", str);
 
-    golioth_status_t status = golioth_coap_client_set(
+    enum golioth_status status = golioth_coap_client_set(
             client,
             GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX,
             path,
@@ -116,7 +116,7 @@ golioth_status_t golioth_lightdb_stream_set_string_async(
     return status;
 }
 
-golioth_status_t golioth_lightdb_stream_set_json_async(
+enum golioth_status golioth_lightdb_stream_set_json_async(
         struct golioth_client* client,
         const char* path,
         const char* json_str,
@@ -137,7 +137,7 @@ golioth_status_t golioth_lightdb_stream_set_json_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_stream_set_cbor_async(
+enum golioth_status golioth_lightdb_stream_set_cbor_async(
         struct golioth_client* client,
         const char* path,
         const uint8_t* cbor_data,
@@ -158,7 +158,7 @@ golioth_status_t golioth_lightdb_stream_set_cbor_async(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_stream_set_int_sync(
+enum golioth_status golioth_lightdb_stream_set_int_sync(
         struct golioth_client* client,
         const char* path,
         int32_t value,
@@ -179,7 +179,7 @@ golioth_status_t golioth_lightdb_stream_set_int_sync(
             timeout_s);
 }
 
-golioth_status_t golioth_lightdb_stream_set_bool_sync(
+enum golioth_status golioth_lightdb_stream_set_bool_sync(
         struct golioth_client* client,
         const char* path,
         bool value,
@@ -199,7 +199,7 @@ golioth_status_t golioth_lightdb_stream_set_bool_sync(
             timeout_s);
 }
 
-golioth_status_t golioth_lightdb_stream_set_float_sync(
+enum golioth_status golioth_lightdb_stream_set_float_sync(
         struct golioth_client* client,
         const char* path,
         float value,
@@ -220,7 +220,7 @@ golioth_status_t golioth_lightdb_stream_set_float_sync(
             timeout_s);
 }
 
-golioth_status_t golioth_lightdb_stream_set_string_sync(
+enum golioth_status golioth_lightdb_stream_set_string_sync(
         struct golioth_client* client,
         const char* path,
         const char* str,
@@ -237,7 +237,7 @@ golioth_status_t golioth_lightdb_stream_set_string_sync(
     memset(buf, 0, bufsize);
     snprintf(buf, bufsize, "\"%s\"", str);
 
-    golioth_status_t status = golioth_coap_client_set(
+    enum golioth_status status = golioth_coap_client_set(
             client,
             GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX,
             path,
@@ -253,7 +253,7 @@ golioth_status_t golioth_lightdb_stream_set_string_sync(
     return status;
 }
 
-golioth_status_t golioth_lightdb_stream_set_json_sync(
+enum golioth_status golioth_lightdb_stream_set_json_sync(
         struct golioth_client* client,
         const char* path,
         const char* json_str,
@@ -273,7 +273,7 @@ golioth_status_t golioth_lightdb_stream_set_json_sync(
             timeout_s);
 }
 
-golioth_status_t golioth_lightdb_stream_set_cbor_sync(
+enum golioth_status golioth_lightdb_stream_set_cbor_sync(
         struct golioth_client* client,
         const char* path,
         const uint8_t* cbor_data,

--- a/src/lightdb_stream.c
+++ b/src/lightdb_stream.c
@@ -13,7 +13,7 @@
 #define GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX ".s/"
 
 golioth_status_t golioth_lightdb_stream_set_int_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t value,
         golioth_set_cb_fn callback,
@@ -35,7 +35,7 @@ golioth_status_t golioth_lightdb_stream_set_int_async(
 }
 
 golioth_status_t golioth_lightdb_stream_set_bool_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         bool value,
         golioth_set_cb_fn callback,
@@ -56,7 +56,7 @@ golioth_status_t golioth_lightdb_stream_set_bool_async(
 }
 
 golioth_status_t golioth_lightdb_stream_set_float_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         float value,
         golioth_set_cb_fn callback,
@@ -78,7 +78,7 @@ golioth_status_t golioth_lightdb_stream_set_float_async(
 }
 
 golioth_status_t golioth_lightdb_stream_set_string_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* str,
         size_t str_len,
@@ -117,7 +117,7 @@ golioth_status_t golioth_lightdb_stream_set_string_async(
 }
 
 golioth_status_t golioth_lightdb_stream_set_json_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* json_str,
         size_t json_str_len,
@@ -138,7 +138,7 @@ golioth_status_t golioth_lightdb_stream_set_json_async(
 }
 
 golioth_status_t golioth_lightdb_stream_set_cbor_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const uint8_t* cbor_data,
         size_t cbor_data_len,
@@ -159,7 +159,7 @@ golioth_status_t golioth_lightdb_stream_set_cbor_async(
 }
 
 golioth_status_t golioth_lightdb_stream_set_int_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         int32_t value,
         int32_t timeout_s)
@@ -180,7 +180,7 @@ golioth_status_t golioth_lightdb_stream_set_int_sync(
 }
 
 golioth_status_t golioth_lightdb_stream_set_bool_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         bool value,
         int32_t timeout_s)
@@ -200,7 +200,7 @@ golioth_status_t golioth_lightdb_stream_set_bool_sync(
 }
 
 golioth_status_t golioth_lightdb_stream_set_float_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         float value,
         int32_t timeout_s)
@@ -221,7 +221,7 @@ golioth_status_t golioth_lightdb_stream_set_float_sync(
 }
 
 golioth_status_t golioth_lightdb_stream_set_string_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* str,
         size_t str_len,
@@ -254,7 +254,7 @@ golioth_status_t golioth_lightdb_stream_set_string_sync(
 }
 
 golioth_status_t golioth_lightdb_stream_set_json_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const char* json_str,
         size_t json_str_len,
@@ -274,7 +274,7 @@ golioth_status_t golioth_lightdb_stream_set_json_sync(
 }
 
 golioth_status_t golioth_lightdb_stream_set_cbor_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path,
         const uint8_t* cbor_data,
         size_t cbor_data_len,

--- a/src/log.c
+++ b/src/log.c
@@ -34,7 +34,7 @@ static const char* _level_to_str[GOLIOTH_LOG_LEVEL_DEBUG + 1] = {
         [GOLIOTH_LOG_LEVEL_DEBUG] = "debug"};
 
 static golioth_status_t golioth_log_internal(
-        golioth_client_t client,
+        struct golioth_client* client,
         golioth_log_level_t level,
         const char* tag,
         const char* log_message,
@@ -89,7 +89,7 @@ cleanup:
 }
 
 golioth_status_t golioth_log_error_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         golioth_set_cb_fn callback,
@@ -106,7 +106,7 @@ golioth_status_t golioth_log_error_async(
 }
 
 golioth_status_t golioth_log_warn_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         golioth_set_cb_fn callback,
@@ -123,7 +123,7 @@ golioth_status_t golioth_log_warn_async(
 }
 
 golioth_status_t golioth_log_info_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         golioth_set_cb_fn callback,
@@ -140,7 +140,7 @@ golioth_status_t golioth_log_info_async(
 }
 
 golioth_status_t golioth_log_debug_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         golioth_set_cb_fn callback,
@@ -157,7 +157,7 @@ golioth_status_t golioth_log_debug_async(
 }
 
 golioth_status_t golioth_log_error_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s) {
@@ -166,7 +166,7 @@ golioth_status_t golioth_log_error_sync(
 }
 
 golioth_status_t golioth_log_warn_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s) {
@@ -175,7 +175,7 @@ golioth_status_t golioth_log_warn_sync(
 }
 
 golioth_status_t golioth_log_info_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s) {
@@ -184,7 +184,7 @@ golioth_status_t golioth_log_info_sync(
 }
 
 golioth_status_t golioth_log_debug_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* tag,
         const char* log_message,
         int32_t timeout_s) {

--- a/src/log.c
+++ b/src/log.c
@@ -33,7 +33,7 @@ static const char* _level_to_str[GOLIOTH_LOG_LEVEL_DEBUG + 1] = {
         [GOLIOTH_LOG_LEVEL_INFO] = "info",
         [GOLIOTH_LOG_LEVEL_DEBUG] = "debug"};
 
-static golioth_status_t golioth_log_internal(
+static enum golioth_status golioth_log_internal(
         struct golioth_client* client,
         golioth_log_level_t level,
         const char* tag,
@@ -45,7 +45,7 @@ static golioth_status_t golioth_log_internal(
     assert(level <= GOLIOTH_LOG_LEVEL_DEBUG);
 
     uint8_t* cbor_buf = malloc(CBOR_LOG_MAX_LEN);
-    golioth_status_t status = GOLIOTH_ERR_SERIALIZE;
+    enum golioth_status status = GOLIOTH_ERR_SERIALIZE;
     bool ok;
 
     if (!cbor_buf) {
@@ -88,7 +88,7 @@ cleanup:
     return status;
 }
 
-golioth_status_t golioth_log_error_async(
+enum golioth_status golioth_log_error_async(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -105,7 +105,7 @@ golioth_status_t golioth_log_error_async(
             callback_arg);
 }
 
-golioth_status_t golioth_log_warn_async(
+enum golioth_status golioth_log_warn_async(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -122,7 +122,7 @@ golioth_status_t golioth_log_warn_async(
             callback_arg);
 }
 
-golioth_status_t golioth_log_info_async(
+enum golioth_status golioth_log_info_async(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -139,7 +139,7 @@ golioth_status_t golioth_log_info_async(
             callback_arg);
 }
 
-golioth_status_t golioth_log_debug_async(
+enum golioth_status golioth_log_debug_async(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -156,7 +156,7 @@ golioth_status_t golioth_log_debug_async(
             callback_arg);
 }
 
-golioth_status_t golioth_log_error_sync(
+enum golioth_status golioth_log_error_sync(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -165,7 +165,7 @@ golioth_status_t golioth_log_error_sync(
             client, GOLIOTH_LOG_LEVEL_ERROR, tag, log_message, true, timeout_s, NULL, NULL);
 }
 
-golioth_status_t golioth_log_warn_sync(
+enum golioth_status golioth_log_warn_sync(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -174,7 +174,7 @@ golioth_status_t golioth_log_warn_sync(
             client, GOLIOTH_LOG_LEVEL_WARN, tag, log_message, true, timeout_s, NULL, NULL);
 }
 
-golioth_status_t golioth_log_info_sync(
+enum golioth_status golioth_log_info_sync(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,
@@ -183,7 +183,7 @@ golioth_status_t golioth_log_info_sync(
             client, GOLIOTH_LOG_LEVEL_INFO, tag, log_message, true, timeout_s, NULL, NULL);
 }
 
-golioth_status_t golioth_log_debug_sync(
+enum golioth_status golioth_log_debug_sync(
         struct golioth_client* client,
         const char* tag,
         const char* log_message,

--- a/src/ota.c
+++ b/src/ota.c
@@ -74,7 +74,7 @@ const golioth_ota_component_t* golioth_ota_find_component(
 }
 
 golioth_status_t golioth_ota_observe_manifest_async(
-        golioth_client_t client,
+        struct golioth_client* client,
         golioth_get_cb_fn callback,
         void* arg) {
     return golioth_coap_client_observe_async(
@@ -82,7 +82,7 @@ golioth_status_t golioth_ota_observe_manifest_async(
 }
 
 golioth_status_t golioth_ota_report_state_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         golioth_ota_state_t state,
         golioth_ota_reason_t reason,
         const char* package,
@@ -251,7 +251,7 @@ golioth_status_t golioth_ota_payload_as_manifest(
 }
 
 static void on_block_rcvd(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -278,7 +278,7 @@ static void on_block_rcvd(
 }
 
 golioth_status_t golioth_ota_get_block_sync(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* package,
         const char* version,
         size_t block_index,

--- a/src/ota.c
+++ b/src/ota.c
@@ -73,7 +73,7 @@ const golioth_ota_component_t* golioth_ota_find_component(
     return found;
 }
 
-golioth_status_t golioth_ota_observe_manifest_async(
+enum golioth_status golioth_ota_observe_manifest_async(
         struct golioth_client* client,
         golioth_get_cb_fn callback,
         void* arg) {
@@ -81,7 +81,7 @@ golioth_status_t golioth_ota_observe_manifest_async(
             client, "", GOLIOTH_OTA_MANIFEST_PATH, GOLIOTH_CONTENT_TYPE_CBOR, callback, arg);
 }
 
-golioth_status_t golioth_ota_report_state_sync(
+enum golioth_status golioth_ota_report_state_sync(
         struct golioth_client* client,
         golioth_ota_state_t state,
         golioth_ota_reason_t reason,
@@ -218,7 +218,7 @@ static int components_decode(zcbor_state_t* zsd, void* value) {
     return 0;
 }
 
-golioth_status_t golioth_ota_payload_as_manifest(
+enum golioth_status golioth_ota_payload_as_manifest(
         const uint8_t* payload,
         size_t payload_size,
         golioth_ota_manifest_t* manifest) {
@@ -277,7 +277,7 @@ static void on_block_rcvd(
     *out_params->block_nbytes = payload_size;
 }
 
-golioth_status_t golioth_ota_get_block_sync(
+enum golioth_status golioth_ota_get_block_sync(
         struct golioth_client* client,
         const char* package,
         const char* version,
@@ -300,7 +300,7 @@ golioth_status_t golioth_ota_get_block_sync(
     //
     // Ref: https://golioth.atlassian.net/wiki/spaces/EN/pages/262275073/OTA+Compressed+Artifacts
 
-    golioth_status_t status = GOLIOTH_OK;
+    enum golioth_status status = GOLIOTH_OK;
     status = golioth_coap_client_get_block(
             client,
             GOLIOTH_OTA_COMPONENT_PATH_PREFIX,

--- a/src/ota.c
+++ b/src/ota.c
@@ -47,7 +47,7 @@ struct component_tstr_value {
     size_t value_len;
 };
 
-static golioth_ota_state_t _state = GOLIOTH_OTA_STATE_IDLE;
+static enum golioth_ota_state _state = GOLIOTH_OTA_STATE_IDLE;
 
 size_t golioth_ota_size_to_nblocks(size_t component_size) {
     size_t nblocks = component_size / GOLIOTH_OTA_BLOCKSIZE;
@@ -57,13 +57,13 @@ size_t golioth_ota_size_to_nblocks(size_t component_size) {
     return nblocks;
 }
 
-const golioth_ota_component_t* golioth_ota_find_component(
-        const golioth_ota_manifest_t* manifest,
+const struct golioth_ota_component* golioth_ota_find_component(
+        const struct golioth_ota_manifest* manifest,
         const char* package) {
     // Scan the manifest until we find the component with matching package.
-    const golioth_ota_component_t* found = NULL;
+    const struct golioth_ota_component* found = NULL;
     for (size_t i = 0; i < manifest->num_components; i++) {
-        const golioth_ota_component_t* c = &manifest->components[i];
+        const struct golioth_ota_component* c = &manifest->components[i];
         bool matches = (0 == strcmp(c->package, package));
         if (matches) {
             found = c;
@@ -83,8 +83,8 @@ enum golioth_status golioth_ota_observe_manifest_async(
 
 enum golioth_status golioth_ota_report_state_sync(
         struct golioth_client* client,
-        golioth_ota_state_t state,
-        golioth_ota_reason_t reason,
+        enum golioth_ota_state state,
+        enum golioth_ota_reason reason,
         const char* package,
         const char* current_version,
         const char* target_version,
@@ -168,7 +168,7 @@ static int component_entry_decode_value(zcbor_state_t* zsd, void* void_value) {
 }
 
 static int components_decode(zcbor_state_t* zsd, void* value) {
-    golioth_ota_manifest_t* manifest = value;
+    struct golioth_ota_manifest* manifest = value;
     int err;
     bool ok;
 
@@ -179,7 +179,7 @@ static int components_decode(zcbor_state_t* zsd, void* value) {
     }
 
     for (size_t i = 0; i < ARRAY_SIZE(manifest->components) && !zcbor_list_or_map_end(zsd); i++) {
-        golioth_ota_component_t* component = &manifest->components[i];
+        struct golioth_ota_component* component = &manifest->components[i];
         struct component_tstr_value package = {
                 component->package,
                 sizeof(component->package) - 1,
@@ -221,7 +221,7 @@ static int components_decode(zcbor_state_t* zsd, void* value) {
 enum golioth_status golioth_ota_payload_as_manifest(
         const uint8_t* payload,
         size_t payload_size,
-        golioth_ota_manifest_t* manifest) {
+        struct golioth_ota_manifest* manifest) {
     ZCBOR_STATE_D(zsd, 3, payload, payload_size, 1);
     int64_t manifest_sequence_number;
     struct zcbor_map_entry map_entries[] = {
@@ -316,7 +316,7 @@ enum golioth_status golioth_ota_get_block_sync(
     return status;
 }
 
-golioth_ota_state_t golioth_ota_get_state(void) {
+enum golioth_ota_state golioth_ota_get_state(void) {
     return _state;
 }
 

--- a/src/ota.c
+++ b/src/ota.c
@@ -252,7 +252,7 @@ golioth_status_t golioth_ota_payload_as_manifest(
 
 static void on_block_rcvd(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -185,7 +185,7 @@ static void on_rpc(
             GOLIOTH_SYS_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_rpc_register(
+enum golioth_status golioth_rpc_register(
         struct golioth_client* client,
         const char* method,
         golioth_rpc_cb_fn callback,

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -66,7 +66,7 @@ static int params_decode(zcbor_state_t* zsd, void* value) {
 }
 
 static void on_rpc(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -186,7 +186,7 @@ static void on_rpc(
 }
 
 golioth_status_t golioth_rpc_register(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* method,
         golioth_rpc_cb_fn callback,
         void* callback_arg) {

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -113,13 +113,13 @@ static void on_rpc(
         return;
     }
 
-    golioth_rpc_t* grpc = golioth_coap_client_get_rpc(client);
+    struct golioth_rpc* grpc = golioth_coap_client_get_rpc(client);
 
-    const golioth_rpc_method_t* matching_rpc = NULL;
-    golioth_rpc_status_t status = GOLIOTH_RPC_UNKNOWN;
+    const struct golioth_rpc_method* matching_rpc = NULL;
+    enum golioth_rpc_status status = GOLIOTH_RPC_UNKNOWN;
 
     for (int i = 0; i < grpc->num_rpcs; i++) {
-        const golioth_rpc_method_t* rpc = &grpc->rpcs[i];
+        const struct golioth_rpc_method* rpc = &grpc->rpcs[i];
         if (strlen(rpc->method) == method.len
             && strncmp(rpc->method, (char*)method.value, method.len) == 0) {
             matching_rpc = rpc;
@@ -190,7 +190,7 @@ enum golioth_status golioth_rpc_register(
         const char* method,
         golioth_rpc_cb_fn callback,
         void* callback_arg) {
-    golioth_rpc_t* grpc = golioth_coap_client_get_rpc(client);
+    struct golioth_rpc* grpc = golioth_coap_client_get_rpc(client);
 
     if (grpc->num_rpcs >= CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS) {
         GLTH_LOGE(
@@ -200,7 +200,7 @@ enum golioth_status golioth_rpc_register(
         return GOLIOTH_ERR_MEM_ALLOC;
     }
 
-    golioth_rpc_method_t* rpc = &grpc->rpcs[grpc->num_rpcs];
+    struct golioth_rpc_method* rpc = &grpc->rpcs[grpc->num_rpcs];
 
     rpc->method = method;
     rpc->callback = callback;

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -67,7 +67,7 @@ static int params_decode(zcbor_state_t* zsd, void* value) {
 
 static void on_rpc(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,

--- a/src/settings.c
+++ b/src/settings.c
@@ -338,7 +338,7 @@ static void settings_lazy_init(struct golioth_client* client) {
         return;
     }
 
-    golioth_status_t status = golioth_coap_client_observe_async(
+    enum golioth_status status = golioth_coap_client_observe_async(
             client, SETTINGS_PATH_PREFIX, "", GOLIOTH_CONTENT_TYPE_CBOR, on_settings, NULL);
 
     if (status != GOLIOTH_OK) {
@@ -365,7 +365,7 @@ golioth_setting_t* alloc_setting(struct golioth_client* client) {
     return &gsettings->settings[gsettings->num_settings++];
 }
 
-golioth_status_t golioth_settings_register_int(
+enum golioth_status golioth_settings_register_int(
         struct golioth_client* client,
         const char* setting_name,
         golioth_int_setting_cb callback,
@@ -374,7 +374,7 @@ golioth_status_t golioth_settings_register_int(
             client, setting_name, INT32_MIN, INT32_MAX, callback, callback_arg);
 }
 
-golioth_status_t golioth_settings_register_int_with_range(
+enum golioth_status golioth_settings_register_int_with_range(
         struct golioth_client* client,
         const char* setting_name,
         int32_t min_val,
@@ -402,7 +402,7 @@ golioth_status_t golioth_settings_register_int_with_range(
     return GOLIOTH_OK;
 }
 
-golioth_status_t golioth_settings_register_bool(
+enum golioth_status golioth_settings_register_bool(
         struct golioth_client* client,
         const char* setting_name,
         golioth_bool_setting_cb callback,
@@ -426,7 +426,7 @@ golioth_status_t golioth_settings_register_bool(
     return GOLIOTH_OK;
 }
 
-golioth_status_t golioth_settings_register_float(
+enum golioth_status golioth_settings_register_float(
         struct golioth_client* client,
         const char* setting_name,
         golioth_float_setting_cb callback,

--- a/src/settings.c
+++ b/src/settings.c
@@ -295,7 +295,7 @@ static int settings_decode(zcbor_state_t* zsd, void* value) {
 
 static void on_settings(
         struct golioth_client* client,
-        const golioth_response_t* response,
+        const struct golioth_response* response,
         const char* path,
         const uint8_t* payload,
         size_t payload_size,

--- a/src/settings.c
+++ b/src/settings.c
@@ -68,7 +68,7 @@ static void response_init(struct settings_response* response, struct golioth_cli
 static void add_error_to_response(
         struct settings_response* response,
         const char* key,
-        golioth_settings_status_t code) {
+        enum golioth_settings_status code) {
     if (response->num_errors == 0) {
         zcbor_tstr_put_lit(response->zse, "errors");
         zcbor_list_start_encode(response->zse, ZCBOR_MAX_ELEM_COUNT);
@@ -87,9 +87,9 @@ static void add_error_to_response(
     response->num_errors++;
 }
 
-static golioth_setting_t* find_registered_setting(golioth_settings_t* gsettings, const char* key) {
+static struct golioth_setting* find_registered_setting(struct golioth_settings* gsettings, const char* key) {
     for (size_t i = 0; i < gsettings->num_settings; i++) {
-        golioth_setting_t* s = &gsettings->settings[i];
+        struct golioth_setting* s = &gsettings->settings[i];
         if (!s->is_valid) {
             continue;
         }
@@ -154,8 +154,8 @@ static int settings_decode(zcbor_state_t* zsd, void* value) {
     struct settings_response* settings_response = value;
     struct golioth_client* client = settings_response->client;
     struct zcbor_string label;
-    golioth_settings_status_t setting_status = GOLIOTH_SETTINGS_SUCCESS;
-    golioth_settings_t* gsettings = golioth_coap_client_get_settings(client);
+    enum golioth_settings_status setting_status = GOLIOTH_SETTINGS_SUCCESS;
+    struct golioth_settings* gsettings = golioth_coap_client_get_settings(client);
     bool ok;
 
     if (zcbor_nil_expect(zsd, NULL)) {
@@ -188,7 +188,7 @@ static int settings_decode(zcbor_state_t* zsd, void* value) {
 
         GLTH_LOGD(TAG, "key = %s, major_type = %d", key, major_type);
 
-        const golioth_setting_t* registered_setting = find_registered_setting(gsettings, key);
+        const struct golioth_setting* registered_setting = find_registered_setting(gsettings, key);
         if (!registered_setting) {
             add_error_to_response(settings_response, key, GOLIOTH_SETTINGS_VALUE_FORMAT_NOT_VALID);
 
@@ -332,7 +332,7 @@ static void on_settings(
 }
 
 static void settings_lazy_init(struct golioth_client* client) {
-    golioth_settings_t* gsettings = golioth_coap_client_get_settings(client);
+    struct golioth_settings* gsettings = golioth_coap_client_get_settings(client);
 
     if (gsettings->initialized) {
         return;
@@ -349,10 +349,10 @@ static void settings_lazy_init(struct golioth_client* client) {
     gsettings->initialized = true;
 }
 
-golioth_setting_t* alloc_setting(struct golioth_client* client) {
+struct golioth_setting* alloc_setting(struct golioth_client* client) {
     settings_lazy_init(client);
 
-    golioth_settings_t* gsettings = golioth_coap_client_get_settings(client);
+    struct golioth_settings* gsettings = golioth_coap_client_get_settings(client);
 
     if (gsettings->num_settings == CONFIG_GOLIOTH_MAX_NUM_SETTINGS) {
         GLTH_LOGE(
@@ -386,7 +386,7 @@ enum golioth_status golioth_settings_register_int_with_range(
         return GOLIOTH_ERR_NULL;
     }
 
-    golioth_setting_t* new_setting = alloc_setting(client);
+    struct golioth_setting* new_setting = alloc_setting(client);
     if (!new_setting) {
         return GOLIOTH_ERR_MEM_ALLOC;
     }
@@ -412,7 +412,7 @@ enum golioth_status golioth_settings_register_bool(
         return GOLIOTH_ERR_NULL;
     }
 
-    golioth_setting_t* new_setting = alloc_setting(client);
+    struct golioth_setting* new_setting = alloc_setting(client);
     if (!new_setting) {
         return GOLIOTH_ERR_MEM_ALLOC;
     }
@@ -436,7 +436,7 @@ enum golioth_status golioth_settings_register_float(
         return GOLIOTH_ERR_NULL;
     }
 
-    golioth_setting_t* new_setting = alloc_setting(client);
+    struct golioth_setting* new_setting = alloc_setting(client);
     if (!new_setting) {
         return GOLIOTH_ERR_MEM_ALLOC;
     }

--- a/src/settings.c
+++ b/src/settings.c
@@ -50,10 +50,10 @@ struct settings_response {
     zcbor_state_t zse[1 /* num_backups */ + 2];
     uint8_t buf[GOLIOTH_SETTINGS_MAX_RESPONSE_LEN];
     size_t num_errors;
-    golioth_client_t client;
+    struct golioth_client* client;
 };
 
-static void response_init(struct settings_response* response, golioth_client_t client) {
+static void response_init(struct settings_response* response, struct golioth_client* client) {
     memset(response, 0, sizeof(*response));
 
     response->client = client;
@@ -101,7 +101,7 @@ static golioth_setting_t* find_registered_setting(golioth_settings_t* gsettings,
 }
 
 static int finalize_and_send_response(
-        golioth_client_t client,
+        struct golioth_client* client,
         struct settings_response* response,
         int64_t version) {
     bool ok;
@@ -152,7 +152,7 @@ static int finalize_and_send_response(
 
 static int settings_decode(zcbor_state_t* zsd, void* value) {
     struct settings_response* settings_response = value;
-    golioth_client_t client = settings_response->client;
+    struct golioth_client* client = settings_response->client;
     struct zcbor_string label;
     golioth_settings_status_t setting_status = GOLIOTH_SETTINGS_SUCCESS;
     golioth_settings_t* gsettings = golioth_coap_client_get_settings(client);
@@ -294,7 +294,7 @@ static int settings_decode(zcbor_state_t* zsd, void* value) {
 }
 
 static void on_settings(
-        golioth_client_t client,
+        struct golioth_client* client,
         const golioth_response_t* response,
         const char* path,
         const uint8_t* payload,
@@ -331,7 +331,7 @@ static void on_settings(
     finalize_and_send_response(client, &settings_response, version);
 }
 
-static void settings_lazy_init(golioth_client_t client) {
+static void settings_lazy_init(struct golioth_client* client) {
     golioth_settings_t* gsettings = golioth_coap_client_get_settings(client);
 
     if (gsettings->initialized) {
@@ -349,7 +349,7 @@ static void settings_lazy_init(golioth_client_t client) {
     gsettings->initialized = true;
 }
 
-golioth_setting_t* alloc_setting(golioth_client_t client) {
+golioth_setting_t* alloc_setting(struct golioth_client* client) {
     settings_lazy_init(client);
 
     golioth_settings_t* gsettings = golioth_coap_client_get_settings(client);
@@ -366,7 +366,7 @@ golioth_setting_t* alloc_setting(golioth_client_t client) {
 }
 
 golioth_status_t golioth_settings_register_int(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* setting_name,
         golioth_int_setting_cb callback,
         void* callback_arg) {
@@ -375,7 +375,7 @@ golioth_status_t golioth_settings_register_int(
 }
 
 golioth_status_t golioth_settings_register_int_with_range(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* setting_name,
         int32_t min_val,
         int32_t max_val,
@@ -403,7 +403,7 @@ golioth_status_t golioth_settings_register_int_with_range(
 }
 
 golioth_status_t golioth_settings_register_bool(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* setting_name,
         golioth_bool_setting_cb callback,
         void* callback_arg) {
@@ -427,7 +427,7 @@ golioth_status_t golioth_settings_register_bool(
 }
 
 golioth_status_t golioth_settings_register_float(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* setting_name,
         golioth_float_setting_cb callback,
         void* callback_arg) {

--- a/tests/hil/platform/esp-idf/main/app_main.c
+++ b/tests/hil/platform/esp-idf/main/app_main.c
@@ -13,7 +13,7 @@
 
 #define TAG "hil_test"
 
-void hil_test_entry(const golioth_client_config_t *config);
+void hil_test_entry(const struct golioth_client_config *config);
 
 void app_main(void) {
     // Initialize NVS first.
@@ -42,7 +42,7 @@ void app_main(void) {
     const char* psk_id = nvs_read_golioth_psk_id();
     const char* psk = nvs_read_golioth_psk();
 
-    golioth_client_config_t config = {
+    struct golioth_client_config config = {
             .credentials = {
                     .auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
                     .psk = {

--- a/tests/hil/platform/zephyr/src/main.c
+++ b/tests/hil/platform/zephyr/src/main.c
@@ -10,7 +10,7 @@ LOG_MODULE_REGISTER(test, LOG_LEVEL_DBG);
 #include <samples/common/net_connect.h>
 #include <samples/common/sample_credentials.h>
 
-void hil_test_entry(const golioth_client_config_t *config);
+void hil_test_entry(const struct golioth_client_config *config);
 
 int main(void)
 {

--- a/tests/hil/tests/connection/test.c
+++ b/tests/hil/tests/connection/test.c
@@ -5,7 +5,7 @@ LOG_TAG_DEFINE(test_connect);
 
 void hil_test_entry(const golioth_client_config_t *config)
 {
-    golioth_client_t client = golioth_client_create(config);
+    struct golioth_client* client = golioth_client_create(config);
 
     (void) client;
 

--- a/tests/hil/tests/connection/test.c
+++ b/tests/hil/tests/connection/test.c
@@ -3,7 +3,7 @@
 
 LOG_TAG_DEFINE(test_connect);
 
-void hil_test_entry(const golioth_client_config_t *config)
+void hil_test_entry(const struct golioth_client_config *config)
 {
     struct golioth_client* client = golioth_client_create(config);
 

--- a/tests/unit_tests/fakes/coap_client_fake.c
+++ b/tests/unit_tests/fakes/coap_client_fake.c
@@ -1,7 +1,7 @@
 #include <fff.h>
 #include "coap_client_fake.h"
 
-DEFINE_FAKE_VALUE_FUNC(golioth_rpc_t*, golioth_coap_client_get_rpc, struct golioth_client*);
+DEFINE_FAKE_VALUE_FUNC(struct golioth_rpc*, golioth_coap_client_get_rpc, struct golioth_client*);
 DEFINE_FAKE_VALUE_FUNC(
         enum golioth_status,
         golioth_coap_client_observe_async,

--- a/tests/unit_tests/fakes/coap_client_fake.c
+++ b/tests/unit_tests/fakes/coap_client_fake.c
@@ -3,7 +3,7 @@
 
 DEFINE_FAKE_VALUE_FUNC(golioth_rpc_t*, golioth_coap_client_get_rpc, struct golioth_client*);
 DEFINE_FAKE_VALUE_FUNC(
-        golioth_status_t,
+        enum golioth_status,
         golioth_coap_client_observe_async,
         struct golioth_client*,
         const char*,
@@ -12,7 +12,7 @@ DEFINE_FAKE_VALUE_FUNC(
         golioth_get_cb_fn,
         void*);
 DEFINE_FAKE_VALUE_FUNC(
-        golioth_status_t,
+        enum golioth_status,
         golioth_coap_client_set,
         struct golioth_client*,
         const char*,

--- a/tests/unit_tests/fakes/coap_client_fake.c
+++ b/tests/unit_tests/fakes/coap_client_fake.c
@@ -1,11 +1,11 @@
 #include <fff.h>
 #include "coap_client_fake.h"
 
-DEFINE_FAKE_VALUE_FUNC(golioth_rpc_t*, golioth_coap_client_get_rpc, golioth_client_t);
+DEFINE_FAKE_VALUE_FUNC(golioth_rpc_t*, golioth_coap_client_get_rpc, struct golioth_client*);
 DEFINE_FAKE_VALUE_FUNC(
         golioth_status_t,
         golioth_coap_client_observe_async,
-        golioth_client_t,
+        struct golioth_client*,
         const char*,
         const char*,
         uint32_t,
@@ -14,7 +14,7 @@ DEFINE_FAKE_VALUE_FUNC(
 DEFINE_FAKE_VALUE_FUNC(
         golioth_status_t,
         golioth_coap_client_set,
-        golioth_client_t,
+        struct golioth_client*,
         const char*,
         const char*,
         uint32_t,

--- a/tests/unit_tests/fakes/coap_client_fake.h
+++ b/tests/unit_tests/fakes/coap_client_fake.h
@@ -4,7 +4,7 @@
 
 DECLARE_FAKE_VALUE_FUNC(golioth_rpc_t*, golioth_coap_client_get_rpc, struct golioth_client*);
 DECLARE_FAKE_VALUE_FUNC(
-        golioth_status_t,
+        enum golioth_status,
         golioth_coap_client_observe_async,
         struct golioth_client*,
         const char*,
@@ -13,7 +13,7 @@ DECLARE_FAKE_VALUE_FUNC(
         golioth_get_cb_fn,
         void*);
 DECLARE_FAKE_VALUE_FUNC(
-        golioth_status_t,
+        enum golioth_status,
         golioth_coap_client_set,
         struct golioth_client*,
         const char*,

--- a/tests/unit_tests/fakes/coap_client_fake.h
+++ b/tests/unit_tests/fakes/coap_client_fake.h
@@ -2,11 +2,11 @@
 
 #include <coap_client.h>
 
-DECLARE_FAKE_VALUE_FUNC(golioth_rpc_t*, golioth_coap_client_get_rpc, golioth_client_t);
+DECLARE_FAKE_VALUE_FUNC(golioth_rpc_t*, golioth_coap_client_get_rpc, struct golioth_client*);
 DECLARE_FAKE_VALUE_FUNC(
         golioth_status_t,
         golioth_coap_client_observe_async,
-        golioth_client_t,
+        struct golioth_client*,
         const char*,
         const char*,
         uint32_t,
@@ -15,7 +15,7 @@ DECLARE_FAKE_VALUE_FUNC(
 DECLARE_FAKE_VALUE_FUNC(
         golioth_status_t,
         golioth_coap_client_set,
-        golioth_client_t,
+        struct golioth_client*,
         const char*,
         const char*,
         uint32_t,

--- a/tests/unit_tests/fakes/coap_client_fake.h
+++ b/tests/unit_tests/fakes/coap_client_fake.h
@@ -2,7 +2,7 @@
 
 #include <coap_client.h>
 
-DECLARE_FAKE_VALUE_FUNC(golioth_rpc_t*, golioth_coap_client_get_rpc, struct golioth_client*);
+DECLARE_FAKE_VALUE_FUNC(struct golioth_rpc*, golioth_coap_client_get_rpc, struct golioth_client*);
 DECLARE_FAKE_VALUE_FUNC(
         enum golioth_status,
         golioth_coap_client_observe_async,

--- a/tests/unit_tests/test_rpc.c
+++ b/tests/unit_tests/test_rpc.c
@@ -26,7 +26,7 @@ golioth_rpc_t grpc_fake;
 uint8_t last_coap_payload[256];
 size_t last_coap_payload_size;
 
-golioth_status_t golioth_coap_client_set_custom_fake(
+enum golioth_status golioth_coap_client_set_custom_fake(
         struct golioth_client* client,
         const char* path_prefix,
         const char* path,
@@ -60,7 +60,7 @@ void tearDown(void) {
 }
 
 void test_rpc_register(void) {
-    golioth_status_t ret = golioth_rpc_register(NULL, "", NULL, NULL);
+    enum golioth_status ret = golioth_rpc_register(NULL, "", NULL, NULL);
 
     TEST_ASSERT_EQUAL(GOLIOTH_OK, ret);
     TEST_ASSERT_EQUAL(1, grpc_fake.num_rpcs);
@@ -69,7 +69,7 @@ void test_rpc_register(void) {
 
 void test_rpc_register_multi(void) {
     for (int i = 0; i < 3; i++) {
-        golioth_status_t ret = golioth_rpc_register(NULL, "", NULL, NULL);
+        enum golioth_status ret = golioth_rpc_register(NULL, "", NULL, NULL);
         TEST_ASSERT_EQUAL(GOLIOTH_OK, ret);
     }
 
@@ -79,11 +79,11 @@ void test_rpc_register_multi(void) {
 
 void test_rpc_register_too_many(void) {
     for (int i = 0; i < CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS; i++) {
-        golioth_status_t ret = golioth_rpc_register(NULL, "", NULL, NULL);
+        enum golioth_status ret = golioth_rpc_register(NULL, "", NULL, NULL);
         TEST_ASSERT_EQUAL(GOLIOTH_OK, ret);
     }
 
-    golioth_status_t ret = golioth_rpc_register(NULL, "", NULL, NULL);
+    enum golioth_status ret = golioth_rpc_register(NULL, "", NULL, NULL);
     TEST_ASSERT_EQUAL(GOLIOTH_ERR_MEM_ALLOC, ret);
 
     TEST_ASSERT_EQUAL(8, grpc_fake.num_rpcs);
@@ -215,7 +215,7 @@ void test_rpc_call_not_registered(void) {
 }
 
 void test_rpc_call_one(void) {
-    golioth_status_t ret = golioth_rpc_register(NULL, "test", test_rpc_method_fn, NULL);
+    enum golioth_status ret = golioth_rpc_register(NULL, "test", test_rpc_method_fn, NULL);
     TEST_ASSERT_EQUAL(GOLIOTH_OK, ret);
 
     const uint8_t payload[] = {
@@ -267,7 +267,7 @@ golioth_rpc_status_t rpc_method_fake(
 
 void test_rpc_call_with_return(void) {
     test_rpc_method_fn_fake.custom_fake = rpc_method_fake;
-    golioth_status_t ret = golioth_rpc_register(NULL, "test", test_rpc_method_fn, NULL);
+    enum golioth_status ret = golioth_rpc_register(NULL, "test", test_rpc_method_fn, NULL);
     TEST_ASSERT_EQUAL(GOLIOTH_OK, ret);
 
     const uint8_t payload[] = {
@@ -314,7 +314,7 @@ void test_rpc_call_with_return(void) {
 
 void test_rpc_call_one_with_params(void) {
     test_rpc_method_fn_fake.custom_fake = rpc_method_fake;
-    golioth_status_t ret = golioth_rpc_register(NULL, "test", test_rpc_method_fn, (void*)true);
+    enum golioth_status ret = golioth_rpc_register(NULL, "test", test_rpc_method_fn, (void*)true);
     TEST_ASSERT_EQUAL(GOLIOTH_OK, ret);
 
     const uint8_t payload[] = {
@@ -340,7 +340,7 @@ void test_rpc_call_one_with_params(void) {
 }
 
 void test_rpc_call_same_multiple(void) {
-    golioth_status_t ret = golioth_rpc_register(NULL, "test", test_rpc_method_fn, NULL);
+    enum golioth_status ret = golioth_rpc_register(NULL, "test", test_rpc_method_fn, NULL);
     TEST_ASSERT_EQUAL(GOLIOTH_OK, ret);
 
     const uint8_t payload[] = {
@@ -370,7 +370,7 @@ void test_rpc_register_many_call_all(void) {
     char* method_names[CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS];
     for (int i = 0; i < CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS; i++) {
         asprintf(&method_names[i], "test%d", i);
-        golioth_status_t ret =
+        enum golioth_status ret =
                 golioth_rpc_register(NULL, method_names[i], test_rpc_method_fn, NULL);
         TEST_ASSERT_EQUAL(GOLIOTH_OK, ret);
     }

--- a/tests/unit_tests/test_rpc.c
+++ b/tests/unit_tests/test_rpc.c
@@ -27,7 +27,7 @@ uint8_t last_coap_payload[256];
 size_t last_coap_payload_size;
 
 golioth_status_t golioth_coap_client_set_custom_fake(
-        golioth_client_t client,
+        struct golioth_client* client,
         const char* path_prefix,
         const char* path,
         uint32_t content_type,

--- a/tests/unit_tests/test_rpc.c
+++ b/tests/unit_tests/test_rpc.c
@@ -20,9 +20,9 @@ static const char* last_wrn_msg = NULL;
 #include "fakes/coap_client_fake.h"
 #include "../../src/rpc.c"
 
-FAKE_VALUE_FUNC(golioth_rpc_status_t, test_rpc_method_fn, zcbor_state_t*, zcbor_state_t*, void*);
+FAKE_VALUE_FUNC(enum golioth_rpc_status, test_rpc_method_fn, zcbor_state_t*, zcbor_state_t*, void*);
 
-golioth_rpc_t grpc_fake;
+struct golioth_rpc grpc_fake;
 uint8_t last_coap_payload[256];
 size_t last_coap_payload_size;
 
@@ -240,7 +240,7 @@ void test_rpc_call_one(void) {
 /** Extract the major type, i.e. the first 3 bits of the header byte. */
 #define ZCBOR_MAJOR_TYPE(header_byte) ((zcbor_major_type_t)(((header_byte) >> 5) & 0x7))
 
-golioth_rpc_status_t rpc_method_fake(
+enum golioth_rpc_status rpc_method_fake(
         zcbor_state_t* request_params_array,
         zcbor_state_t* response_detail_map,
         void* callback_arg) {


### PR DESCRIPTION
We were using typedefs in 2 ways, both of which were problematic:

Using typedefs to create `void *` handles for the coap client. Typedef'ing a pointer prevents the `const` keyword from working correctly, and casting to `void *` prevents compile-time type checks. We want to hide the members of a struct, not the fact that the variable is a pointer to a struct, so we can use opaque structs instead.

Other times we would create a new type with typedef, but still expect the user to know the underlying type. E.g. by typedef'ing a struct and then requiring users to set or read members of that struct. In this case, using a typedef obscures information about the variable, but doesn't actually provide any encapsulation or abstraction. The end result is just code that's harder to read.

Resolves golioth/firmware-issue-tracker#362