### PR TITLE
ci: pin version of `gdown` package

### DIFF
--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -146,7 +146,7 @@ jobs:
     - name: Download and install ModusToolbox 2.4
       shell: bash
       run: |
-        pip install click gdown cryptography intelhex cbor
+        pip install click gdown==4.6.0 cryptography intelhex cbor
         gdown $MTB_DOWNLOAD_ID -O /tmp/ModusToolbox_$MTB_VERSION-linux-install.tar.gz
         tar -C $HOME -zxf /tmp/ModusToolbox_$MTB_VERSION-linux-install.tar.gz
         rm /tmp/ModusToolbox_$MTB_VERSION-linux-install.tar.gz


### PR DESCRIPTION
The latest version of `gdown` has a regression that prevents us from being able to download the Modus Toolbox package. Pin `gdown` to 4.6.0 to avoid the regression.

Fixes golioth/firmware-issue-tracker#375