### PR TITLE
examples: zephyr: settings: extend twister timeout

### DIFF
--- a/examples/zephyr/settings/sample.yaml
+++ b/examples/zephyr/settings/sample.yaml
@@ -6,6 +6,7 @@ common:
   tags: golioth socket goliothd
 tests:
   sample.golioth.settings:
+    timeout: 90
     extra_args: EXTRA_CONF_FILE="../common/runtime_psk.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128


### PR DESCRIPTION
When running the twister test on the nrf9160dk, it can take some time to connect to the cellular network. This can cause the test to hit the twister default timeout of 60s. Extending the timeout to 90 seconds should give the test enough time to complete successfully.

Fixes golioth/firmware-issue-tracker#373