### PR TITLE
settings: check if int type settings are within range

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -288,6 +288,13 @@ static int settings_decode(zcbor_state_t *zsd, void *value)
                     break;
                 }
 
+                if ((value < registered_setting->int_min_val)
+                    || (value > registered_setting->int_max_val))
+                {
+                    setting_status = GOLIOTH_SETTINGS_VALUE_OUTSIDE_RANGE;
+                    break;
+                }
+
                 setting_status =
                     registered_setting->int_cb((int32_t) value, registered_setting->cb_arg);
                 break;


### PR DESCRIPTION
The Settings API allows users to specify a minimum and maximum value for integer type settings. However, we weren't actually enforcing these limits.

Fixes golioth/firmware-issue-tracker#455