### PR TITLE
zephyr: coap_req: do not free unallocated 'coap_req'

### DIFF
--- a/src/zephyr_coap_req.c
+++ b/src/zephyr_coap_req.c
@@ -544,7 +544,7 @@ int golioth_coap_req_cb(struct golioth_client *client,
     if (err)
     {
         LOG_ERR("Failed to create new CoAP GET request: %d", err);
-        goto free_req;
+        return err;
     }
 
     if (method == COAP_METHOD_GET && (flags & GOLIOTH_COAP_REQ_OBSERVE))


### PR DESCRIPTION
Fix undefined behavior related to `free()` of uninitialized pointer. Just
return early when allocation with `golioth_coap_req_new()` has failed.