### PR TITLE
zephyr: allow to override GOLIOTH_COAP_HOST_URI from env

### DIFF
--- a/examples/zephyr/common/Kconfig
+++ b/examples/zephyr/common/Kconfig
@@ -11,8 +11,6 @@ menuconfig GOLIOTH_SAMPLE_COMMON
 
 if GOLIOTH_SAMPLE_COMMON
 
-rsource "Kconfig.defconfig"
-
 choice GOLIOTH_SAMPLE_AUTH_TYPE
 	prompt "Authentication type"
 

--- a/examples/zephyr/common/Kconfig.defconfig
+++ b/examples/zephyr/common/Kconfig.defconfig
@@ -102,6 +102,9 @@ config POSIX_MAX_FDS
 config REBOOT
 	default y
 
+config GOLIOTH_COAP_HOST_URI
+	default "$(GOLIOTH_COAP_HOST_URI)" if "$(GOLIOTH_COAP_HOST_URI)" != ""
+
 if GOLIOTH_AUTH_METHOD_PSK
 
 config GOLIOTH_SAMPLE_PSK_ID

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -1,6 +1,8 @@
 # Copyright (c) 2023 Golioth, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+rsource '${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/examples/zephyr/common/Kconfig.defconfig'
+
 config LIBCOAP_TLS_HOSTNAME_LEN_MAX
 	int "Maximum length for hostname of a TLS peer"
 	default 64


### PR DESCRIPTION
So far `examples/zephyr/common/Kconfig.default` was sourced at the
beginning of `examples/zephyr/common/Kconfig`. The latter was source
however at the end of `port/zephyr/Kconfig`. This means that any default
values inside of `port/zephyr/Kconfig` could not be overridden.

Source `Kconfig.default` at the beginning of `port/zephyr/Kconfig`, so that
all SDK Kconfig options can be overridden.

Provide a default entry for `GOLIOTH_COAP_HOST_URI`, so environment variable
with that name (if defined) will override default value.

This is useful for testing with self-hosted backend instances.