### PR TITLE
examples: zephyr: lightdb: extend timeout

### DIFF
--- a/examples/zephyr/lightdb/delete/src/main.c
+++ b/examples/zephyr/lightdb/delete/src/main.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(lightdb_delete, LOG_LEVEL_DBG);
 
 #include <samples/common/net_connect.h>
 
-#define APP_TIMEOUT_S 1
+#define APP_TIMEOUT_S 5
 
 struct golioth_client *client;
 static K_SEM_DEFINE(connected, 0, 1);

--- a/examples/zephyr/lightdb/get/src/main.c
+++ b/examples/zephyr/lightdb/get/src/main.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(lightdb_get, LOG_LEVEL_DBG);
 
 #include <samples/common/net_connect.h>
 
-#define APP_TIMEOUT_S 1
+#define APP_TIMEOUT_S 5
 
 struct golioth_client *client;
 static K_SEM_DEFINE(connected, 0, 1);

--- a/examples/zephyr/lightdb/observe/src/main.c
+++ b/examples/zephyr/lightdb/observe/src/main.c
@@ -15,8 +15,6 @@ LOG_MODULE_REGISTER(lightdb_observe, LOG_LEVEL_DBG);
 
 #include <samples/common/net_connect.h>
 
-#define APP_TIMEOUT_S 1
-
 struct golioth_client *client;
 static K_SEM_DEFINE(connected, 0, 1);
 

--- a/examples/zephyr/lightdb/set/src/main.c
+++ b/examples/zephyr/lightdb/set/src/main.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(lightdb_set, LOG_LEVEL_DBG);
 
 #include <samples/common/net_connect.h>
 
-#define APP_TIMEOUT_S 1
+#define APP_TIMEOUT_S 5
 
 struct golioth_client *client;
 static K_SEM_DEFINE(connected, 0, 1);


### PR DESCRIPTION
The lightdb examples were using a 1 second timeout for synchronous operations, which we can hit quite often on a cell network. Extending the timeout to 5 seconds should be more than sufficient.