### PR TITLE
stream: use golioth_content_type to set objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.0] - TBA
 
 ### Breaking Changes
-- Remove `golioth_` prefix from filenames and move header files
-  under `golioth/` folder.
+- Remove `golioth_` prefix from filenames and move header files under
+  `golioth/` folder.
+- Stream: change `json` and `cbor` object set calls to specify type in
+  the parameters (instead of separate function calls). This matches the
+  approach taken in the LightDB State module:
+  `golioth_stream_set_async/sync`
 
 ## [0.9.0] - 2023-11-08
 

--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -109,12 +109,13 @@ static void temperature_push_async(const struct sensor_value *temp)
 
     snprintk(sbuf, sizeof(sbuf), "{\"temp\":%d.%06d}", temp->val1, abs(temp->val2));
 
-    err = golioth_stream_set_json_async(client,
-                                        "sensor",
-                                        sbuf,
-                                        strlen(sbuf),
-                                        temperature_push_handler,
-                                        NULL);
+    err = golioth_stream_set_async(client,
+                                   "sensor",
+                                   GOLIOTH_CONTENT_TYPE_JSON,
+                                   sbuf,
+                                   strlen(sbuf),
+                                   temperature_push_handler,
+                                   NULL);
     if (err)
     {
         LOG_WRN("Failed to push temperature: %d", err);
@@ -129,7 +130,12 @@ static void temperature_push_sync(const struct sensor_value *temp)
 
     snprintk(sbuf, sizeof(sbuf), "{\"temp\":%d.%06d}", temp->val1, abs(temp->val2));
 
-    err = golioth_stream_set_json_sync(client, "sensor", sbuf, strlen(sbuf), 1);
+    err = golioth_stream_set_sync(client,
+                                  "sensor",
+                                  GOLIOTH_CONTENT_TYPE_JSON,
+                                  sbuf,
+                                  strlen(sbuf),
+                                  1);
 
     if (err)
     {

--- a/include/golioth/stream.h
+++ b/include/golioth/stream.h
@@ -116,14 +116,15 @@ enum golioth_status golioth_stream_set_string_sync(struct golioth_client *client
                                                    size_t str_len,
                                                    int32_t timeout_s);
 
-/// Set a JSON object (encoded as a string) in LightDB strean at a particular path asynchronously
+/// Set an object in LightDB stream at a particular path asynchronously
 ///
-/// Similar to @ref golioth_stream_set_int_async.
-///
+/// Similar to @ref golioth_stream_set_int_async, but content_type must be specified
+////
 /// @param client The client handle from @ref golioth_client_create
-/// @param path The path in LightDB strean to set (e.g. "my_obj")
-/// @param json_str A JSON object encoded as a string (e.g. "{ \"string_key\": \"value\"}")
-/// @param json_str_len Length of json_str, not including NULL terminator
+/// @param path The path in LightDB stream to set (e.g. "my_obj")
+/// @param content_type The serialization format of buf
+/// @param buf A buffer containing the object to send
+/// @param buf_len Length of buf
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
 ///
@@ -132,41 +133,29 @@ enum golioth_status golioth_stream_set_string_sync(struct golioth_client *client
 /// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
 /// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
 /// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-enum golioth_status golioth_stream_set_json_async(struct golioth_client *client,
-                                                  const char *path,
-                                                  const char *json_str,
-                                                  size_t json_str_len,
-                                                  golioth_set_cb_fn callback,
-                                                  void *callback_arg);
+enum golioth_status golioth_stream_set_async(struct golioth_client *client,
+                                             const char *path,
+                                             enum golioth_content_type content_type,
+                                             const uint8_t *buf,
+                                             size_t buf_len,
+                                             golioth_set_cb_fn callback,
+                                             void *callback_arg);
 
-/// Set a JSON object (encoded as a string) in LightDB strean at a particular path synchronously
+/// Set an object in LightDB stream at a particular path synchronously
 ///
-/// Similar to @ref golioth_stream_set_int_sync.
+/// Similar to @ref golioth_stream_set_int_sync, but content_type must be specified
 ///
 /// @param client The client handle from @ref golioth_client_create
 /// @param path The path in LightDB stream to set (e.g. "my_obj")
-/// @param json_str A JSON object encoded as a string (e.g. "{ \"string_key\": \"value\"}")
-/// @param json_str_len Length of json_str, not including NULL terminator
+/// @param content_type The serialization format of buf
+/// @param buf A buffer containing the object to send
+/// @param buf_len Length of buf
 /// @param timeout_s The timeout, in seconds, for receiving a server response
-enum golioth_status golioth_stream_set_json_sync(struct golioth_client *client,
-                                                 const char *path,
-                                                 const char *json_str,
-                                                 size_t json_str_len,
-                                                 int32_t timeout_s);
-
-/// Similar to @ref golioth_stream_set_json_async, but for CBOR
-enum golioth_status golioth_stream_set_cbor_async(struct golioth_client *client,
-                                                  const char *path,
-                                                  const uint8_t *cbor_data,
-                                                  size_t cbor_data_len,
-                                                  golioth_set_cb_fn callback,
-                                                  void *callback_arg);
-
-/// Similar to @ref golioth_stream_set_json_sync, but for CBOR
-enum golioth_status golioth_stream_set_cbor_sync(struct golioth_client *client,
-                                                 const char *path,
-                                                 const uint8_t *cbor_data,
-                                                 size_t cbor_data_len,
-                                                 int32_t timeout_s);
+enum golioth_status golioth_stream_set_sync(struct golioth_client *client,
+                                            const char *path,
+                                            enum golioth_content_type content_type,
+                                            const uint8_t *buf,
+                                            size_t buf_len,
+                                            int32_t timeout_s);
 
 /// @}

--- a/src/stream.c
+++ b/src/stream.c
@@ -110,38 +110,20 @@ enum golioth_status golioth_stream_set_string_async(struct golioth_client *clien
     return status;
 }
 
-enum golioth_status golioth_stream_set_json_async(struct golioth_client *client,
-                                                  const char *path,
-                                                  const char *json_str,
-                                                  size_t json_str_len,
-                                                  golioth_set_cb_fn callback,
-                                                  void *callback_arg)
+enum golioth_status golioth_stream_set_async(struct golioth_client *client,
+                                             const char *path,
+                                             enum golioth_content_type content_type,
+                                             const uint8_t *buf,
+                                             size_t buf_len,
+                                             golioth_set_cb_fn callback,
+                                             void *callback_arg)
 {
     return golioth_coap_client_set(client,
                                    GOLIOTH_STREAM_PATH_PREFIX,
                                    path,
-                                   GOLIOTH_CONTENT_TYPE_JSON,
-                                   (const uint8_t *) json_str,
-                                   json_str_len,
-                                   callback,
-                                   callback_arg,
-                                   false,
-                                   GOLIOTH_SYS_WAIT_FOREVER);
-}
-
-enum golioth_status golioth_stream_set_cbor_async(struct golioth_client *client,
-                                                  const char *path,
-                                                  const uint8_t *cbor_data,
-                                                  size_t cbor_data_len,
-                                                  golioth_set_cb_fn callback,
-                                                  void *callback_arg)
-{
-    return golioth_coap_client_set(client,
-                                   GOLIOTH_STREAM_PATH_PREFIX,
-                                   path,
-                                   GOLIOTH_CONTENT_TYPE_CBOR,
-                                   cbor_data,
-                                   cbor_data_len,
+                                   content_type,
+                                   buf,
+                                   buf_len,
                                    callback,
                                    callback_arg,
                                    false,
@@ -236,36 +218,19 @@ enum golioth_status golioth_stream_set_string_sync(struct golioth_client *client
     return status;
 }
 
-enum golioth_status golioth_stream_set_json_sync(struct golioth_client *client,
-                                                 const char *path,
-                                                 const char *json_str,
-                                                 size_t json_str_len,
-                                                 int32_t timeout_s)
+enum golioth_status golioth_stream_set_sync(struct golioth_client *client,
+                                            const char *path,
+                                            enum golioth_content_type content_type,
+                                            const uint8_t *buf,
+                                            size_t buf_len,
+                                            int32_t timeout_s)
 {
     return golioth_coap_client_set(client,
                                    GOLIOTH_STREAM_PATH_PREFIX,
                                    path,
-                                   GOLIOTH_CONTENT_TYPE_JSON,
-                                   (const uint8_t *) json_str,
-                                   json_str_len,
-                                   NULL,
-                                   NULL,
-                                   true,
-                                   timeout_s);
-}
-
-enum golioth_status golioth_stream_set_cbor_sync(struct golioth_client *client,
-                                                 const char *path,
-                                                 const uint8_t *cbor_data,
-                                                 size_t cbor_data_len,
-                                                 int32_t timeout_s)
-{
-    return golioth_coap_client_set(client,
-                                   GOLIOTH_STREAM_PATH_PREFIX,
-                                   path,
-                                   GOLIOTH_CONTENT_TYPE_CBOR,
-                                   cbor_data,
-                                   cbor_data_len,
+                                   content_type,
+                                   buf,
+                                   buf_len,
                                    NULL,
                                    NULL,
                                    true,


### PR DESCRIPTION
Remove the `golioth_stream_set_cbor_async/sync` and `golioth_stream_set_json_async/sync` functions and replace them with `golioth_stream_set_async/sync` function that requires a `golioth_content_type` as an argument.

This makes it possible to add more content types in the future without introducing breaking changes.