### PR TITLE
[ESP-IDF] Enable compiler warnings errors

### DIFF
--- a/port/esp_idf/components/golioth_sdk/CMakeLists.txt
+++ b/port/esp_idf/components/golioth_sdk/CMakeLists.txt
@@ -50,6 +50,18 @@ idf_component_register(
         "${sdk_src}/isrgrootx1.der"
 )
 
+# Enable errors and warnings that ESP-IDF disables by default
+list(APPEND EXTRA_C_FLAGS_LIST
+    -Werror=unused-function
+    -Werror=unused-variable
+    -Werror=unused-but-set-variable
+    -Werror=deprecated-declarations
+)
+
+if(${IDF_VERSION_MAJOR} GREATER_EQUAL "5")
+    list(APPEND EXTRA_C_FLAGS_LIST -Wenum-conversion -Werror=enum-conversion)
+endif()
+
 component_compile_options(${EXTRA_C_FLAGS_LIST})
 
 target_compile_definitions(${COMPONENT_LIB} PUBLIC WITH_POSIX)

--- a/port/esp_idf/golioth_port_config.h
+++ b/port/esp_idf/golioth_port_config.h
@@ -8,7 +8,31 @@
 #include <sdkconfig.h>
 #include <esp_log.h>
 
-#define GLTH_LOG_BUFFER_HEXDUMP ESP_LOG_BUFFER_HEXDUMP
+#define GLTH_LOG_BUFFER_HEXDUMP(TAG, payload, size, level)                   \
+    do                                                                       \
+    {                                                                        \
+        switch (level)                                                       \
+        {                                                                    \
+            case GOLIOTH_DEBUG_LOG_LEVEL_ERROR:                              \
+                ESP_LOG_BUFFER_HEXDUMP(TAG, payload, size, ESP_LOG_ERROR);   \
+                break;                                                       \
+            case GOLIOTH_DEBUG_LOG_LEVEL_WARN:                               \
+                ESP_LOG_BUFFER_HEXDUMP(TAG, payload, size, ESP_LOG_WARN);    \
+                break;                                                       \
+            case GOLIOTH_DEBUG_LOG_LEVEL_INFO:                               \
+                ESP_LOG_BUFFER_HEXDUMP(TAG, payload, size, ESP_LOG_INFO);    \
+                break;                                                       \
+            case GOLIOTH_DEBUG_LOG_LEVEL_DEBUG:                              \
+                ESP_LOG_BUFFER_HEXDUMP(TAG, payload, size, ESP_LOG_DEBUG);   \
+                break;                                                       \
+            case GOLIOTH_DEBUG_LOG_LEVEL_VERBOSE:                            \
+                ESP_LOG_BUFFER_HEXDUMP(TAG, payload, size, ESP_LOG_VERBOSE); \
+                break;                                                       \
+            case GOLIOTH_DEBUG_LOG_LEVEL_NONE:                               \
+            default:                                                         \
+                break;                                                       \
+        }                                                                    \
+    } while (0)
 
 // TODO - should we hook into the ESP logging backend via esp_log_set_vprintf?
 // This would enable all logs to be sent to Golioth (not just the GLTH_LOGX logs).

--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -418,7 +418,7 @@ static void golioth_coap_empty(golioth_coap_request_msg_t *req, coap_session_t *
     //     DTLS: session disconnected (reason 1)
     //
     // Instead, we will send an empty DELETE request
-    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_DELETE, session);
+    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_CODE_DELETE, session);
     if (!req_pdu)
     {
         GLTH_LOGE(TAG, "coap_new_pdu() delete failed");
@@ -431,7 +431,7 @@ static void golioth_coap_empty(golioth_coap_request_msg_t *req, coap_session_t *
 
 static void golioth_coap_get(golioth_coap_request_msg_t *req, coap_session_t *session)
 {
-    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_GET, session);
+    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_CODE_GET, session);
     if (!req_pdu)
     {
         GLTH_LOGE(TAG, "coap_new_pdu() get failed");
@@ -448,7 +448,7 @@ static void golioth_coap_get_block(golioth_coap_request_msg_t *req,
                                    struct golioth_client *client,
                                    coap_session_t *session)
 {
-    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_GET, session);
+    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_CODE_GET, session);
     if (!req_pdu)
     {
         GLTH_LOGE(TAG, "coap_new_pdu() get failed");
@@ -479,7 +479,7 @@ static void golioth_coap_get_block(golioth_coap_request_msg_t *req,
 
 static void golioth_coap_post(golioth_coap_request_msg_t *req, coap_session_t *session)
 {
-    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_POST, session);
+    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_CODE_POST, session);
     if (!req_pdu)
     {
         GLTH_LOGE(TAG, "coap_new_pdu() post failed");
@@ -495,7 +495,7 @@ static void golioth_coap_post(golioth_coap_request_msg_t *req, coap_session_t *s
 
 static void golioth_coap_delete(golioth_coap_request_msg_t *req, coap_session_t *session)
 {
-    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_DELETE, session);
+    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_CODE_DELETE, session);
     if (!req_pdu)
     {
         GLTH_LOGE(TAG, "coap_new_pdu() delete failed");
@@ -537,7 +537,7 @@ static void golioth_coap_observe(golioth_coap_request_msg_t *req,
                                  coap_session_t *session)
 {
     // GET with an OBSERVE option
-    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_GET, session);
+    coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_CODE_GET, session);
     if (!req_pdu)
     {
         GLTH_LOGE(TAG, "coap_new_pdu() get failed");


### PR DESCRIPTION
ESP-IDF disables some compiler warnings and errors that are useful and should not be ignored. This commit explicitly enables some warnings and errors for the SDK component and fixes the warnings/errors that doing so revealed.

Resolves golioth/firmware-issue-tracker#441