### PR TITLE
doxygen: fix root url used by sitemap

### DIFF
--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -1639,7 +1639,7 @@ TOC_EXPAND             = NO
 # protocol see https://www.sitemaps.org
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SITEMAP_URL            = /
+SITEMAP_URL            = https://firmware-sdk-docs.golioth.io
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that


### PR DESCRIPTION
The root url was specified by / but needs to be the actual url of the host site.