### PR TITLE
hil: zephyr: add delay before provisioning

### DIFF
--- a/tests/hil/tests/settings/test_settings.py
+++ b/tests/hil/tests/settings/test_settings.py
@@ -30,6 +30,9 @@ async def setup(project, board, device):
     await project.settings.set('TEST_NOT_REGISTERED', 27)
     await project.settings.set('TEST_WRONG_TYPE', "wrong")
 
+    # Delay to give NVS time to initialize
+    time.sleep(4)
+
     # Set Golioth credentials
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)


### PR DESCRIPTION
Add delay so slower devices have time to initialize NVS.

This resolves an issue I'm seeing with the nRF52840 where the credentials are not being stored because they are written before NVS is ready:

```
------------------------------------------------------------------------------------ Captured stdout setup ------------------------------------------------------------------------------------
o come up
uart:~$
uart:~$ settings set wifi/ssid "MySSID"
Setting wifi/ssid to MySSID
Failed to save setting wifi/ssid:MySSID
[00:00:02.707,366] <inf> wifi_esp_at: AT version: 2.4.0.0(s-4c6eb5e - ESP32 - May 20 2022 03:12:58)
[00:00:02.710,571] <inf> wifi_esp_at: SDK version: qa-test-v4.3.3-20220423
[00:00:02.716,979] <inf> wifi_esp_at: Bin version: 2.4.0(WROVER-32)
[00:00:03.159,454] <inf> wifi_esp_at: ESP Wi-Fi ready
*** Booting Zephyr OS build v3.6.0 ***
[00:00:03.167,724] <inf> fs_nvs: 8 Sectors of 4096 bytes
[00:00:03.167,755] <inf> fs_nvs: alloc wra: 0, fe8
[00:00:03.167,755] <inf> fs_nvs: data wra: 0, 0
[00:00:03.168,060] <inf> golioth_samples: Waiting to obtain IP address
```