### PR TITLE
zephyr: common: add LTE handler log level symbol

### DIFF
--- a/examples/zephyr/common/Kconfig
+++ b/examples/zephyr/common/Kconfig
@@ -86,6 +86,22 @@ config GOLIOTH_SAMPLE_NRF91_LTE_MONITOR
 	help
 	  LTE Link Control events monitor for nRF91.
 
+if GOLIOTH_SAMPLE_NRF91_LTE_MONITOR
+
+config GOLIOTH_SAMPLE_NRF91_LTE_MONITOR_LOG_LEVEL
+	int "Default log level for LTE Monitor"
+	default 3
+	help
+	  The default log level for the LTE Monitor in the Golioth common library.
+
+	  0: NONE
+	  1: ERR
+	  2: WRN
+	  3: INF
+	  4: DBG
+
+endif # GOLIOTH_SAMPLE_NRF91_LTE_MONITOR
+
 config GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE
 	bool "Automatically override modem reset loop restriction"
 	depends on GOLIOTH_SAMPLE_NRF91_LTE_MONITOR

--- a/examples/zephyr/common/nrf91_lte_monitor.c
+++ b/examples/zephyr/common/nrf91_lte_monitor.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(lte_monitor);
+LOG_MODULE_REGISTER(lte_monitor, CONFIG_GOLIOTH_SAMPLE_NRF91_LTE_MONITOR_LOG_LEVEL);
 
 #include <modem/lte_lc.h>
 #include <zephyr/init.h>
@@ -45,10 +45,10 @@ static void lte_handler(const struct lte_lc_evt *const evt)
             switch (evt->rrc_mode)
             {
                 case LTE_LC_RRC_MODE_CONNECTED:
-                    LOG_INF("RRC: Connected");
+                    LOG_DBG("RRC: Connected");
                     break;
                 case LTE_LC_RRC_MODE_IDLE:
-                    LOG_INF("RRC: Idle");
+                    LOG_DBG("RRC: Idle");
                     break;
             }
             break;


### PR DESCRIPTION
Add symbol to control the log level of the LTE monitor handler in the common library. Quiet the log output by changing RRC log messages to DBG level and setting the default LTE Monitor log level to INF.

Resolves https://github.com/golioth/firmware-issue-tracker/issues/448