### PR TITLE
coap_client_zephyr: remove unused client struct member

### DIFF
--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -499,8 +499,7 @@ free_req:
 static void on_keepalive(golioth_sys_timer_t timer, void *arg)
 {
     struct golioth_client *client = arg;
-    if (client->is_running && golioth_client_num_items_in_request_queue(client) == 0
-        && !client->pending_req)
+    if (client->is_running && golioth_client_num_items_in_request_queue(client) == 0)
     {
         golioth_coap_client_empty(client, false, GOLIOTH_SYS_WAIT_FOREVER);
     }

--- a/src/coap_client_zephyr.h
+++ b/src/coap_client_zephyr.h
@@ -74,7 +74,6 @@ struct golioth_client
     bool end_session;
     bool session_connected;
     struct golioth_client_config config;
-    golioth_coap_request_msg_t *pending_req;
     golioth_coap_observe_info_t observations[CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS];
     // token to use for block GETs (must use same token for all blocks)
     uint8_t block_token[8];


### PR DESCRIPTION
The `pending_req` member is a relic from libcoap and not used in the Zephyr coap client implementation.