### PR TITLE
Use `@retval` instead of `@return` when relevant

### DIFF
--- a/docs/Style_Guide.md
+++ b/docs/Style_Guide.md
@@ -158,7 +158,7 @@ place to add a code comment.
 * Use `@param [direction] <name> <description>` for function parameters
     - `direction` is one of `in`, `out`, or `inout`
     - Note: a lot of existing code does not specify param direction (these need to be fixed).
-* Use separate `@return <value> - <description>` lines for each possible return type.
+* Use separate `@retval <value> <description>` lines for each possible return type.
 * For `const char*` string parameters, indicate whether the string is expected
   to be NULL-terminated or not.
 * If there are parameters that must not be NULL, indicate this in the description.

--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -204,8 +204,8 @@ bool golioth_client_wait_for_connect(struct golioth_client *client, int timeout_
 ///
 /// @param client The client handle
 ///
-/// @return GOLIOTH_OK Client started
-/// @return GOLIOTH_ERR_NULL Client handle invalid
+/// @retval GOLIOTH_OK Client started
+/// @retval GOLIOTH_ERR_NULL Client handle invalid
 enum golioth_status golioth_client_start(struct golioth_client *client);
 
 /// Stop the Golioth client
@@ -220,8 +220,8 @@ enum golioth_status golioth_client_start(struct golioth_client *client);
 ///
 /// @param client The client handle
 ///
-/// @return GOLIOTH_OK Client stopped
-/// @return GOLIOTH_ERR_NULL Client handle invalid
+/// @retval GOLIOTH_OK Client stopped
+/// @retval GOLIOTH_ERR_NULL Client handle invalid
 enum golioth_status golioth_client_stop(struct golioth_client *client);
 
 /// Destroy a Golioth client
@@ -235,8 +235,8 @@ void golioth_client_destroy(struct golioth_client *client);
 ///
 /// @param client The client handle
 ///
-/// @return true The client is running
-/// @return false The client is not running, or the client handle is not valid
+/// @retval true The client is running
+/// @retval false The client is not running, or the client handle is not valid
 bool golioth_client_is_running(struct golioth_client *client);
 
 /// Returns whether the client is currently connected to Golioth servers.
@@ -246,8 +246,8 @@ bool golioth_client_is_running(struct golioth_client *client);
 ///
 /// @param client The client handle
 ///
-/// @return true The client is connected to Golioth
-/// @return false The client is not connected, or the client handle is not valid
+/// @retval true The client is connected to Golioth
+/// @retval false The client is not connected, or the client handle is not valid
 bool golioth_client_is_connected(struct golioth_client *client);
 
 /// Register a callback that will be called on client events (e.g. connected, disconnected)

--- a/include/golioth/lightdb_state.h
+++ b/include/golioth/lightdb_state.h
@@ -32,11 +32,11 @@
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
 ///
-/// @return GOLIOTH_OK - request enqueued
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
+/// @retval GOLIOTH_OK request enqueued
+/// @retval GOLIOTH_ERR_NULL invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE client is not running, currently stopped
+/// @retval GOLIOTH_ERR_MEM_ALLOC memory allocation error
+/// @retval GOLIOTH_ERR_QUEUE_FULL request queue is full, this request is dropped
 enum golioth_status golioth_lightdb_set_int_async(struct golioth_client *client,
                                                   const char *path,
                                                   int32_t value,
@@ -56,12 +56,12 @@ enum golioth_status golioth_lightdb_set_int_async(struct golioth_client *client,
 /// @param value The value to set at path
 /// @param timeout_s The timeout, in seconds, for receiving a server response
 ///
-/// @return GOLIOTH_OK - response received from server, set was successful
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-/// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
+/// @retval GOLIOTH_OK response received from server, set was successful
+/// @retval GOLIOTH_ERR_NULL invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE client is not running, currently stopped
+/// @retval GOLIOTH_ERR_MEM_ALLOC memory allocation error
+/// @retval GOLIOTH_ERR_QUEUE_FULL request queue is full, this request is dropped
+/// @retval GOLIOTH_ERR_TIMEOUT response not received from server, timeout occurred
 enum golioth_status golioth_lightdb_set_int_sync(struct golioth_client *client,
                                                  const char *path,
                                                  int32_t value,
@@ -129,11 +129,11 @@ enum golioth_status golioth_lightdb_set_string_sync(struct golioth_client *clien
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
 ///
-/// @return GOLIOTH_OK - request enqueued
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
+/// @retval GOLIOTH_OK request enqueued
+/// @retval GOLIOTH_ERR_NULL invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE client is not running, currently stopped
+/// @retval GOLIOTH_ERR_MEM_ALLOC memory allocation error
+/// @retval GOLIOTH_ERR_QUEUE_FULL request queue is full, this request is dropped
 enum golioth_status golioth_lightdb_set_async(struct golioth_client *client,
                                               const char *path,
                                               enum golioth_content_type content_type,
@@ -197,11 +197,11 @@ enum golioth_status golioth_lightdb_get_async(struct golioth_client *client,
 /// @param value Output parameter, memory allocated by caller, populated with value of integer
 /// @param timeout_s The timeout, in seconds, for receiving a server response
 ///
-/// @return GOLIOTH_OK - response received from server, set was successful
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-/// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
+/// @retval GOLIOTH_OK response received from server, set was successful
+/// @retval GOLIOTH_ERR_NULL invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE client is not running, currently stopped
+/// @retval GOLIOTH_ERR_QUEUE_FULL request queue is full, this request is dropped
+/// @retval GOLIOTH_ERR_TIMEOUT response not received from server, timeout occurred
 enum golioth_status golioth_lightdb_get_int_sync(struct golioth_client *client,
                                                  const char *path,
                                                  int32_t *value,
@@ -247,11 +247,11 @@ enum golioth_status golioth_lightdb_get_sync(struct golioth_client *client,
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
 ///
-/// @return GOLIOTH_OK - request enqueued
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
+/// @retval GOLIOTH_OK request enqueued
+/// @retval GOLIOTH_ERR_NULL invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE client is not running, currently stopped
+/// @retval GOLIOTH_ERR_MEM_ALLOC memory allocation error
+/// @retval GOLIOTH_ERR_QUEUE_FULL request queue is full, this request is dropped
 enum golioth_status golioth_lightdb_delete_async(struct golioth_client *client,
                                                  const char *path,
                                                  golioth_set_cb_fn callback,
@@ -269,11 +269,11 @@ enum golioth_status golioth_lightdb_delete_async(struct golioth_client *client,
 /// @param path The path in LightDB state to delete (e.g. "my_integer")
 /// @param timeout_s The timeout, in seconds, for receiving a server response
 ///
-/// @return GOLIOTH_OK - response received from server, set was successful
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-/// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
+/// @retval GOLIOTH_OK response received from server, set was successful
+/// @retval GOLIOTH_ERR_NULL invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE client is not running, currently stopped
+/// @retval GOLIOTH_ERR_QUEUE_FULL request queue is full, this request is dropped
+/// @retval GOLIOTH_ERR_TIMEOUT response not received from server, timeout occurred
 enum golioth_status golioth_lightdb_delete_sync(struct golioth_client *client,
                                                 const char *path,
                                                 int32_t timeout_s);
@@ -297,11 +297,11 @@ enum golioth_status golioth_lightdb_delete_sync(struct golioth_client *client,
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
 ///
-/// @return GOLIOTH_OK - request enqueued
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
+/// @retval GOLIOTH_OK request enqueued
+/// @retval GOLIOTH_ERR_NULL invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE client is not running, currently stopped
+/// @retval GOLIOTH_ERR_MEM_ALLOC memory allocation error
+/// @retval GOLIOTH_ERR_QUEUE_FULL request queue is full, this request is dropped
 enum golioth_status golioth_lightdb_observe_async(struct golioth_client *client,
                                                   const char *path,
                                                   golioth_get_cb_fn callback,

--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -100,8 +100,8 @@ struct golioth_ota_manifest
 /// @param payload_size Size of payload, in bytes
 /// @param manifest Output param, memory allocated by caller, populated with manifest
 ///
-/// @return GOLIOTH_OK - payload converted to struct golioth_ota_manifest
-/// @return GOLIOTH_ERR_INVALID_FORMAT - failed to parse manifest
+/// @retval GOLIOTH_OK payload converted to struct golioth_ota_manifest
+/// @retval GOLIOTH_ERR_INVALID_FORMAT failed to parse manifest
 enum golioth_status golioth_ota_payload_as_manifest(const uint8_t *payload,
                                                     size_t payload_size,
                                                     struct golioth_ota_manifest *manifest);
@@ -152,11 +152,11 @@ enum golioth_status golioth_ota_observe_manifest_async(struct golioth_client *cl
 /// @param is_last Set to true, if this is the last block
 /// @param timeout_s The timeout, in seconds, for receiving a server response
 ///
-/// @return GOLIOTH_OK - response received from server, get was successful
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-/// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
+/// @retval GOLIOTH_OK response received from server, get was successful
+/// @retval GOLIOTH_ERR_NULL invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE client is not running, currently stopped
+/// @retval GOLIOTH_ERR_QUEUE_FULL request queue is full, this request is dropped
+/// @retval GOLIOTH_ERR_TIMEOUT response not received from server, timeout occurred
 enum golioth_status golioth_ota_get_block_sync(struct golioth_client *client,
                                                const char *package,
                                                const char *version,
@@ -176,11 +176,11 @@ enum golioth_status golioth_ota_get_block_sync(struct golioth_client *client,
 /// @param target_version The artifact new/target version from manifest. Can be NULL.
 /// @param timeout_s The timeout, in seconds, for receiving a server response
 ///
-/// @return GOLIOTH_OK - response received from server, get was successful
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-/// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
+/// @retval GOLIOTH_OK response received from server, get was successful
+/// @retval GOLIOTH_ERR_NULL invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE client is not running, currently stopped
+/// @retval GOLIOTH_ERR_QUEUE_FULL request queue is full, this request is dropped
+/// @retval GOLIOTH_ERR_TIMEOUT response not received from server, timeout occurred
 enum golioth_status golioth_ota_report_state_sync(struct golioth_client *client,
                                                   enum golioth_ota_state state,
                                                   enum golioth_ota_reason reason,

--- a/include/golioth/payload_utils.h
+++ b/include/golioth/payload_utils.h
@@ -35,8 +35,8 @@ float golioth_payload_as_float(const uint8_t *payload, size_t payload_size);
 /// @param payload Pointer to payload data
 /// @param payload_size Size of payload, in bytes
 ///
-/// @return true - payload is exactly the string "true"
-/// @return false - otherwise
+/// @retval true payload is exactly the string "true"
+/// @retval false otherwise
 bool golioth_payload_as_bool(const uint8_t *payload, size_t payload_size);
 
 /// Returns true if payload has no contents
@@ -44,10 +44,8 @@ bool golioth_payload_as_bool(const uint8_t *payload, size_t payload_size);
 /// @param payload Pointer to payload data
 /// @param payload_size Size of payload, in bytes
 ///
-/// @return true - payload is NULL
-/// @return true - payload_size is 0
-/// @return true - payload is exactly the string "null"
-/// @return false - otherwise
+/// @retval true payload is NULL, payload_size is 0 or payload is exactly the string "null"
+/// @retval false otherwise
 bool golioth_payload_is_null(const uint8_t *payload, size_t payload_size);
 
 /// @}

--- a/include/golioth/rpc.h
+++ b/include/golioth/rpc.h
@@ -76,8 +76,8 @@ enum golioth_rpc_status
 /// @param response_detail_map zcbor encode state, inside of the RPC response detail map
 /// @param callback_arg callback_arg, unchanged from callback_arg of @ref golioth_rpc_register
 ///
-/// @return GOLIOTH_RPC_OK - if method was called successfully
-/// @return GOLIOTH_RPC_INVALID_ARGUMENT - if params were invalid
+/// @retval GOLIOTH_RPC_OK method was called successfully
+/// @retval GOLIOTH_RPC_INVALID_ARGUMENT params were invalid
 /// @return otherwise - method failure
 typedef enum golioth_rpc_status (*golioth_rpc_cb_fn)(zcbor_state_t *request_params_array,
                                                      zcbor_state_t *response_detail_map,

--- a/include/golioth/settings.h
+++ b/include/golioth/settings.h
@@ -102,10 +102,10 @@ struct golioth_settings *golioth_settings_init(struct golioth_client *client);
 /// @param callback_arg General-purpose user argument, forwarded as-is to
 ///     callback, can be NULL.
 ///
-/// @return GOLIOTH_OK - Setting registered successfully
-/// @return GOLIOTH_ERR_MEM_ALLOC - Max number of registered settings exceeded
-/// @return GOLIOTH_ERR_NOT_IMPLEMENTED - If Golioth settings are disabled in config
-/// @return GOLIOTH_ERR_NULL - callback is NULL
+/// @retval GOLIOTH_OK Setting registered successfully
+/// @retval GOLIOTH_ERR_MEM_ALLOC Max number of registered settings exceeded
+/// @retval GOLIOTH_ERR_NOT_IMPLEMENTED If Golioth settings are disabled in config
+/// @retval GOLIOTH_ERR_NULL callback is NULL
 enum golioth_status golioth_settings_register_int(struct golioth_settings *settings,
                                                   const char *setting_name,
                                                   golioth_int_setting_cb callback,

--- a/include/golioth/stream.h
+++ b/include/golioth/stream.h
@@ -28,11 +28,11 @@
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
 ///
-/// @return GOLIOTH_OK - request enqueued
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
+/// @retval GOLIOTH_OK - request enqueued
+/// @retval GOLIOTH_ERR_NULL - invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
+/// @retval GOLIOTH_ERR_MEM_ALLOC - memory allocation error
+/// @retval GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
 enum golioth_status golioth_stream_set_int_async(struct golioth_client *client,
                                                  const char *path,
                                                  int32_t value,
@@ -52,12 +52,12 @@ enum golioth_status golioth_stream_set_int_async(struct golioth_client *client,
 /// @param value The value to set at path
 /// @param timeout_s The timeout, in seconds, for receiving a server response
 ///
-/// @return GOLIOTH_OK - response received from server, set was successful
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
-/// @return GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
+/// @retval GOLIOTH_OK - response received from server, set was successful
+/// @retval GOLIOTH_ERR_NULL - invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
+/// @retval GOLIOTH_ERR_MEM_ALLOC - memory allocation error
+/// @retval GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
+/// @retval GOLIOTH_ERR_TIMEOUT - response not received from server, timeout occurred
 enum golioth_status golioth_stream_set_int_sync(struct golioth_client *client,
                                                 const char *path,
                                                 int32_t value,
@@ -128,11 +128,11 @@ enum golioth_status golioth_stream_set_string_sync(struct golioth_client *client
 /// @param callback Callback to call on response received or timeout. Can be NULL.
 /// @param callback_arg Callback argument, passed directly when callback invoked. Can be NULL.
 ///
-/// @return GOLIOTH_OK - request enqueued
-/// @return GOLIOTH_ERR_NULL - invalid client handle
-/// @return GOLIOTH_ERR_INVALID_STATE - client is not running, currently stopped
-/// @return GOLIOTH_ERR_MEM_ALLOC - memory allocation error
-/// @return GOLIOTH_ERR_QUEUE_FULL - request queue is full, this request is dropped
+/// @retval GOLIOTH_OK request enqueued
+/// @retval GOLIOTH_ERR_NULL invalid client handle
+/// @retval GOLIOTH_ERR_INVALID_STATE client is not running, currently stopped
+/// @retval GOLIOTH_ERR_MEM_ALLOC memory allocation error
+/// @retval GOLIOTH_ERR_QUEUE_FULL request queue is full, this request is dropped
 enum golioth_status golioth_stream_set_async(struct golioth_client *client,
                                              const char *path,
                                              enum golioth_content_type content_type,


### PR DESCRIPTION
`@retval` expects the first token to be a literal value, and renders it as code in the docs. This looks a little nicer than `@return` both in our generated docs and most code completion tools.

This PR changes the return value description to `@retval` for all functions that only list return values, but keeps the ones that still have a mix as-is.

[Example from Zephyr docs](https://docs.zephyrproject.org/latest/doxygen/html/group__memory__attr__heap.html#ga85301dfc19493a84e89f965ed793d576).

### Examples from Microsoft's C/C++ extension for VS Code:
`@return`:
![Screenshot from 2024-03-04 12-32-01](https://github.com/golioth/golioth-firmware-sdk/assets/7857838/1cb76e4b-28a4-494b-ad94-1a6159ad7d60)

`@retval`:
![Screenshot from 2024-03-04 12-31-37](https://github.com/golioth/golioth-firmware-sdk/assets/7857838/6a57e553-e72a-4e12-be21-405e8ca09b63)
