### PR TITLE
Get wifi from gh secrets

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -131,7 +131,6 @@ jobs:
           GOLIOTH_API_KEY: ${{ secrets.PROD_CI_PROJECT_API_KEY }}
           WIFI_SSID: ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}
           WIFI_PSK: ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}
-          GOLIOTH_CREDENTIALS_FILE: /opt/credentials/credentials_${{ inputs.hil_board }}.yml
         run: |
           source /opt/credentials/runner_env.sh
           export PATH=$PATH:/opt/SEGGER/JLink

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -129,6 +129,8 @@ jobs:
           hil_board: ${{ inputs.hil_board }}
           west_board: ${{ inputs.west_board }}
           GOLIOTH_API_KEY: ${{ secrets.PROD_CI_PROJECT_API_KEY }}
+          WIFI_SSID: ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}
+          WIFI_PSK: ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}
           GOLIOTH_CREDENTIALS_FILE: /opt/credentials/credentials_${{ inputs.hil_board }}.yml
         run: |
           source /opt/credentials/runner_env.sh

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -69,4 +69,10 @@ jobs:
         run: |
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
-          pytest --rootdir . tests/hil/tests/connection --board esp-idf --port ${!PORT_VAR} --credentials-file /opt/credentials/credentials_${hil_board}.yml --fw-image merged.bin --api-key ${{ secrets.PROD_CI_PROJECT_API_KEY }}
+          pytest --rootdir . tests/hil/tests/connection                       \
+            --board esp-idf                                                   \
+            --port ${!PORT_VAR}                                               \
+            --fw-image merged.bin                                             \
+            --api-key ${{ secrets.PROD_CI_PROJECT_API_KEY }}                  \
+            --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
+            --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -97,4 +97,11 @@ jobs:
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
           SNR_VAR=CI_${hil_board^^}_SNR
-          pytest --rootdir . tests/hil/tests/connection --board ${hil_board} --port ${!PORT_VAR} --credentials-file /opt/credentials/credentials_${hil_board}.yml --fw-image ${{ inputs.binary_name }} --serial-number ${!SNR_VAR} --api-key ${{ secrets.PROD_CI_PROJECT_API_KEY }}
+          pytest --rootdir . tests/hil/tests/connection                       \
+            --board ${hil_board}                                              \
+            --port ${!PORT_VAR}                                               \
+            --fw-image ${{ inputs.binary_name }}                              \
+            --serial-number ${!SNR_VAR}                                       \
+            --api-key ${{ secrets.PROD_CI_PROJECT_API_KEY }}                  \
+            --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
+            --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}

--- a/examples/zephyr/fw_update/pytest/conftest.py
+++ b/examples/zephyr/fw_update/pytest/conftest.py
@@ -7,8 +7,8 @@ UPDATE_PACKAGE = 'main'
 
 
 def pytest_addoption(parser):
-    parser.addoption("--credentials-file", type=str,
-                     help="YAML formatted settings file")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
     parser.addoption("--west-board", type=str,
                      help="Name of the board as specified in the Zephyr tree")
 
@@ -17,14 +17,19 @@ def pytest_addoption(parser):
 def anyio_backend():
     return 'trio'
 
+@pytest.fixture(scope="session")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
+    else:
+        return os.environ['WIFI_SSID']
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    if request.config.getoption("--credentials-file") is not None:
-        return request.config.getoption("---credentials-file")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['GOLIOTH_CREDENTIALS_FILE']
-
+        return os.environ['WIFI_PSK']
 
 @pytest.fixture(scope="session")
 def west_board(request):

--- a/examples/zephyr/fw_update/pytest/test_sample.py
+++ b/examples/zephyr/fw_update/pytest/test_sample.py
@@ -7,7 +7,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_fw_update(shell, project, device, credentials_file, fw_info, release):
+async def test_fw_update(shell, project, device, wifi_ssid, wifi_psk, fw_info, release):
 
     # Wait for app to start running or 10 seconds to pass so runtime settings are ready.
 
@@ -15,11 +15,6 @@ async def test_fw_update(shell, project, device, credentials_file, fw_info, rele
         shell._device.readlines_until(regex=".*Start FW Update sample.", timeout=10.0)
     except:
         pass
-
-    # Read credentials
-
-    with open(credentials_file, 'r') as f:
-        credentials = yaml.safe_load(f)
 
     # Set Golioth credential
 
@@ -29,10 +24,8 @@ async def test_fw_update(shell, project, device, credentials_file, fw_info, rele
 
     # Set WiFi credential
 
-    for setting in credentials['settings']:
-        if 'golioth' in setting:
-            continue
-        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())

--- a/examples/zephyr/hello/pytest/conftest.py
+++ b/examples/zephyr/hello/pytest/conftest.py
@@ -2,16 +2,23 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--credentials-file", type=str,
-                     help="YAML formatted settings file")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    if request.config.getoption("--credentials-file") is not None:
-        return request.config.getoption("---credentials-file")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+        return os.environ['WIFI_SSID']
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ['WIFI_PSK']

--- a/examples/zephyr/hello/pytest/test_sample.py
+++ b/examples/zephyr/hello/pytest/test_sample.py
@@ -10,12 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_hello(shell, device, credentials_file):
-    # Read credentials
-
-    with open(credentials_file, 'r') as f:
-        credentials = yaml.safe_load(f)
-
+async def test_hello(shell, device, wifi_ssid, wifi_psk):
     time.sleep(2)
 
     # Set Golioth credential
@@ -26,10 +21,8 @@ async def test_hello(shell, device, credentials_file):
 
     # Set WiFi credential
 
-    for setting in credentials['settings']:
-        if 'golioth' in setting:
-            continue
-        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())

--- a/examples/zephyr/lightdb/delete/pytest/conftest.py
+++ b/examples/zephyr/lightdb/delete/pytest/conftest.py
@@ -2,16 +2,23 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--credentials-file", type=str,
-                     help="YAML formatted settings file")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    if request.config.getoption("--credentials-file") is not None:
-        return request.config.getoption("---credentials-file")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+        return os.environ['WIFI_SSID']
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ['WIFI_PSK']

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -9,17 +9,12 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_lightdb_delete(shell, device, credentials_file):
+async def test_lightdb_delete(shell, device, wifi_ssid, wifi_psk):
     # Set counter in lightdb state
 
     await device.lightdb.set("counter", 34)
     counter = await device.lightdb.get("counter")
     assert counter == 34
-
-    # Read credentials
-
-    with open(credentials_file, 'r') as f:
-        credentials = yaml.safe_load(f)
 
     time.sleep(2)
 
@@ -31,10 +26,8 @@ async def test_lightdb_delete(shell, device, credentials_file):
 
     # Set WiFi credential
 
-    for setting in credentials['settings']:
-        if 'golioth' in setting:
-            continue
-        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())

--- a/examples/zephyr/lightdb/get/pytest/conftest.py
+++ b/examples/zephyr/lightdb/get/pytest/conftest.py
@@ -2,16 +2,23 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--credentials-file", type=str,
-                     help="YAML formatted settings file")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    if request.config.getoption("--credentials-file") is not None:
-        return request.config.getoption("---credentials-file")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+        return os.environ['WIFI_SSID']
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ['WIFI_PSK']

--- a/examples/zephyr/lightdb/get/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/get/pytest/test_sample.py
@@ -9,15 +9,10 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_lightdb_get(shell, device, credentials_file):
+async def test_lightdb_get(shell, device, wifi_ssid, wifi_psk):
     # Delete counter in lightdb state
 
     await device.lightdb.delete("counter")
-
-    # Read credentials
-
-    with open(credentials_file, 'r') as f:
-        credentials = yaml.safe_load(f)
 
     time.sleep(2)
 
@@ -29,10 +24,8 @@ async def test_lightdb_get(shell, device, credentials_file):
 
     # Set WiFi credential
 
-    for setting in credentials['settings']:
-        if 'golioth' in setting:
-            continue
-        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())

--- a/examples/zephyr/lightdb/observe/pytest/conftest.py
+++ b/examples/zephyr/lightdb/observe/pytest/conftest.py
@@ -2,16 +2,23 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--credentials-file", type=str,
-                     help="YAML formatted settings file")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    if request.config.getoption("--credentials-file") is not None:
-        return request.config.getoption("---credentials-file")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+        return os.environ['WIFI_SSID']
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ['WIFI_PSK']

--- a/examples/zephyr/lightdb/observe/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/observe/pytest/test_sample.py
@@ -9,15 +9,10 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_lightdb_observe(shell, device, credentials_file):
+async def test_lightdb_observe(shell, device, wifi_ssid, wifi_psk):
     # Delete counter in lightdb state
 
     await device.lightdb.delete("counter")
-
-    # Read credentials
-
-    with open(credentials_file, 'r') as f:
-        credentials = yaml.safe_load(f)
 
     time.sleep(2)
 
@@ -29,10 +24,8 @@ async def test_lightdb_observe(shell, device, credentials_file):
 
     # Set WiFi credential
 
-    for setting in credentials['settings']:
-        if 'golioth' in setting:
-            continue
-        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())

--- a/examples/zephyr/lightdb/set/pytest/conftest.py
+++ b/examples/zephyr/lightdb/set/pytest/conftest.py
@@ -2,16 +2,23 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--credentials-file", type=str,
-                     help="YAML formatted settings file")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    if request.config.getoption("--credentials-file") is not None:
-        return request.config.getoption("---credentials-file")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+        return os.environ['WIFI_SSID']
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ['WIFI_PSK']

--- a/examples/zephyr/lightdb/set/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/set/pytest/test_sample.py
@@ -9,15 +9,10 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_lightdb_set(shell, device, credentials_file):
+async def test_lightdb_set(shell, device, wifi_ssid, wifi_psk):
     # Delete counter in lightdb state
 
     await device.lightdb.delete("counter")
-
-    # Read credentials
-
-    with open(credentials_file, 'r') as f:
-        credentials = yaml.safe_load(f)
 
     time.sleep(2)
 
@@ -29,10 +24,8 @@ async def test_lightdb_set(shell, device, credentials_file):
 
     # Set WiFi credential
 
-    for setting in credentials['settings']:
-        if 'golioth' in setting:
-            continue
-        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())

--- a/examples/zephyr/lightdb_stream/pytest/conftest.py
+++ b/examples/zephyr/lightdb_stream/pytest/conftest.py
@@ -2,16 +2,23 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--credentials-file", type=str,
-                     help="YAML formatted settings file")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    if request.config.getoption("--credentials-file") is not None:
-        return request.config.getoption("---credentials-file")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+        return os.environ['WIFI_SSID']
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ['WIFI_PSK']

--- a/examples/zephyr/lightdb_stream/pytest/test_sample.py
+++ b/examples/zephyr/lightdb_stream/pytest/test_sample.py
@@ -9,12 +9,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_lightdb_stream(shell, device, credentials_file):
-    # Read credentials
-
-    with open(credentials_file, 'r') as f:
-        credentials = yaml.safe_load(f)
-
+async def test_lightdb_stream(shell, device, wifi_ssid, wifi_psk):
     time.sleep(2)
 
     # Set Golioth credential
@@ -25,10 +20,8 @@ async def test_lightdb_stream(shell, device, credentials_file):
 
     # Set WiFi credential
 
-    for setting in credentials['settings']:
-        if 'golioth' in setting:
-            continue
-        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())

--- a/examples/zephyr/logging/pytest/conftest.py
+++ b/examples/zephyr/logging/pytest/conftest.py
@@ -2,16 +2,23 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--credentials-file", type=str,
-                     help="YAML formatted settings file")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    if request.config.getoption("--credentials-file") is not None:
-        return request.config.getoption("---credentials-file")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+        return os.environ['WIFI_SSID']
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ['WIFI_PSK']

--- a/examples/zephyr/logging/pytest/test_sample.py
+++ b/examples/zephyr/logging/pytest/test_sample.py
@@ -49,12 +49,7 @@ def verify_log_messages(logs):
     assert len(expected_logs) == 0, 'Unable to find all Log messages on server'
 
 
-async def test_logging(shell, device, credentials_file):
-    # Read credentials
-
-    with open(credentials_file, 'r') as f:
-        credentials = yaml.safe_load(f)
-
+async def test_logging(shell, device, wifi_ssid, wifi_psk):
     time.sleep(2)
 
     # Set Golioth credential
@@ -65,10 +60,8 @@ async def test_logging(shell, device, credentials_file):
 
     # Set WiFi credential
 
-    for setting in credentials['settings']:
-        if 'golioth' in setting:
-            continue
-        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())

--- a/examples/zephyr/rpc/pytest/conftest.py
+++ b/examples/zephyr/rpc/pytest/conftest.py
@@ -2,16 +2,23 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--credentials-file", type=str,
-                     help="YAML formatted settings file")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    if request.config.getoption("--credentials-file") is not None:
-        return request.config.getoption("---credentials-file")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+        return os.environ['WIFI_SSID']
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ['WIFI_PSK']

--- a/examples/zephyr/rpc/pytest/test_sample.py
+++ b/examples/zephyr/rpc/pytest/test_sample.py
@@ -8,12 +8,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_logging(shell, device, credentials_file):
-    # Read credentials
-
-    with open(credentials_file, 'r') as f:
-        credentials = yaml.safe_load(f)
-
+async def test_logging(shell, device, wifi_ssid, wifi_psk):
     time.sleep(2)
 
     # Set Golioth credential
@@ -24,10 +19,8 @@ async def test_logging(shell, device, credentials_file):
 
     # Set WiFi credential
 
-    for setting in credentials['settings']:
-        if 'golioth' in setting:
-            continue
-        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())

--- a/examples/zephyr/settings/pytest/conftest.py
+++ b/examples/zephyr/settings/pytest/conftest.py
@@ -2,16 +2,23 @@ import os
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--credentials-file", type=str,
-                     help="YAML formatted settings file")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    if request.config.getoption("--credentials-file") is not None:
-        return request.config.getoption("---credentials-file")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['GOLIOTH_CREDENTIALS_FILE']
+        return os.environ['WIFI_SSID']
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ['WIFI_PSK']

--- a/examples/zephyr/settings/pytest/test_sample.py
+++ b/examples/zephyr/settings/pytest/test_sample.py
@@ -6,7 +6,7 @@ import yaml
 
 pytestmark = pytest.mark.anyio
 
-async def test_settings(shell, project, device, credentials_file):
+async def test_settings(shell, project, device, wifi_ssid, wifi_psk):
     # Delete any existing device-level settings
 
     settings = await device.settings.get_all()
@@ -18,11 +18,6 @@ async def test_settings(shell, project, device, credentials_file):
 
     await project.settings.set('LOOP_DELAY_S', 1)
 
-    # Read credentials
-
-    with open(credentials_file, 'r') as f:
-        credentials = yaml.safe_load(f)
-
     time.sleep(2)
 
     # Set Golioth credential
@@ -33,10 +28,8 @@ async def test_settings(shell, project, device, credentials_file):
 
     # Set WiFi credential
 
-    for setting in credentials['settings']:
-        if 'golioth' in setting:
-            continue
-        shell.exec_command(f"settings set {setting} \"{credentials['settings'][setting]}\"")
+    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())

--- a/tests/hil/scripts/pytest-hil/board.py
+++ b/tests/hil/scripts/pytest-hil/board.py
@@ -2,10 +2,9 @@ from abc import ABC, abstractmethod
 import serial
 from time import time, sleep
 import re
-import yaml
 
 class Board(ABC):
-    def __init__(self, port, baud, credentials_file, fw_image, serial_number):
+    def __init__(self, port, baud, wifi_ssid, wifi_psk, fw_image, serial_number):
         if serial_number:
             self.serial_number = serial_number
         self.port = port
@@ -18,14 +17,9 @@ class Board(ABC):
 
         self.serial_device = serial.Serial(port, baud, timeout=1)
 
-        # Read credentials
-        with open(credentials_file, 'r') as f:
-            credentials = yaml.safe_load(f)
-            settings = credentials['settings']
-
         # Set WiFi credentials
         if self.USES_WIFI:
-            self.set_wifi_credentials(settings['wifi/ssid'], settings['wifi/psk'])
+            self.set_wifi_credentials(wifi_ssid, wifi_psk)
 
     def wait_for_regex_in_line(self, regex, timeout_s=20, log=True):
         start_time = time()

--- a/tests/hil/scripts/pytest-hil/plugin.py
+++ b/tests/hil/scripts/pytest-hil/plugin.py
@@ -12,14 +12,13 @@ def pytest_addoption(parser):
             help="The port to which the device is attached (eg: /dev/ttyACM0)")
     parser.addoption("--baud", type=int, default=115200,
             help="Serial port baud rate (default: 115200)")
-    parser.addoption(
-        "--credentials-file", action="store", type=str,
-        help="YAML formatted settings file"
-    )
     parser.addoption("--fw-image", type=str,
             help="Firmware binary to program to device")
     parser.addoption("--serial-number", type=str,
             help="Serial number to identify on-board debugger")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk", type=str, help="WiFi PSK")
+
 
 @pytest.fixture(scope="session")
 def board_name(request):
@@ -34,10 +33,6 @@ def baud(request):
     return request.config.getoption("--baud")
 
 @pytest.fixture(scope="session")
-def credentials_file(request):
-    return request.config.getoption("--credentials-file")
-
-@pytest.fixture(scope="session")
 def fw_image(request):
     return request.config.getoption("--fw-image")
 
@@ -45,18 +40,25 @@ def fw_image(request):
 def serial_number(request):
     return request.config.getoption("--serial-number")
 
+@pytest.fixture(scope="session")
+def wifi_ssid(request):
+    return request.config.getoption("--wifi-ssid")
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    return request.config.getoption("--wifi-psk")
 
 @pytest.fixture(scope="module")
-def board(board_name, port, baud, credentials_file, fw_image, serial_number):
+def board(board_name, port, baud, wifi_ssid, wifi_psk, fw_image, serial_number):
     if board_name.lower() == "esp-idf":
-        return ESPIDFBoard(port, baud, credentials_file, fw_image, serial_number)
+        return ESPIDFBoard(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     elif board_name.lower() == "esp32_devkitc_wrover":
-        return ESP32DevKitCWROVER(port, baud, credentials_file, fw_image, serial_number)
+        return ESP32DevKitCWROVER(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     elif board_name.lower() == "nrf52840dk":
-        return nRF52840DK(port, baud, credentials_file, fw_image, serial_number)
+        return nRF52840DK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     elif board_name.lower() == "nrf9160dk":
-        return nRF9160DK(port, baud, credentials_file, fw_image, serial_number)
+        return nRF9160DK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     elif board_name.lower() == "mimxrt1024_evk":
-        return MIMXRT1024EVK(port, baud, credentials_file, fw_image, serial_number)
+        return MIMXRT1024EVK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     else:
         raise ValueError("Unknown board")


### PR DESCRIPTION
This pulls WiFi credentials for each runner from GitHub secrets, instead of using prepositioned config files on the runners. With this is in place, we're almost ready to retire the configuration files, only the legacy `Test on Hardware` workflow still uses them.

The last commit is rather large, but it's making the same small change for each Zephyr sample.

Resolves golioth/firmware-issue-tracker#359