### PR TITLE
examples: zephyr: increase fd for fw update

### DIFF
--- a/examples/zephyr/common/Kconfig.defconfig
+++ b/examples/zephyr/common/Kconfig.defconfig
@@ -19,8 +19,17 @@ endif # DNS_RESOLVER
 if EVENTFD
 
 config EVENTFD_MAX
+    depends on !GOLIOTH_FW_UPDATE
 	default 6
 
+if GOLIOTH_FW_UPDATE
+
+config EVENTFD_MAX
+	default 13
+config POSIX_MAX_FDS
+	default 23
+
+endif # GOLIOTH_FW_UPDATE
 endif # EVENTFD
 
 if LOG_BACKEND_GOLIOTH


### PR DESCRIPTION
* Increase the max eventfd to avoid ENOMEM error in fw_update example
* Increase the total file descriptors to match, avoiding ENFILE error

We should consider moving this out of examples/zephyr/common and into the defconfig for the SDK as it will be needed whenever firmware update is selected.

(edit: I just force-pushed to fix the name of the error in the commit message)