### PR TITLE
tests: hil: increase connection timeout

### DIFF
--- a/tests/hil/tests/connection/test_connection.py
+++ b/tests/hil/tests/connection/test_connection.py
@@ -11,4 +11,4 @@ async def test_connect(board, device):
     board.reset()
 
     # Confirm connection to Golioth
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=60)
+    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)

--- a/tests/hil/tests/settings/test_settings.py
+++ b/tests/hil/tests/settings/test_settings.py
@@ -38,7 +38,7 @@ async def setup(project, board, device):
     board.reset()
 
     # Confirm connection to Golioth
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=60)
+    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 
 async def assert_settings_error(device, key, error):
     await device.refresh()


### PR DESCRIPTION
Some boards (e.g. cellular connected boards) can take a long time to connect to the internet. Increase the timeout when waiting for a connection to accomodate these boards.

Fixes golioth/firmware-issue-tracker#480