### PR TITLE
examples: zephyr: hardcoded_credentials: replace strlen() with sizeof()

### DIFF
--- a/examples/zephyr/common/hardcoded_credentials.c
+++ b/examples/zephyr/common/hardcoded_credentials.c
@@ -48,9 +48,9 @@ static const struct golioth_client_config _golioth_client_config = {
             .psk =
                 {
                     .psk_id = CONFIG_GOLIOTH_SAMPLE_PSK_ID,
-                    .psk_id_len = strlen(CONFIG_GOLIOTH_SAMPLE_PSK_ID),
+                    .psk_id_len = sizeof(CONFIG_GOLIOTH_SAMPLE_PSK_ID) - 1,
                     .psk = CONFIG_GOLIOTH_SAMPLE_PSK,
-                    .psk_len = strlen(CONFIG_GOLIOTH_SAMPLE_PSK),
+                    .psk_len = sizeof(CONFIG_GOLIOTH_SAMPLE_PSK) - 1,
                 },
         },
 };


### PR DESCRIPTION
Fix following build error when used with `native_sim`:

```
/hardcoded_credentials.c:51:35: error: initializer element is not constant
   51 |         .psk_id_len = strlen(CONFIG_GOLIOTH_SAMPLE_PSK_ID),
      |                       ^~~~~~
```

by replacing `strlen()` with `sizeof() - 1`.