### PR TITLE
tests: hil: connection: delay for NVS init at test start

### DIFF
--- a/tests/hil/scripts/pytest-hil/board.py
+++ b/tests/hil/scripts/pytest-hil/board.py
@@ -13,7 +13,7 @@ class Board(ABC):
             self.program(fw_image)
 
             # Wait for reboot
-            sleep(3)
+            sleep(6)
 
         self.serial_device = serial.Serial(port, baud, timeout=1, write_timeout=1)
 

--- a/tests/hil/tests/settings/test_settings.py
+++ b/tests/hil/tests/settings/test_settings.py
@@ -30,9 +30,6 @@ async def setup(project, board, device):
     await project.settings.set('TEST_NOT_REGISTERED', 27)
     await project.settings.set('TEST_WRONG_TYPE', "wrong")
 
-    # Delay to give NVS time to initialize
-    time.sleep(4)
-
     # Set Golioth credentials
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)


### PR DESCRIPTION
Now that we erase the baords between test runs, we need to delay at the start of each test to give time for the settings partition to be reformatted before we attempt to store settings to flash.

This is a temporary fix until a more robust solution is in place.