### PR TITLE
examples: zephyr: certificate_provisioning: fix deadlock

### DIFF
--- a/examples/zephyr/certificate_provisioning/src/main.c
+++ b/examples/zephyr/certificate_provisioning/src/main.c
@@ -160,8 +160,6 @@ int main(void)
         client = golioth_client_create(&client_config);
 
         golioth_client_register_event_callback(client, on_client_event, NULL);
-
-        k_sem_take(&connected, K_FOREVER);
     }
     else
     {


### PR DESCRIPTION
We were waiting for the connected semaphore twice, which results in the example hanging forever on the second sem wait.

Fixes golioth/firmware-issue-tracker#416
Fixes golioth/firmware-issue-tracker#410