### PR TITLE
treewide: Fixup copyright notices

### DIFF
--- a/examples/common/golioth_basics.h
+++ b/examples/common/golioth_basics.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #include <golioth/client.h>

--- a/examples/esp_idf/common/util.h
+++ b/examples/esp_idf/common/util.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #define COUNT_OF(x) ((sizeof(x) / sizeof(0 [x])) / ((size_t)(!(sizeof(x) % sizeof(0 [x])))))

--- a/examples/linux/certificate_auth/golioth_user_config.h
+++ b/examples/linux/certificate_auth/golioth_user_config.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #define CONFIG_GOLIOTH_COAP_HOST_URI "coaps://coap.golioth.io"

--- a/examples/linux/certificate_auth/main.c
+++ b/examples/linux/certificate_auth/main.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>

--- a/examples/linux/golioth_basics/golioth_user_config.h
+++ b/examples/linux/golioth_basics/golioth_user_config.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #define CONFIG_GOLIOTH_AUTO_LOG_TO_CLOUD 1

--- a/examples/linux/golioth_basics/main.c
+++ b/examples/linux/golioth_basics/main.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <string.h>
 #include <assert.h>
 #include <stdlib.h>

--- a/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_user_config.h
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/source/golioth_user_config.h
@@ -1,4 +1,9 @@
-#pragma once
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ #pragma once
 
 #define CONFIG_GOLIOTH_AUTO_LOG_TO_CLOUD 1
 #define CONFIG_GOLIOTH_COAP_REQUEST_QUEUE_MAX_ITEMS 20

--- a/examples/zephyr/certificate_provisioning/src/main.c
+++ b/examples/zephyr/certificate_provisioning/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/examples/zephyr/fw_update/src/main.c
+++ b/examples/zephyr/fw_update/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/examples/zephyr/golioth_basics/main.c
+++ b/examples/zephyr/golioth_basics/main.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <string.h>
 #include <assert.h>
 

--- a/examples/zephyr/hello/src/main.c
+++ b/examples/zephyr/hello/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/examples/zephyr/lightdb/delete/src/main.c
+++ b/examples/zephyr/lightdb/delete/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/examples/zephyr/lightdb/get/src/main.c
+++ b/examples/zephyr/lightdb/get/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/examples/zephyr/lightdb/observe/src/main.c
+++ b/examples/zephyr/lightdb/observe/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/examples/zephyr/lightdb/set/src/main.c
+++ b/examples/zephyr/lightdb/set/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/examples/zephyr/logging/src/main.c
+++ b/examples/zephyr/logging/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/examples/zephyr/rpc/src/main.c
+++ b/examples/zephyr/rpc/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/examples/zephyr/settings/src/main.c
+++ b/examples/zephyr/settings/src/main.c
@@ -1,7 +1,7 @@
 /*
- * copyright (c) 2023 golioth, inc.
+ * Copyright (c) 2023 Golioth, Inc.
  *
- * spdx-license-identifier: apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/logging/log.h>

--- a/include/golioth/config.h
+++ b/include/golioth/config.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 // This file defines default configuration values.

--- a/include/golioth/golioth_debug.h
+++ b/include/golioth/golioth_debug.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #include <golioth/config.h>

--- a/include/golioth/golioth_sys.h
+++ b/include/golioth/golioth_sys.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #include <stdint.h>

--- a/port/esp_idf/fw_update_esp_idf.c
+++ b/port/esp_idf/fw_update_esp_idf.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <golioth/fw_update.h>
 #include "esp_log.h"
 #include "esp_ota_ops.h"

--- a/port/esp_idf/golioth_port_config.h
+++ b/port/esp_idf/golioth_port_config.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #include <esp_log.h>

--- a/port/freertos/golioth_sys_freertos.c
+++ b/port/freertos/golioth_sys_freertos.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <golioth/golioth_sys.h>
 #include <FreeRTOS.h>
 #include <task.h>

--- a/port/linux/golioth_sys_linux.c
+++ b/port/linux/golioth_sys_linux.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <golioth/golioth_sys.h>
 #include <unistd.h>
 #include <signal.h>

--- a/port/modus_toolbox/fw_update_mcuboot.c
+++ b/port/modus_toolbox/fw_update_mcuboot.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <golioth/fw_update.h>
 #include "bootutil/bootutil.h"
 #include "bootutil/image.h"

--- a/port/modus_toolbox/golioth_port_config.h
+++ b/port/modus_toolbox/golioth_port_config.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 // Same as GLTH_LOGX, but with 32-bit timestamp (PRIu32),

--- a/port/modus_toolbox/libcoap/include/coap_config.h
+++ b/port/modus_toolbox/libcoap/include/coap_config.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #include <sys/socket.h>

--- a/port/modus_toolbox/libcoap/libcoap_posix_timers.c
+++ b/port/modus_toolbox/libcoap/libcoap_posix_timers.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include "libcoap_posix_timers.h"
 #include <FreeRTOS.h>
 #include <task.h>

--- a/port/modus_toolbox/libcoap/mbedtls_timing.c
+++ b/port/modus_toolbox/libcoap/mbedtls_timing.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include "mbedtls/timing.h"
 #include <FreeRTOS.h>
 #include <task.h>

--- a/port/zephyr/golioth_fw_zephyr.c
+++ b/port/zephyr/golioth_fw_zephyr.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <zephyr/dfu/flash_img.h>
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/storage/flash_map.h>

--- a/port/zephyr/golioth_sys_zephyr.c
+++ b/port/zephyr/golioth_sys_zephyr.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <unistd.h>
 #include <zephyr/kernel.h>
 #include <zephyr/posix/poll.h>

--- a/port/zephyr/libcoap/include/sys/random.h
+++ b/port/zephyr/libcoap/include/sys/random.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #ifndef __LIBCOAP_SYS_RANDOM_H__
 #define __LIBCOAP_SYS_RANDOM_H__
 

--- a/src/event_group.c
+++ b/src/event_group.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include "event_group.h"
 #include <golioth/golioth_sys.h>
 #include <string.h>  // memset

--- a/src/event_group.h
+++ b/src/event_group.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #include <stdint.h>

--- a/src/golioth_debug.c
+++ b/src/golioth_debug.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <golioth/golioth_debug.h>
 #include <golioth/log.h>
 #include <stdio.h>

--- a/src/mbox.c
+++ b/src/mbox.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include "mbox.h"
 #include <golioth/golioth_debug.h>
 #include <golioth/golioth_sys.h>

--- a/src/mbox.h
+++ b/src/mbox.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #include <golioth/golioth_sys.h>

--- a/src/ringbuf.c
+++ b/src/ringbuf.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include "ringbuf.h"
 #include <string.h>
 

--- a/src/ringbuf.h
+++ b/src/ringbuf.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #include <stdint.h>

--- a/src/zcbor_any_skip_fixed.h
+++ b/src/zcbor_any_skip_fixed.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #ifndef __ZCBOR_ANY_SKIP_FIXED_H__
 #define __ZCBOR_ANY_SKIP_FIXED_H__
 


### PR DESCRIPTION
Add missing copyright headers and make the case consistent.

Fixes golioth/firmware-issue-tracker#356