### PR TITLE
pin cryptography pip package version

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -47,7 +47,7 @@ jobs:
         pip3 install -r zephyr/scripts/requirements-build-test.txt
         pip3 install -r zephyr/scripts/requirements-run-test.txt
         # Needed for TF-M
-        pip3 install cryptography pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.9.0 jinja2 click
+        pip3 install cryptography==41.0.7 pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.9.0 jinja2 click
 
     - name: Download binary blobs
       if: ${{ inputs.binary_blob }}

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -46,7 +46,7 @@ jobs:
         pip3 install -r zephyr/scripts/requirements-build-test.txt
         pip3 install -r zephyr/scripts/requirements-run-test.txt
         # Needed for TF-M
-        pip3 install cryptography pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.9.0 jinja2 click
+        pip3 install cryptography==41.0.7 pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.9.0 jinja2 click
 
     - name: Download binary blobs
       if: ${{ inputs.binary_blob }}

--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -146,7 +146,7 @@ jobs:
     - name: Download and install ModusToolbox 2.4
       shell: bash
       run: |
-        pip install click gdown==4.6.0 cryptography intelhex cbor
+        pip install click gdown==4.6.0 cryptography==41.0.7 intelhex cbor
         gdown $MTB_DOWNLOAD_ID -O /tmp/ModusToolbox_$MTB_VERSION-linux-install.tar.gz
         tar -C $HOME -zxf /tmp/ModusToolbox_$MTB_VERSION-linux-install.tar.gz
         rm /tmp/ModusToolbox_$MTB_VERSION-linux-install.tar.gz


### PR DESCRIPTION
cryptography 42.0.0 breaks the modus toolbox build so pin the version to 41.0.7

Fixes https://github.com/golioth/firmware-issue-tracker/issues/396