### PR TITLE
examples: zephyr: pull psk from rest api for tests

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -104,7 +104,7 @@ jobs:
           pip3 install -r zephyr/scripts/requirements-build-test.txt
           pip3 install -r zephyr/scripts/requirements-run-test.txt
 
-          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.3.0
+          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.4.0
       - name: Power Cycle USB Hub
         run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build

--- a/examples/zephyr/hello/pytest/test_sample.py
+++ b/examples/zephyr/hello/pytest/test_sample.py
@@ -18,9 +18,17 @@ async def test_hello(shell, device, credentials_file):
 
     time.sleep(2)
 
-    # Set credentials
+    # Set Golioth credential
+
+    golioth_cred = (await device.credentials.list())[0]
+    shell.exec_command(f"settings set golioth/psk-id {golioth_cred.identity}")
+    shell.exec_command(f"settings set golioth/psk {golioth_cred.key}")
+
+    # Set WiFi credential
 
     for setting in credentials['settings']:
+        if 'golioth' in setting:
+            continue
         shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
 
     shell._device.clear_buffer()

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -23,9 +23,17 @@ async def test_lightdb_delete(shell, device, credentials_file):
 
     time.sleep(2)
 
-    # Set credentials
+    # Set Golioth credential
+
+    golioth_cred = (await device.credentials.list())[0]
+    shell.exec_command(f"settings set golioth/psk-id {golioth_cred.identity}")
+    shell.exec_command(f"settings set golioth/psk {golioth_cred.key}")
+
+    # Set WiFi credential
 
     for setting in credentials['settings']:
+        if 'golioth' in setting:
+            continue
         shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
 
     shell._device.clear_buffer()

--- a/examples/zephyr/lightdb/get/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/get/pytest/test_sample.py
@@ -21,9 +21,17 @@ async def test_lightdb_get(shell, device, credentials_file):
 
     time.sleep(2)
 
-    # Set credentials
+    # Set Golioth credential
+
+    golioth_cred = (await device.credentials.list())[0]
+    shell.exec_command(f"settings set golioth/psk-id {golioth_cred.identity}")
+    shell.exec_command(f"settings set golioth/psk {golioth_cred.key}")
+
+    # Set WiFi credential
 
     for setting in credentials['settings']:
+        if 'golioth' in setting:
+            continue
         shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
 
     shell._device.clear_buffer()

--- a/examples/zephyr/lightdb/observe/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/observe/pytest/test_sample.py
@@ -21,9 +21,17 @@ async def test_lightdb_observe(shell, device, credentials_file):
 
     time.sleep(2)
 
-    # Set credentials
+    # Set Golioth credential
+
+    golioth_cred = (await device.credentials.list())[0]
+    shell.exec_command(f"settings set golioth/psk-id {golioth_cred.identity}")
+    shell.exec_command(f"settings set golioth/psk {golioth_cred.key}")
+
+    # Set WiFi credential
 
     for setting in credentials['settings']:
+        if 'golioth' in setting:
+            continue
         shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
 
     shell._device.clear_buffer()

--- a/examples/zephyr/lightdb/set/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/set/pytest/test_sample.py
@@ -21,9 +21,17 @@ async def test_lightdb_set(shell, device, credentials_file):
 
     time.sleep(2)
 
-    # Set credentials
+    # Set Golioth credential
+
+    golioth_cred = (await device.credentials.list())[0]
+    shell.exec_command(f"settings set golioth/psk-id {golioth_cred.identity}")
+    shell.exec_command(f"settings set golioth/psk {golioth_cred.key}")
+
+    # Set WiFi credential
 
     for setting in credentials['settings']:
+        if 'golioth' in setting:
+            continue
         shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
 
     shell._device.clear_buffer()

--- a/examples/zephyr/lightdb_stream/pytest/test_sample.py
+++ b/examples/zephyr/lightdb_stream/pytest/test_sample.py
@@ -17,9 +17,17 @@ async def test_lightdb_stream(shell, device, credentials_file):
 
     time.sleep(2)
 
-    # Set credentials
+    # Set Golioth credential
+
+    golioth_cred = (await device.credentials.list())[0]
+    shell.exec_command(f"settings set golioth/psk-id {golioth_cred.identity}")
+    shell.exec_command(f"settings set golioth/psk {golioth_cred.key}")
+
+    # Set WiFi credential
 
     for setting in credentials['settings']:
+        if 'golioth' in setting:
+            continue
         shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
 
     shell._device.clear_buffer()

--- a/examples/zephyr/logging/pytest/test_sample.py
+++ b/examples/zephyr/logging/pytest/test_sample.py
@@ -57,9 +57,17 @@ async def test_logging(shell, device, credentials_file):
 
     time.sleep(2)
 
-    # Set credentials
+    # Set Golioth credential
+
+    golioth_cred = (await device.credentials.list())[0]
+    shell.exec_command(f"settings set golioth/psk-id {golioth_cred.identity}")
+    shell.exec_command(f"settings set golioth/psk {golioth_cred.key}")
+
+    # Set WiFi credential
 
     for setting in credentials['settings']:
+        if 'golioth' in setting:
+            continue
         shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
 
     shell._device.clear_buffer()

--- a/examples/zephyr/rpc/pytest/test_sample.py
+++ b/examples/zephyr/rpc/pytest/test_sample.py
@@ -16,9 +16,17 @@ async def test_logging(shell, device, credentials_file):
 
     time.sleep(2)
 
-    # Set credentials
+    # Set Golioth credential
+
+    golioth_cred = (await device.credentials.list())[0]
+    shell.exec_command(f"settings set golioth/psk-id {golioth_cred.identity}")
+    shell.exec_command(f"settings set golioth/psk {golioth_cred.key}")
+
+    # Set WiFi credential
 
     for setting in credentials['settings']:
+        if 'golioth' in setting:
+            continue
         shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
 
     shell._device.clear_buffer()

--- a/examples/zephyr/settings/pytest/test_sample.py
+++ b/examples/zephyr/settings/pytest/test_sample.py
@@ -25,9 +25,17 @@ async def test_settings(shell, project, device, credentials_file):
 
     time.sleep(2)
 
-    # Set credentials
+    # Set Golioth credential
+
+    golioth_cred = (await device.credentials.list())[0]
+    shell.exec_command(f"settings set golioth/psk-id {golioth_cred.identity}")
+    shell.exec_command(f"settings set golioth/psk {golioth_cred.key}")
+
+    # Set WiFi credential
 
     for setting in credentials['settings']:
+        if 'golioth' in setting:
+            continue
         shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
 
     shell._device.clear_buffer()


### PR DESCRIPTION
Instead of relying on files existing on disk to get the PSK-ID and PSK, instead pull credentials from the Golioth REST API. This is done through the `device` fixture provided by the Golioth pytest plugin.

Resolves golioth/firmware-issue-tracker#358