### PR TITLE
ci: parameterize backend environment target for HIL tests

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -19,9 +19,19 @@ on:
         required: false
         type: boolean
         default: true
+      api-url:
+        required: true
+        type: string
+      api-key-id:
+        required: true
+        type: string
+      coap_gateway_url:
+        required: true
+        type: string
 
 jobs:
   build:
+    name: zephyr-${{ inputs.hil_board }}-twister-build
     container: golioth/golioth-zephyr-base:0.16.3-SDK-v0
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
@@ -56,11 +66,14 @@ jobs:
 
     - name: Compile Tests
       run: |
+        export EXTRA_BUILD_ARGS=-x=CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"
+
         zephyr/scripts/twister                                                \
               --platform ${{ inputs.west_board }}                             \
               -T modules/lib/golioth-firmware-sdk/examples/zephyr             \
               --build-only                                                    \
-              --package-artifacts test_artifacts_${{ inputs.west_board }}.tar
+              --package-artifacts test_artifacts_${{ inputs.west_board }}.tar \
+              $EXTRA_BUILD_ARGS
 
     - name: Save artifacts
       uses: actions/upload-artifact@v4
@@ -69,6 +82,7 @@ jobs:
         path: test_artifacts_${{ inputs.west_board }}.tar
 
   test:
+    name: zephyr-${{ inputs.hil_board }}-twister-run
     if: ${{ inputs.run_tests }}
     needs: build
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
@@ -115,7 +129,7 @@ jobs:
           pip3 install -r zephyr/scripts/requirements-build-test.txt
           pip3 install -r zephyr/scripts/requirements-run-test.txt
 
-          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.5.1
+          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.6.0
       - name: Power Cycle USB Hub
         run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build
@@ -130,7 +144,8 @@ jobs:
         env:
           hil_board: ${{ inputs.hil_board }}
           west_board: ${{ inputs.west_board }}
-          GOLIOTH_API_KEY: ${{ secrets.PROD_CI_PROJECT_API_KEY }}
+          GOLIOTH_API_KEY: ${{ secrets[inputs.api-key-id] }}
+          GOLIOTH_API_URL: ${{ inputs.api-url }}
           WIFI_SSID: ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}
           WIFI_PSK: ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}
         run: |

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -9,9 +9,19 @@ on:
       idf_target:
         required: true
         type: string
+      api-url:
+        required: true
+        type: string
+      api-key-id:
+        required: true
+        type: string
+      coap_gateway_url:
+        required: true
+        type: string
 
 jobs:
   build:
+    name: esp-idf-${{ inputs.hil_board }}-build
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository and Submodules
@@ -23,13 +33,17 @@ jobs:
       with:
         python-version: 3.x
         architecture: 'x64'
+    - name: Prep for build
+      id: build_prep
+      run: |
+        echo CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\" >> tests/hil/platform/esp-idf/sdkconfig.defaults
     - name: Build Test Firmware
       uses: espressif/esp-idf-ci-action@v1
       with:
         esp_idf_version: v5.1.1
         target: ${{ inputs.idf_target }}
         path: 'tests/hil/platform/esp-idf'
-        command: 'idf.py -D GOLIOTH_HIL_TEST=connection build'
+        command: 'idf.py -DGOLIOTH_HIL_TEST=connection build'
     - name: Save Artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -37,6 +51,7 @@ jobs:
         path: tests/hil/platform/esp-idf/build/merged.bin
 
   test:
+    name: esp-idf-${{ inputs.hil_board }}-test
     needs: build
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
 
@@ -54,7 +69,7 @@ jobs:
         run: |
           pip install pytest pytest-timeout
           pip install tests/hil/scripts/pytest-hil
-          pip install git+https://github.com/golioth/python-golioth-tools@v0.5.1
+          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.0
       - name: Power Cycle USB Hub
         run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build
@@ -73,7 +88,8 @@ jobs:
             --board esp-idf                                                   \
             --port ${!PORT_VAR}                                               \
             --fw-image merged.bin                                             \
-            --api-key ${{ secrets.PROD_CI_PROJECT_API_KEY }}                  \
+            --api-url ${{ inputs.api-url }}                                   \
+            --api-key ${{ secrets[inputs.api-key-id] }}                       \
             --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
             --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
             --timeout=600

--- a/.github/workflows/hil_test_trigger.yml
+++ b/.github/workflows/hil_test_trigger.yml
@@ -1,0 +1,14 @@
+name: Hardware-in-the-Loop Tests Trigger (push and schedule)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  schedule:
+    # Run workflow at the start of every day (12 AM UTC)
+    - cron: "0 0 * * *"
+
+jobs:
+  hil_tests:
+    uses: ./.github/workflows/hil_tests.yml
+    secrets: inherit

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -18,9 +18,19 @@ on:
       binary_blob:
         required: false
         type: string
+      api-url:
+        required: true
+        type: string
+      api-key-id:
+        required: true
+        type: string
+      coap_gateway_url:
+        required: true
+        type: string
 
 jobs:
   build:
+    name: zephyr-${{ inputs.hil_board }}-build
     container: golioth/golioth-zephyr-base:0.16.3-SDK-v0
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
@@ -54,8 +64,10 @@ jobs:
         west blobs fetch ${{ inputs.binary_blob }}
 
     - name: Compile
+      shell: bash
       run: |
-        west build -p -b ${{ inputs.west_board }} modules/lib/golioth-firmware-sdk/tests/hil/platform/zephyr -- -DGOLIOTH_HIL_TEST=connection
+        export EXTRA_BUILD_ARGS=-DCONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"
+        west build -p -b ${{ inputs.west_board }} modules/lib/golioth-firmware-sdk/tests/hil/platform/zephyr -- $EXTRA_BUILD_ARGS -DGOLIOTH_HIL_TEST=connection
 
     - name: Save artifacts
       uses: actions/upload-artifact@v4
@@ -64,6 +76,7 @@ jobs:
         path: build/zephyr/${{ inputs.binary_name }}
 
   test:
+    name: zephyr-${{ inputs.hil_board }}-test
     needs: build
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
 
@@ -81,7 +94,7 @@ jobs:
         run: |
           pip install pytest pytest-timeout
           pip install tests/hil/scripts/pytest-hil
-          pip install git+https://github.com/golioth/python-golioth-tools@v0.5.1
+          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.0
       - name: Power Cycle USB Hub
         run: /opt/golioth-scripts/power-cycle-usb-hub.sh
       - name: Download build
@@ -102,7 +115,8 @@ jobs:
             --port ${!PORT_VAR}                                               \
             --fw-image ${{ inputs.binary_name }}                              \
             --serial-number ${!SNR_VAR}                                       \
-            --api-key ${{ secrets.PROD_CI_PROJECT_API_KEY }}                  \
+            --api-url ${{ inputs.api-url }}                                   \
+            --api-key ${{ secrets[inputs.api-key-id] }}                       \
             --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
             --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
             --timeout=600

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -1,13 +1,37 @@
 name: Hardware-in-the-Loop Tests
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-  schedule:
-    # Run workflow at the start of every day (12 AM UTC)
-    - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      api-url:
+        description: "API gateway URL for Golioth backend services"
+        required: false
+        default: "https://api.golioth.io"
+      api-key-id:
+        description: "Name of GitHub secret containing an API key that will be used to authenticate with the Golioth backend"
+        required: false
+        default: "PROD_CI_PROJECT_API_KEY"
+      coap_gateway_url:
+        description: "The CoAP gateway URL to be hardcoded into test firmware"
+        required: false
+        default: "coaps://coap.golioth.io"
+  workflow_call:
+    inputs:
+      api-url:
+        description: "API gateway URL for Golioth backend services"
+        required: false
+        type: string
+        default: "https://api.golioth.io"
+      api-key-id:
+        description: "Name of GitHub secret containing an API key that will be used to authenticate with the Golioth backend"
+        required: false
+        type: string
+        default: "PROD_CI_PROJECT_API_KEY"
+      coap_gateway_url:
+        description: "The CoAP gateway URL to be hardcoded into test firmware"
+        required: false
+        type: string
+        default: "coaps://coap.golioth.io"
 
 jobs:
   hil_test_zephyr:
@@ -39,6 +63,9 @@ jobs:
       manifest: ${{ matrix.manifest }}
       binary_name: ${{ matrix.binary_name}}
       binary_blob: ${{ matrix.binary_blob }}
+      api-url: ${{ inputs.api-url }}
+      api-key-id: ${{ inputs.api-key-id }}
+      coap_gateway_url: ${{ inputs.coap_gateway_url }}
     secrets: inherit
 
   hil_test_esp-idf:
@@ -56,6 +83,9 @@ jobs:
     with:
       hil_board: ${{ matrix.hil_board }}
       idf_target: ${{ matrix.idf_target }}
+      api-url: ${{ inputs.api-url }}
+      api-key-id: ${{ inputs.api-key-id }}
+      coap_gateway_url: ${{ inputs.coap_gateway_url }}
     secrets: inherit
 
   hil_sample_zephyr:
@@ -95,4 +125,7 @@ jobs:
       manifest: ${{ matrix.manifest }}
       binary_blob: ${{ matrix.binary_blob }}
       run_tests: ${{ matrix.run_tests }}
+      api-url: ${{ inputs.api-url }}
+      api-key-id: ${{ inputs.api-key-id }}
+      coap_gateway_url: ${{ inputs.coap_gateway_url }}
     secrets: inherit


### PR DESCRIPTION
This commit provides the option of specifying the API URL, API Key (through GitHub secret name) and CoAP gateway URI to use when triggering HIL tests through the GitHub Actions UI. Together, these options allow targeting the tests against different Golioth backend environments, such as the Dev environment. By default, tests will continue to run against the Production environment.

Inputs (including default values) are only available when the workflow has been either called by another workflow or manually dispatched. So to ensure that the HIL workflow continues to run nightly and on pushes to PRs, there is now a separate workflow that is trigger by schedule, PR and pushes to `main` that calls the HIL tests workflow, which takes input as described above.

Additionally, the GitHub actions UI doesn't handle nested workflow calls well at all, so I've add more descriptive names for each job to make the visualization easier to read.

[Here](https://github.com/golioth/golioth-firmware-sdk/actions/runs/8084586964/job/22090540627) is an example of the workflow being manually dispatched to run against the production backend (using only defaults) and [here](https://github.com/golioth/golioth-firmware-sdk/actions/runs/8084590336/job/22090282113) is one where it is being run against the dev backend environment.