### PR TITLE
pytest-hil: respect timeout when waiting for serial input

### DIFF
--- a/tests/hil/scripts/pytest-hil/board.py
+++ b/tests/hil/scripts/pytest-hil/board.py
@@ -33,7 +33,8 @@ class Board(ABC):
     def wait_for_regex_in_line(self, regex, timeout_s=20, log=True):
         start_time = time()
         while True:
-            line = self.serial_device.readline().decode('utf-8', errors='replace').replace("\r\n", "")
+            self.serial_device.timeout=timeout_s
+            line = self.serial_device.read_until().decode('utf-8', errors='replace').replace("\r\n", "")
             if line != "" and log:
                 print(line)
             if time() - start_time > timeout_s:


### PR DESCRIPTION
The pytest-hil package uses serial.readline() in a loop to wait for strings. Each iteration through the loop, we check for a timeout. But serial.readline() itself has no timeout and so if we receive no input at all, we will never check the timeout and hang forever. This happens sometimes when the serial port gets locked up (e.g. on the mimxrt1024).

Fixes golioth/firmware-issue-tracker#424