### PR TITLE
Detect and fix modem reset loop

### DIFF
--- a/examples/zephyr/common/Kconfig
+++ b/examples/zephyr/common/Kconfig
@@ -87,6 +87,16 @@ config GOLIOTH_SAMPLE_NRF91_LTE_MONITOR
 	help
 	  LTE Link Control events monitor for nRF91.
 
+config GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE
+	bool "Automatically override modem reset loop restriction"
+	depends on GOLIOTH_SAMPLE_NRF91_LTE_MONITOR
+	help
+	  When selected, the device will automatically factory reset the modem
+	  when the modem reports that it has activated the reset loop restriction.
+	  This will remove the reset loop restriction.
+
+	  WARNING: It is not recommended to activate this setting in production.
+
 config GOLIOTH_SAMPLE_PSK_SETTINGS
        bool "Load credentials from persistent settings"
        default y if !GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS

--- a/examples/zephyr/common/nrf91_lte_monitor.c
+++ b/examples/zephyr/common/nrf91_lte_monitor.c
@@ -47,6 +47,15 @@ static void lte_handler(const struct lte_lc_evt* const evt) {
                     break;
             }
             break;
+        case LTE_LC_EVT_MODEM_EVENT:
+            switch (evt->modem_evt) {
+                case LTE_LC_MODEM_EVT_RESET_LOOP:
+                    LOG_INF("Modem: Reset Loop detected");
+                    break;
+                default:
+                    break;
+            }
+            break;
         default:
             break;
     }
@@ -54,6 +63,7 @@ static void lte_handler(const struct lte_lc_evt* const evt) {
 
 static int nrf91_lte_monitor_init(void) {
     lte_lc_register_handler(lte_handler);
+    lte_lc_modem_events_enable();
 
     return 0;
 }

--- a/examples/zephyr/common/nrf91_lte_monitor.c
+++ b/examples/zephyr/common/nrf91_lte_monitor.c
@@ -9,6 +9,7 @@ LOG_MODULE_REGISTER(lte_monitor);
 
 #include <modem/lte_lc.h>
 #include <zephyr/init.h>
+#include <zephyr/sys/reboot.h>
 
 static void lte_handler(const struct lte_lc_evt* const evt) {
     switch (evt->type) {
@@ -51,6 +52,13 @@ static void lte_handler(const struct lte_lc_evt* const evt) {
             switch (evt->modem_evt) {
                 case LTE_LC_MODEM_EVT_RESET_LOOP:
                     LOG_INF("Modem: Reset Loop detected");
+
+#if defined(CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE)
+                    LOG_WRN("Attempting factory reset to override reset loop restriction");
+                    lte_lc_offline();
+                    lte_lc_factory_reset(LTE_LC_FACTORY_RESET_ALL);
+                    sys_reboot(SYS_REBOOT_COLD);
+#endif
                     break;
                 default:
                     break;

--- a/examples/zephyr/hello/sample.yaml
+++ b/examples/zephyr/hello/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
       - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
+      - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/lightdb/delete/sample.yaml
+++ b/examples/zephyr/lightdb/delete/sample.yaml
@@ -12,6 +12,7 @@ tests:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
       - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
+      - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/lightdb/get/sample.yaml
+++ b/examples/zephyr/lightdb/get/sample.yaml
@@ -12,6 +12,7 @@ tests:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
       - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
+      - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/lightdb/observe/sample.yaml
+++ b/examples/zephyr/lightdb/observe/sample.yaml
@@ -12,6 +12,7 @@ tests:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
       - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
+      - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/lightdb/set/sample.yaml
+++ b/examples/zephyr/lightdb/set/sample.yaml
@@ -12,6 +12,7 @@ tests:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
       - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
+      - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/lightdb_stream/sample.yaml
+++ b/examples/zephyr/lightdb_stream/sample.yaml
@@ -12,6 +12,7 @@ tests:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
       - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
+      - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/logging/sample.yaml
+++ b/examples/zephyr/logging/sample.yaml
@@ -12,6 +12,7 @@ tests:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
       - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
+      - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/rpc/sample.yaml
+++ b/examples/zephyr/rpc/sample.yaml
@@ -12,6 +12,7 @@ tests:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
       - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
+      - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk

--- a/examples/zephyr/settings/sample.yaml
+++ b/examples/zephyr/settings/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
       - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
+      - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover
       mimxrt1024_evk


### PR DESCRIPTION
The nrf91 modem has a built in reset loop restriction that activates when the device is reset 7 times in a row within 30 seconds of connecting to the network. This restriction prevents the modem from connecting to the network for 30 minutes. We hit this frequently during CI. This PR monitors for an event from the modem that indicates the reset loop is active and notifies the user when the event is received. It also adds a Kconfig option to automatically factory reset the modem when we enter the reset loop. This removes the reset loop restriction and lets the modem start working immediately, but is not recommended in production because a) it may just send you back into the reset loop and b) factory reset writes to flash and so has flash wear implications. Neither of these apply to us in CI because a) we know why the device is resetting so often (we're doing it on purpose) and b) we're writing to the program flash more often than we do a factory reset, so the MCU flash will wear out before the modem flash.

Fixes golioth/firmware-issue-tracker#317