### PR TITLE
ci: fix infinite hangs

### DIFF
--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python dependencies
         run: |
-          pip install pytest
+          pip install pytest pytest-timeout
           pip install tests/hil/scripts/pytest-hil
           pip install git+https://github.com/golioth/python-golioth-tools@v0.5.1
       - name: Power Cycle USB Hub
@@ -75,4 +75,5 @@ jobs:
             --fw-image merged.bin                                             \
             --api-key ${{ secrets.PROD_CI_PROJECT_API_KEY }}                  \
             --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
-            --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}
+            --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
+            --timeout=600

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python dependencies
         run: |
-          pip install pytest
+          pip install pytest pytest-timeout
           pip install tests/hil/scripts/pytest-hil
           pip install git+https://github.com/golioth/python-golioth-tools@v0.5.1
       - name: Power Cycle USB Hub
@@ -104,4 +104,5 @@ jobs:
             --serial-number ${!SNR_VAR}                                       \
             --api-key ${{ secrets.PROD_CI_PROJECT_API_KEY }}                  \
             --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
-            --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}
+            --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
+            --timeout=600

--- a/tests/hil/scripts/pytest-hil/board.py
+++ b/tests/hil/scripts/pytest-hil/board.py
@@ -15,7 +15,7 @@ class Board(ABC):
             # Wait for reboot
             sleep(3)
 
-        self.serial_device = serial.Serial(port, baud, timeout=1)
+        self.serial_device = serial.Serial(port, baud, timeout=1, write_timeout=1)
 
         # Set WiFi credentials
         if self.USES_WIFI:


### PR DESCRIPTION
The rt1024 connection test sometimes hangs forever, despite read timeouts on the serial device. This is because the serial device was hanging up on _writes_. This PR adds a write_timeout to the serial device so the test will fail if the device becomes locked up.

As an additional precaution, this also installs and uses the `pytest-timeout` pytest plugin to add a 10 minute overall timeout to each test. 10 minutes is more than enough for our current tests, and will catch any other infinite loops or hangs that may occur.

Fixes golioth/firmware-issue-tracker#424