### PR TITLE
ci: update github actions versions

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -63,7 +63,7 @@ jobs:
               --package-artifacts test_artifacts_${{ inputs.west_board }}.tar
 
     - name: Save artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test_artifacts_${{ inputs.west_board }}
         path: test_artifacts_${{ inputs.west_board }}.tar
@@ -117,7 +117,7 @@ jobs:
       - name: Power Cycle USB Hub
         run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test_artifacts_${{ inputs.west_board }}
           path: .
@@ -146,7 +146,7 @@ jobs:
                 --west-flash="--skip-rebuild,--dev-id=${!SNR_VAR}"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: twister-run-artifacts-${{ inputs.hil_board }}

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -31,7 +31,7 @@ jobs:
         path: 'tests/hil/platform/esp-idf'
         command: 'idf.py -D GOLIOTH_HIL_TEST=connection build'
     - name: Save Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.hil_board }}-connection-esp-idf
         path: tests/hil/platform/esp-idf/build/merged.bin
@@ -57,7 +57,7 @@ jobs:
       - name: Power Cycle USB Hub
         run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.hil_board }}-connection-esp-idf
           path: .

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -58,7 +58,7 @@ jobs:
         west build -p -b ${{ inputs.west_board }} modules/lib/golioth-firmware-sdk/tests/hil/platform/zephyr -- -DGOLIOTH_HIL_TEST=connection
 
     - name: Save artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.hil_board }}-connection-zephyr
         path: build/zephyr/${{ inputs.binary_name }}
@@ -84,7 +84,7 @@ jobs:
       - name: Power Cycle USB Hub
         run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.hil_board }}-connection-zephyr
           path: .

--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -18,7 +18,7 @@ jobs:
         # bound of commits in a single PR.
         fetch-depth: 15
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -48,7 +48,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -77,7 +77,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -116,7 +116,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -139,7 +139,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
         architecture: 'x64'

--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
         architecture: 'x64'
@@ -39,7 +39,7 @@ jobs:
             build/partition_table/partition-table.bin \
             build/ota_data_initial.bin
     - name: Upload tarball
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build.tar.gz
         path: examples/esp_idf/test/build.tar.gz
@@ -57,7 +57,7 @@ jobs:
         cd examples/esp_idf/test
         cp build/test.bin test_new.bin
     - name: Upload 1.2.99 binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test_new.bin
         path: examples/esp_idf/test/test_new.bin
@@ -107,7 +107,7 @@ jobs:
     - name: Checkout repository without submodules
       uses: actions/checkout@v4
     - name: Download build tarball
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: build.tar.gz
         path: examples/esp_idf/test
@@ -116,7 +116,7 @@ jobs:
         cd examples/esp_idf/test
         tar xvf build.tar.gz
     - name: Download 1.2.99 binary
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: test_new.bin
         path: examples/esp_idf/test


### PR DESCRIPTION
Node16 has been deprecated by GitHub. Update all of our actions to the latest version so that they use Node20.

Resolves golioth/firmware-issue-tracker#400