### PR TITLE
ci: test esp-idf samples

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -1,0 +1,96 @@
+name: ESP-IDF Hardware-in-the-Loop Sample Tests
+
+on:
+  workflow_call:
+    inputs:
+      hil_board:
+        required: true
+        type: string
+      idf_target:
+        required: true
+        type: string
+      api-url:
+        required: true
+        type: string
+      api-key-id:
+        required: true
+        type: string
+      coap_gateway_url:
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: esp-idf-${{ inputs.hil_board }}-sample-build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository and Submodules
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: Prep for build
+      id: build_prep
+      run: |
+        echo CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\" >> tests/hil/platform/esp-idf/sdkconfig.defaults
+
+        rm -rf test_binaries
+        mkdir test_binaries
+        echo sample_list=`find examples/esp_idf -type d -name pytest -exec dirname "{}" \;` >> "$GITHUB_OUTPUT"
+    - name: Build Samples
+      uses: espressif/esp-idf-ci-action@v1
+      with:
+        esp_idf_version: v5.2
+        target: ${{ inputs.idf_target }}
+        command: 'for sample in ${{ steps.build_prep.outputs.sample_list }}; do idf.py -C $sample build && mv ${sample}/build/merged.bin test_binaries/$(basename $sample).bin; done'
+    - name: Save Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.hil_board }}-sample-esp-idf
+        path: test_binaries/*
+
+  test:
+    name: esp-idf-${{ inputs.hil_board }}-sample-test
+    needs: build
+    runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
+
+    container:
+      image: golioth/golioth-hil-base:af8e4f5
+      volumes:
+        - /dev:/dev
+        - /home/golioth/credentials:/opt/credentials
+      options: --privileged
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Python dependencies
+        run: |
+          pip install pytest pytest-timeout
+          pip install tests/hil/scripts/pytest-hil
+          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.0
+      - name: Power Cycle USB Hub
+        run: /opt/golioth-scripts/power-cycle-usb-hub.sh
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.hil_board }}-sample-esp-idf
+          path: .
+      - name: Run test
+        shell: bash
+        env:
+          hil_board: ${{ inputs.hil_board }}
+        run: |
+          source /opt/credentials/runner_env.sh
+          PORT_VAR=CI_${hil_board^^}_PORT
+          for sample in `find examples/esp_idf -type d -name pytest -exec dirname "{}" \;`
+          do
+            pytest --rootdir . $sample                                          \
+              --board esp-idf                                                   \
+              --port ${!PORT_VAR}                                               \
+              --fw-image $(basename $sample).bin                                \
+              --api-url ${{ inputs.api-url }}                                   \
+              --api-key ${{ secrets[inputs.api-key-id] }}                       \
+              --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
+              --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
+              --timeout=600
+          done

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -129,3 +129,23 @@ jobs:
       api-key-id: ${{ inputs.api-key-id }}
       coap_gateway_url: ${{ inputs.coap_gateway_url }}
     secrets: inherit
+
+  hil_sample_esp-idf:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - hil_board: esp32s3_devkitc
+            idf_target: esp32s3
+          - hil_board: esp32_devkitc_wrover
+            idf_target: esp32
+          - hil_board: esp32c3_devkitm
+            idf_target: esp32c3
+    uses: ./.github/workflows/hil_sample_esp-idf.yml
+    with:
+      hil_board: ${{ matrix.hil_board }}
+      idf_target: ${{ matrix.idf_target }}
+      api-url: ${{ inputs.api-url }}
+      api-key-id: ${{ inputs.api-key-id }}
+      coap_gateway_url: ${{ inputs.coap_gateway_url }}
+    secrets: inherit


### PR DESCRIPTION
Adds a new workflow for testing ESP-IDF samples. This workflow automatically finds, builds, and tests samples as they are added by looking for directories under `examples/esp-idf` that contain a `pytest` folder.

Resolves golioth/firmware-issue-tracker#436