### PR TITLE
ci: test against prod backend environment

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -104,7 +104,7 @@ jobs:
           pip3 install -r zephyr/scripts/requirements-build-test.txt
           pip3 install -r zephyr/scripts/requirements-run-test.txt
 
-          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.4.0
+          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.5.0
       - name: Power Cycle USB Hub
         run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build
@@ -118,7 +118,7 @@ jobs:
         shell: bash
         env:
           hil_board: ${{ inputs.hil_board }}
-          GOLIOTH_API_KEY: ${{ secrets.DEV_CI_PROJECT_API_KEY }}
+          GOLIOTH_API_KEY: ${{ secrets.PROD_CI_PROJECT_API_KEY }}
           GOLIOTH_CREDENTIALS_FILE: /opt/credentials/credentials_${{ inputs.hil_board }}.yml
         run: |
           source /opt/credentials/runner_env.sh

--- a/examples/zephyr/hello/sample.yaml
+++ b/examples/zephyr/hello/sample.yaml
@@ -10,7 +10,6 @@ tests:
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
-      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
       - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover

--- a/examples/zephyr/lightdb/delete/sample.yaml
+++ b/examples/zephyr/lightdb/delete/sample.yaml
@@ -11,7 +11,6 @@ tests:
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
-      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
       - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover

--- a/examples/zephyr/lightdb/get/sample.yaml
+++ b/examples/zephyr/lightdb/get/sample.yaml
@@ -11,7 +11,6 @@ tests:
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
-      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
       - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover

--- a/examples/zephyr/lightdb/observe/sample.yaml
+++ b/examples/zephyr/lightdb/observe/sample.yaml
@@ -11,7 +11,6 @@ tests:
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
-      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
       - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover

--- a/examples/zephyr/lightdb/set/sample.yaml
+++ b/examples/zephyr/lightdb/set/sample.yaml
@@ -11,7 +11,6 @@ tests:
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
-      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
       - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover

--- a/examples/zephyr/lightdb_stream/sample.yaml
+++ b/examples/zephyr/lightdb_stream/sample.yaml
@@ -11,7 +11,6 @@ tests:
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
-      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
       - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover

--- a/examples/zephyr/logging/sample.yaml
+++ b/examples/zephyr/logging/sample.yaml
@@ -11,7 +11,6 @@ tests:
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
-      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
       - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover

--- a/examples/zephyr/rpc/sample.yaml
+++ b/examples/zephyr/rpc/sample.yaml
@@ -11,7 +11,6 @@ tests:
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
-      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
       - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover

--- a/examples/zephyr/settings/sample.yaml
+++ b/examples/zephyr/settings/sample.yaml
@@ -11,7 +11,6 @@ tests:
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
       - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
-      - CONFIG_GOLIOTH_COAP_HOST_URI="coaps://coap.golioth.dev"
       - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
     platform_allow: >
       esp32_devkitc_wrover


### PR DESCRIPTION
Testing against prod most closely mirrors what devices will experience in the field, and also isolates our tests from any instability in the dev environment.

Resolves golioth/firmware-issue-tracker#325