### PR TITLE
tests: hil: zephyr: override nrf9160dk modem reset loop protection

### DIFF
--- a/tests/hil/platform/zephyr/boards/nrf9160dk_nrf9160_ns.conf
+++ b/tests/hil/platform/zephyr/boards/nrf9160dk_nrf9160_ns.conf
@@ -30,3 +30,6 @@ CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y
+
+# Override modem reset loop protection
+CONFIG_GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE=y


### PR DESCRIPTION
The nrf9160 will refuse to connect to a network after a certain number of resets. We can override this protection, and should do so during CI testing.

Resolves golioth/firmware-issue-tracker#474