### PR TITLE
zephyr: CI: add Hello test using CID

### DIFF
--- a/examples/zephyr/hello/sample.yaml
+++ b/examples/zephyr/hello/sample.yaml
@@ -16,6 +16,21 @@ tests:
       mimxrt1024_evk
       nrf52840dk_nrf52840
       nrf9160dk_nrf9160_ns
+  sample.golioth.hello.cid:
+    harness: pytest
+    tags: golioth socket goliothd
+    timeout: 90
+    extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
+    extra_configs:
+      - CONFIG_GOLIOTH_USE_CONNECTION_ID=y
+      - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
+      - CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=100
+      - CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y
+    platform_allow: >
+      esp32_devkitc_wrover
+      mimxrt1024_evk
+      nrf52840dk_nrf52840
+      nrf9160dk_nrf9160_ns
   sample.golioth.hello.psk:
     build_only: true
     platform_allow: >
@@ -24,16 +39,6 @@ tests:
       nrf52840dk_nrf52840
       qemu_x86
       nrf9160dk_nrf9160_ns
-  sample.golioth.hello.psk.cid:
-    build_only: true
-    platform_allow: >
-      esp32_devkitc_wrover
-      mimxrt1024_evk
-      nrf52840dk_nrf52840
-      qemu_x86
-      nrf9160dk_nrf9160_ns
-    extra_configs:
-      - CONFIG_GOLIOTH_USE_CONNECTION_ID=y
   sample.golioth.hello.cert.buildonly:
     build_only: true
     extra_configs:


### PR DESCRIPTION
Add a Hardware in the Loop test that uses connection ID for the Hello sample.