### PR TITLE
rpc: return `NOT_FOUND` instead of `UNKNOWN`

### DIFF
--- a/src/rpc.c
+++ b/src/rpc.c
@@ -189,6 +189,7 @@ static void on_rpc(struct golioth_client *client,
     }
     else
     {
+        status = GOLIOTH_RPC_NOT_FOUND;
         GLTH_LOGW(TAG, "Method %.*s not registered", method.len, method.value);
     }
 

--- a/tests/unit_tests/test_rpc.c
+++ b/tests/unit_tests/test_rpc.c
@@ -222,7 +222,7 @@ void test_rpc_call_not_registered(void)
         0x31, 0x32, 0x33,                                           /* "123" */
         0x6A,                                                       /* text(10) */
         0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65, /* "statusCode" */
-        0x02,                                                       /* unsigned(2) */
+        0x05,                                                       /* unsigned(5) */
         0xFF,                                                       /* primitive(*) */
     };
     TEST_ASSERT_EQUAL(sizeof(expected), last_coap_payload_size);


### PR DESCRIPTION
`NOT_FOUND` is a more intuitive error code for the case where the device receives an RPC call for a method that isn't registered with the SDK.

Resolves golioth/firmware-issue-tracker#466