### PR TITLE
ci: reduce artifact size for twister tests

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -71,7 +71,7 @@ jobs:
         zephyr/scripts/twister                                                \
               --platform ${{ inputs.west_board }}                             \
               -T modules/lib/golioth-firmware-sdk/examples/zephyr             \
-              --build-only                                                    \
+              --prep-artifacts-for-testing                                    \
               --package-artifacts test_artifacts_${{ inputs.west_board }}.tar \
               $EXTRA_BUILD_ARGS
 


### PR DESCRIPTION
Use `--prep-artifacts-for-testing` to reduce the size of the artifacts that are transferred between the build and test jobs in the workflow.

We couldn't use this before because of a bug when using sysbuild with twister that @szczys fixed in Zephyr 3.6.

Resolves golioth/firmware-issue-tracker#465