### PR TITLE
ci: esp-idf-test: remove setup_python step

### DIFF
--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -28,11 +28,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.x
-        architecture: 'x64'
     - name: Prep for build
       id: build_prep
       run: |


### PR DESCRIPTION
The setup_python step isn't necessary to build the ESP-IDF tests (we don't use Python for this job). Removing the setup step saves nearly a minute in build time.