### PR TITLE
ci: delete `zephyr` folder before `west update`

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -98,6 +98,8 @@ jobs:
           chmod +x $(go env GOPATH)/bin/mcumgr
       - name: Init and update west
         run: |
+          rm -rf zephyr
+
           mkdir -p .west
           cat <<EOF > .west/config
           [manifest]


### PR DESCRIPTION
If the `zephyr` folder already exists, west will leave local modifications to the tree. This can cause issue because other workflows can sometimes leave the tree in a bad state. Removing the folder before running `west update` ensures that west will always clone a fresh copy of the repository.

Fixes golioth/firmware-issue-tracker#446