### PR TITLE
Remove circular references between services and coap_client

### DIFF
--- a/examples/common/golioth_basics.c
+++ b/examples/common/golioth_basics.c
@@ -120,6 +120,9 @@ static void on_my_config(
 
 
 void golioth_basics(struct golioth_client* client) {
+    // Initialize the Settings service
+    struct golioth_settings* settings = golioth_settings_init(client);
+
     // Register a callback function that will be called by the client thread when
     // connect and disconnect events happen.
     //
@@ -222,7 +225,7 @@ void golioth_basics(struct golioth_client* client) {
 
     // We can register a callback for persistent settings. The Settings service
     // allows remote users to manage and push settings to devices.
-    golioth_settings_register_int(client, "LOOP_DELAY_S", on_loop_delay_setting, NULL);
+    golioth_settings_register_int(settings, "LOOP_DELAY_S", on_loop_delay_setting, NULL);
 
     // Now we'll just sit in a loop and update a LightDB state variable every
     // once in a while.

--- a/examples/common/golioth_basics.c
+++ b/examples/common/golioth_basics.c
@@ -120,8 +120,9 @@ static void on_my_config(
 
 
 void golioth_basics(struct golioth_client* client) {
-    // Initialize the Settings service
+    // Initialize the Settings and RPC services
     struct golioth_settings* settings = golioth_settings_init(client);
+    struct golioth_rpc* rpc = golioth_rpc_init(client);
 
     // Register a callback function that will be called by the client thread when
     // connect and disconnect events happen.
@@ -221,7 +222,7 @@ void golioth_basics(struct golioth_client* client) {
     //
     // In this case, the device provides a "multiply" method, which takes two integer
     // input parameters and multiplies them, returning the resulting value.
-    golioth_rpc_register(client, "multiply", on_multiply, NULL);
+    golioth_rpc_register(rpc, "multiply", on_multiply, NULL);
 
     // We can register a callback for persistent settings. The Settings service
     // allows remote users to manage and push settings to devices.

--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -110,9 +110,11 @@ static void test_golioth_client_create(void) {
         _client = golioth_client_create(&config);
 
         TEST_ASSERT_NOT_NULL(_client);
+
+        struct golioth_settings* settings = golioth_settings_init(_client);
         golioth_client_register_event_callback(_client, on_client_event, NULL);
         golioth_rpc_register(_client, "double", on_double, NULL);
-        golioth_settings_register_int(_client, "TEST_SETTING", on_test_setting, NULL);
+        golioth_settings_register_int(settings, "TEST_SETTING", on_test_setting, NULL);
     }
 }
 

--- a/examples/esp_idf/test/main/app_main.c
+++ b/examples/esp_idf/test/main/app_main.c
@@ -111,9 +111,11 @@ static void test_golioth_client_create(void) {
 
         TEST_ASSERT_NOT_NULL(_client);
 
+        struct golioth_rpc* rpc = golioth_rpc_init(_client);
         struct golioth_settings* settings = golioth_settings_init(_client);
+
         golioth_client_register_event_callback(_client, on_client_event, NULL);
-        golioth_rpc_register(_client, "double", on_double, NULL);
+        golioth_rpc_register(rpc, "double", on_double, NULL);
         golioth_settings_register_int(settings, "TEST_SETTING", on_test_setting, NULL);
     }
 }

--- a/examples/zephyr/rpc/src/main.c
+++ b/examples/zephyr/rpc/src/main.c
@@ -65,12 +65,13 @@ int main(void) {
     const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
     struct golioth_client* client = golioth_client_create(client_config);
+    struct golioth_rpc* rpc = golioth_rpc_init(client);
 
     golioth_client_register_event_callback(client, on_client_event, NULL);
 
     k_sem_take(&connected, K_FOREVER);
 
-    int err = golioth_rpc_register(client, "multiply", on_multiply, NULL);
+    int err = golioth_rpc_register(rpc, "multiply", on_multiply, NULL);
 
     if (err) {
         LOG_ERR("Failed to register RPC: %d", err);

--- a/examples/zephyr/settings/src/main.c
+++ b/examples/zephyr/settings/src/main.c
@@ -21,7 +21,6 @@ LOG_MODULE_REGISTER(device_settings, LOG_LEVEL_DBG);
 // Configurable via Settings service, key = "LOOP_DELAY_S"
 int32_t _loop_delay_s = 10;
 
-struct golioth_client* client;
 static K_SEM_DEFINE(connected, 0, 1);
 
 static enum golioth_settings_status on_loop_delay_setting(int32_t new_value, void* arg) {
@@ -51,11 +50,13 @@ int main(void) {
      */
     const struct golioth_client_config* client_config = golioth_sample_credentials_get();
 
-    client = golioth_client_create(client_config);
+    struct golioth_client* client = golioth_client_create(client_config);
 
     golioth_client_register_event_callback(client, on_client_event, NULL);
 
-    golioth_settings_register_int_with_range(client,
+    struct golioth_settings* settings = golioth_settings_init(client);
+
+    golioth_settings_register_int_with_range(settings,
                                              "LOOP_DELAY_S",
                                              LOOP_DELAY_S_MIN,
                                              LOOP_DELAY_S_MAX,

--- a/include/golioth/rpc.h
+++ b/include/golioth/rpc.h
@@ -9,11 +9,12 @@
 #include <zcbor_encode.h>
 #include <golioth/golioth_status.h>
 #include <golioth/client.h>
-#include <golioth/config.h>
 
 /// @defgroup golioth_rpc golioth_rpc
 /// Functions for interacting with the Golioth Remote Procedure Call service
 /// @{
+
+struct golioth_rpc;
 
 /// Enumeration of RPC status codes, sent in the RPC response
 enum golioth_rpc_status {
@@ -82,9 +83,17 @@ typedef enum golioth_rpc_status (*golioth_rpc_cb_fn)(
         zcbor_state_t* response_detail_map,
         void* callback_arg);
 
-/// Register an RPC method
+/// Initialize the RPC service
 ///
 /// @param client Golioth client handle
+///
+/// @return pointer to golioth rpc struct
+/// @return NULL - Error initializing RPC service
+struct golioth_rpc* golioth_rpc_init(struct golioth_client* client);
+
+/// Register an RPC method
+///
+/// @param grpc Golioth RPC service handle
 /// @param method The name of the method to register
 /// @param callback The callback to be invoked, when an RPC request with matching method name
 ///         is received by the client.
@@ -93,23 +102,9 @@ typedef enum golioth_rpc_status (*golioth_rpc_cb_fn)(
 /// @return GOLIOTH_OK - RPC method successfully registered
 /// @return otherwise - Error registering RPC method
 enum golioth_status golioth_rpc_register(
-        struct golioth_client* client,
+        struct golioth_rpc* grpc,
         const char* method,
         golioth_rpc_cb_fn callback,
         void* callback_arg);
-
-/// Private struct to contain data about a single registered method
-struct golioth_rpc_method {
-    const char* method;
-    golioth_rpc_cb_fn callback;
-    void* callback_arg;
-};
-
-/// Private struct to contain RPC state data, stored in
-/// the golioth_coap_client_t struct.
-struct golioth_rpc {
-    struct golioth_rpc_method rpcs[CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS];
-    int num_rpcs;
-};
 
 /// @}

--- a/include/golioth/settings.h
+++ b/include/golioth/settings.h
@@ -38,6 +38,9 @@
 ///
 /// @{
 
+/// Opaque struct for the Settings service
+struct golioth_settings;
+
 /// Enumeration of Settings status codes
 enum golioth_settings_status {
     /// Setting applied successfully to the device, stored in NVS
@@ -78,33 +81,17 @@ typedef enum golioth_settings_status (*golioth_float_setting_cb)(float new_value
 typedef enum golioth_settings_status (
         *golioth_string_setting_cb)(const char* new_value, size_t new_value_len, void* arg);
 
-/// Private struct for storing a single setting
-struct golioth_setting {
-    bool is_valid;
-    const char* key;  // aka name
-    enum golioth_settings_value_type type;
-    union {
-        golioth_int_setting_cb int_cb;
-        golioth_bool_setting_cb bool_cb;
-        golioth_float_setting_cb float_cb;
-        golioth_string_setting_cb string_cb;
-    };
-    int32_t int_min_val;  // applies only to integers
-    int32_t int_max_val;  // applies only to integers
-    void* cb_arg;
-};
-
-/// Private struct to contain settings state data, stored in
-/// the golioth_coap_client_t struct.
-struct golioth_settings {
-    bool initialized;
-    struct golioth_setting settings[CONFIG_GOLIOTH_MAX_NUM_SETTINGS];
-    size_t num_settings;
-};
+/// Initialize the Settings service
+///
+/// @param client Client handle
+///
+/// @return pointer to golioth settings struct
+/// @return NULL - Error initializing Settings service
+struct golioth_settings* golioth_settings_init(struct golioth_client* client);
 
 /// Register a specific setting of type int
 ///
-/// @param client Client handle
+/// @param settings Settings handle
 /// @param setting_name The name of the setting. This is expected to be a literal
 ///     string, therefore on the pointer is registered (not a full copy of the string).
 /// @param callback Callback function that will be called when the setting value is
@@ -117,7 +104,7 @@ struct golioth_settings {
 /// @return GOLIOTH_ERR_NOT_IMPLEMENTED - If Golioth settings are disabled in config
 /// @return GOLIOTH_ERR_NULL - callback is NULL
 enum golioth_status golioth_settings_register_int(
-        struct golioth_client* client,
+        struct golioth_settings* settings,
         const char* setting_name,
         golioth_int_setting_cb callback,
         void* callback_arg);
@@ -125,7 +112,7 @@ enum golioth_status golioth_settings_register_int(
 /// Same as @ref golioth_settings_register_int, but with specific min and
 /// max value which will be checked by this library.
 enum golioth_status golioth_settings_register_int_with_range(
-        struct golioth_client* client,
+        struct golioth_settings* settings,
         const char* setting_name,
         int32_t min_val,
         int32_t max_val,
@@ -134,14 +121,14 @@ enum golioth_status golioth_settings_register_int_with_range(
 
 /// Same as @ref golioth_settings_register_int, but for type bool.
 enum golioth_status golioth_settings_register_bool(
-        struct golioth_client* client,
+        struct golioth_settings* settings,
         const char* setting_name,
         golioth_bool_setting_cb callback,
         void* callback_arg);
 
 /// Same as @ref golioth_settings_register_int, but for type float.
 enum golioth_status golioth_settings_register_float(
-        struct golioth_client* client,
+        struct golioth_settings* settings,
         const char* setting_name,
         golioth_float_setting_cb callback,
         void* callback_arg);

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -35,7 +35,6 @@ struct golioth_client {
     size_t block_token_len;
     golioth_client_event_cb_fn event_callback;
     void* event_callback_arg;
-    struct golioth_rpc rpc;
 };
 
 static bool token_matches_request(const golioth_coap_request_msg_t* req, const coap_pdu_t* pdu) {
@@ -1517,10 +1516,6 @@ uint32_t golioth_client_num_items_in_request_queue(struct golioth_client* client
         return 0;
     }
     return golioth_mbox_num_messages(client->request_queue);
-}
-
-struct golioth_rpc* golioth_coap_client_get_rpc(struct golioth_client* client) {
-    return &client->rpc;
 }
 
 golioth_sys_thread_t golioth_client_get_thread(struct golioth_client* client) {

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -35,7 +35,6 @@ struct golioth_client {
     size_t block_token_len;
     golioth_client_event_cb_fn event_callback;
     void* event_callback_arg;
-    struct golioth_settings settings;
     struct golioth_rpc rpc;
 };
 
@@ -1518,10 +1517,6 @@ uint32_t golioth_client_num_items_in_request_queue(struct golioth_client* client
         return 0;
     }
     return golioth_mbox_num_messages(client->request_queue);
-}
-
-struct golioth_settings* golioth_coap_client_get_settings(struct golioth_client* client) {
-    return &client->settings;
 }
 
 struct golioth_rpc* golioth_coap_client_get_rpc(struct golioth_client* client) {

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <golioth/client.h>
-#include <golioth/settings.h>
 #include <golioth/rpc.h>
 #include <golioth/config.h>
 #include <golioth/golioth_sys.h>
@@ -165,6 +164,5 @@ enum golioth_status golioth_coap_client_observe_async(
 
 /// Getters, for internal SDK code to access data within the
 /// coap client struct.
-struct golioth_settings* golioth_coap_client_get_settings(struct golioth_client* client);
 struct golioth_rpc* golioth_coap_client_get_rpc(struct golioth_client* client);
 golioth_sys_thread_t golioth_coap_client_get_thread(struct golioth_client* client);

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <golioth/client.h>
-#include <golioth/rpc.h>
 #include <golioth/config.h>
 #include <golioth/golioth_sys.h>
 #include "event_group.h"
@@ -164,5 +163,4 @@ enum golioth_status golioth_coap_client_observe_async(
 
 /// Getters, for internal SDK code to access data within the
 /// coap client struct.
-struct golioth_rpc* golioth_coap_client_get_rpc(struct golioth_client* client);
 golioth_sys_thread_t golioth_coap_client_get_thread(struct golioth_client* client);

--- a/src/lightdb_state.c
+++ b/src/lightdb_state.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <assert.h>
+#include <string.h>
 #include "coap_client.h"
 #include <golioth/lightdb_state.h>
 #include <golioth/payload_utils.h>

--- a/src/lightdb_stream.c
+++ b/src/lightdb_stream.c
@@ -3,10 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "coap_client.h"
+#include <string.h>
 #include <golioth/lightdb_stream.h>
-#include "golioth_util.h"
 #include <golioth/golioth_sys.h>
+#include "coap_client.h"
+#include "golioth_util.h"
 
 #if defined(CONFIG_GOLIOTH_LIGHTDB_STREAM)
 

--- a/tests/unit_tests/fakes/coap_client_fake.c
+++ b/tests/unit_tests/fakes/coap_client_fake.c
@@ -1,7 +1,6 @@
 #include <fff.h>
 #include "coap_client_fake.h"
 
-DEFINE_FAKE_VALUE_FUNC(struct golioth_rpc*, golioth_coap_client_get_rpc, struct golioth_client*);
 DEFINE_FAKE_VALUE_FUNC(
         enum golioth_status,
         golioth_coap_client_observe_async,

--- a/tests/unit_tests/fakes/coap_client_fake.h
+++ b/tests/unit_tests/fakes/coap_client_fake.h
@@ -2,7 +2,6 @@
 
 #include <coap_client.h>
 
-DECLARE_FAKE_VALUE_FUNC(struct golioth_rpc*, golioth_coap_client_get_rpc, struct golioth_client*);
 DECLARE_FAKE_VALUE_FUNC(
         enum golioth_status,
         golioth_coap_client_observe_async,


### PR DESCRIPTION
The coap_client module should not have any knowledge of the services built on top of it. Remove the settings and rpc structs from the coap_client and instead create init functions that creates the state structs for each, adds a pointer to the client, and returns the struct to the user.

Resolves golioth/firmware-issue-tracker#370