### PR TITLE
ci: erase nRF9160 at end of tests

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -180,8 +180,27 @@ jobs:
           hil_board: ${{ inputs.hil_board }}
         run: |
           source /opt/credentials/runner_env.sh
+          export PATH=$PATH:/opt/SEGGER/JLink
           SNR_VAR=CI_${hil_board^^}_SNR
+          PORT_VAR=CI_${hil_board^^}_PORT
+          cat <<EOF > erase_mimxrt1024_evk.jlink
+          r
+          h
+          exec EnableEraseAllFlashBanks
+          erase
+          sleep 3
+          r
+          sleep 3
+          q
+          EOF
 
-          if [[ "${hil_board}" == "nrf9160dk" ]]; then
-            nrfjprog -e --snr $CI_NRF9160DK_SNR
+          if [[ "${hil_board}" == "nrf9160dk" ]] || [[ "${hil_board}" == "nrf52840dk" ]]; then
+            nrfjprog --recover --snr ${!SNR_VAR}
+
+          elif [[ "${hil_board}" == "esp32_devkitc_wrover" ]]; then
+            esptool.py --port ${!PORT_VAR} erase_flash
+
+          elif [[ "${hil_board}" == "mimxrt1024_evk" ]]; then
+            JLinkExe -nogui 1 -if swd -speed auto -device MIMXRT1024XXX5A -CommanderScript erase_mimxrt1024_evk.jlink -SelectEmuBySN ${!SNR_VAR}
+
           fi

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -172,3 +172,16 @@ jobs:
             reports/*
             twister-out/**/*.log
             twister-out/**/report.xml
+
+      - name: Erase flash
+        if: always()
+        shell: bash
+        env:
+          hil_board: ${{ inputs.hil_board }}
+        run: |
+          source /opt/credentials/runner_env.sh
+          SNR_VAR=CI_${hil_board^^}_SNR
+
+          if [[ "${hil_board}" == "nrf9160dk" ]]; then
+            nrfjprog -e --snr $CI_NRF9160DK_SNR
+          fi

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -134,8 +134,27 @@ jobs:
           hil_board: ${{ inputs.hil_board }}
         run: |
           source /opt/credentials/runner_env.sh
+          export PATH=$PATH:/opt/SEGGER/JLink
           SNR_VAR=CI_${hil_board^^}_SNR
+          PORT_VAR=CI_${hil_board^^}_PORT
+          cat <<EOF > erase_mimxrt1024_evk.jlink
+          r
+          h
+          exec EnableEraseAllFlashBanks
+          erase
+          sleep 3
+          r
+          sleep 3
+          q
+          EOF
 
-          if [[ "${hil_board}" == "nrf9160dk" ]]; then
-            nrfjprog -e --snr $CI_NRF9160DK_SNR
+          if [[ "${hil_board}" == "nrf9160dk" ]] || [[ "${hil_board}" == "nrf52840dk" ]]; then
+            nrfjprog --recover --snr ${!SNR_VAR}
+
+          elif [[ "${hil_board}" == "esp32_devkitc_wrover" ]]; then
+            esptool.py --port ${!PORT_VAR} erase_flash
+
+          elif [[ "${hil_board}" == "mimxrt1024_evk" ]]; then
+            JLinkExe -nogui 1 -if swd -speed auto -device MIMXRT1024XXX5A -CommanderScript erase_mimxrt1024_evk.jlink -SelectEmuBySN ${!SNR_VAR}
+
           fi

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -127,3 +127,15 @@ jobs:
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
               --timeout=600
           done
+      - name: Erase flash
+        if: always()
+        shell: bash
+        env:
+          hil_board: ${{ inputs.hil_board }}
+        run: |
+          source /opt/credentials/runner_env.sh
+          SNR_VAR=CI_${hil_board^^}_SNR
+
+          if [[ "${hil_board}" == "nrf9160dk" ]]; then
+            nrfjprog -e --snr $CI_NRF9160DK_SNR
+          fi

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -52,10 +52,10 @@ jobs:
             west_board: nrf52840dk_nrf52840
             manifest: .ci-west-zephyr.yml
             binary_name: zephyr.hex
-          # - hil_board: nrf9160dk
-          #   west_board: nrf9160dk_nrf9160_ns
-          #   manifest: .ci-west-ncs.yml
-          #   binary_name: merged.hex
+          - hil_board: nrf9160dk
+            west_board: nrf9160dk_nrf9160_ns
+            manifest: .ci-west-ncs.yml
+            binary_name: merged.hex
     uses: ./.github/workflows/hil_test_zephyr.yml
     with:
       hil_board: ${{ matrix.hil_board }}
@@ -112,7 +112,7 @@ jobs:
           - hil_board: nrf9160dk
             west_board: nrf9160dk_nrf9160_ns
             manifest: .ci-west-ncs.yml
-            run_tests: false
+            run_tests: true
 
           - hil_board: qemu_x86
             west_board: qemu_x86

--- a/examples/zephyr/hello/pytest/test_sample.py
+++ b/examples/zephyr/hello/pytest/test_sample.py
@@ -27,10 +27,10 @@ async def test_hello(shell, device, wifi_ssid, wifi_psk):
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())
 
-    # Record timestamp and wait for fourth hello mesage
+    # Record timestamp and wait for fourth hello message
 
     start = datetime.datetime.utcnow()
-    shell._device.readlines_until(regex=".*Sending hello! 3", timeout=90.0)
+    shell._device.readlines_until(regex=".*Sending hello! 3", timeout=110.0)
 
     # Check logs for hello messages
 

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -34,7 +34,7 @@ async def test_lightdb_delete(shell, device, wifi_ssid, wifi_psk):
 
     # Wait for Golioth connection
 
-    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=30.0)
+    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=90.0)
 
     # Verify lightdb delete (async)
 

--- a/examples/zephyr/lightdb/get/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/get/pytest/test_sample.py
@@ -32,7 +32,7 @@ async def test_lightdb_get(shell, device, wifi_ssid, wifi_psk):
 
     # Wait for Golioth connection
 
-    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=30.0)
+    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=90.0)
 
     # Verify lightdb reads
 

--- a/examples/zephyr/lightdb/observe/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/observe/pytest/test_sample.py
@@ -32,7 +32,7 @@ async def test_lightdb_observe(shell, device, wifi_ssid, wifi_psk):
 
     # Wait for Golioth connection
 
-    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=30.0)
+    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=90.0)
 
     # Verify lightdb observe
 

--- a/examples/zephyr/lightdb/set/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/set/pytest/test_sample.py
@@ -33,7 +33,7 @@ async def test_lightdb_set(shell, device, wifi_ssid, wifi_psk):
 
     # Wait for Golioth connection
 
-    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=30.0)
+    shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=90.0)
 
     # Verify lightdb writes
 

--- a/examples/zephyr/settings/pytest/test_sample.py
+++ b/examples/zephyr/settings/pytest/test_sample.py
@@ -34,7 +34,7 @@ async def test_settings(shell, project, device, wifi_ssid, wifi_psk):
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())
 
-    shell._device.readlines_until(regex=".*Setting loop delay to 1 s", timeout=30.0)
+    shell._device.readlines_until(regex=".*Setting loop delay to 1 s", timeout=90.0)
 
     # Set device-level setting
 


### PR DESCRIPTION
Enable nRF9160dk CI testing with an erase step as the final (required) step of the workflow. This ensures that after a test a dev board will not continue to be connected to the cellular network, accruing data usage charges.