### PR TITLE
ci: use auto-generated boards for twister tests

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -119,7 +119,6 @@ jobs:
         env:
           hil_board: ${{ inputs.hil_board }}
           GOLIOTH_API_KEY: ${{ secrets.DEV_CI_PROJECT_API_KEY }}
-          GOLIOTH_DEVICE_NAME: ${{ runner.name }}-${{ inputs.hil_board }}
           GOLIOTH_CREDENTIALS_FILE: /opt/credentials/credentials_${{ inputs.hil_board }}.yml
         run: |
           source /opt/credentials/runner_env.sh


### PR DESCRIPTION
Don't provide the `GOLIOTH_DEVICE_NAME` environment variable to the twister tests. This will cause the golioth pytest plugin to automatically generate a temporary device in the console to use for the duration of the test, after which it will be deleted. Using automatically generated devices reduces the amount of manual work needed to add a device into the HIL runners (we no longer need to manually create devices) and will make it easier to move to a different project or backend environment in the future.

This uses the functionality provided by golioth/python-golioth-tools#9 and golioth/python-golioth-tools#10

Resolves golioth/firmware-issue-tracker#326