### PR TITLE
Update runtime credentials without reboot

### DIFF
--- a/examples/esp_idf/certificate_auth/main/app_main.c
+++ b/examples/esp_idf/certificate_auth/main/app_main.c
@@ -39,6 +39,20 @@ void app_main(void)
     // Create a background shell/CLI task (type "help" to see a list of supported commands)
     shell_start();
 
+    // If the credentials haven't been set in NVS, we will wait here for the user
+    // to input them via the shell.
+    if (!nvs_wifi_credentials_are_set())
+    {
+        ESP_LOGW(TAG,
+                 "WiFi credentials are not set. "
+                 "Use the shell settings commands to set them.");
+
+        while (!nvs_wifi_credentials_are_set())
+        {
+            vTaskDelay(1000 / portTICK_PERIOD_MS);
+        }
+    }
+
     // Initialize WiFi and wait for it to connect
     wifi_init(nvs_read_wifi_ssid(), nvs_read_wifi_password());
     wifi_wait_for_connected();

--- a/examples/esp_idf/certificate_auth/main/app_main.c
+++ b/examples/esp_idf/certificate_auth/main/app_main.c
@@ -8,6 +8,7 @@
 #include "nvs.h"
 #include "shell.h"
 #include "wifi.h"
+#include "freertos/FreeRTOS.h"
 #include <golioth/client.h>
 #include <golioth/golioth_sys.h>
 

--- a/examples/esp_idf/common/nvs.c
+++ b/examples/esp_idf/common/nvs.c
@@ -110,13 +110,22 @@ bool nvs_erase_str(const char *key)
     return true;
 }
 
-bool nvs_credentials_are_set(void)
+bool nvs_wifi_credentials_are_set(void)
 {
     if (0 == strcmp(nvs_read_wifi_ssid(), NVS_DEFAULT_STR))
     {
         return false;
     }
     if (0 == strcmp(nvs_read_wifi_password(), NVS_DEFAULT_STR))
+    {
+        return false;
+    }
+    return true;
+}
+
+bool nvs_credentials_are_set(void)
+{
+    if (!nvs_wifi_credentials_are_set())
     {
         return false;
     }

--- a/examples/esp_idf/common/nvs.h
+++ b/examples/esp_idf/common/nvs.h
@@ -36,6 +36,7 @@ extern "C"
     bool nvs_write_str(const char *key, const char *str);
     bool nvs_erase_str(const char *key);
 
+    bool nvs_wifi_credentials_are_set(void);
     bool nvs_credentials_are_set(void);
 
 #ifdef __cplusplus

--- a/examples/esp_idf/cpp/main/app_main.cpp
+++ b/examples/esp_idf/cpp/main/app_main.cpp
@@ -7,9 +7,9 @@
 
 extern "C" {
 
+#include "freertos/FreeRTOS.h"
 #include <golioth/client.h>
 #include <golioth/lightdb_state.h>
-#include <golioth/golioth_sys.h>
 
 }
 
@@ -19,12 +19,15 @@ extern "C" void app_main(void) {
     nvs_init();
     shell_start();
 
-    if (!nvs_credentials_are_set()) {
-        while (1) {
-            golioth_sys_msleep(1000);
-            ESP_LOGW(TAG, "WiFi and golioth credentials are not set");
-            ESP_LOGW(TAG, "Use the shell settings commands to set them, then restart");
-            golioth_sys_msleep(UINT32_MAX);
+    if (!nvs_credentials_are_set())
+    {
+        ESP_LOGW(TAG,
+                 "WiFi and Golioth credentials are not set. "
+                 "Use the shell settings commands to set them.");
+
+        while (!nvs_credentials_are_set())
+        {
+            vTaskDelay(1000 / portTICK_PERIOD_MS);
         }
     }
 
@@ -45,9 +48,9 @@ extern "C" void app_main(void) {
 
     int counter = 0;
     while (1) {
-        GLTH_LOGI(TAG, "Hello, Golioth %d!", counter);
+        ESP_LOGI(TAG, "Hello, Golioth %d!", counter);
         golioth_lightdb_set_int_async(client, "counter", counter, NULL, NULL);
-        golioth_sys_msleep(5000);
+        vTaskDelay(5000 / portTICK_PERIOD_MS);
         counter++;
     }
 }

--- a/examples/esp_idf/golioth_basics/main/app_main.c
+++ b/examples/esp_idf/golioth_basics/main/app_main.c
@@ -34,12 +34,13 @@ void app_main(void)
     // to input them via the shell.
     if (!nvs_credentials_are_set())
     {
-        while (1)
+        ESP_LOGW(TAG,
+                 "WiFi and Golioth credentials are not set. "
+                 "Use the shell settings commands to set them.");
+
+        while (!nvs_credentials_are_set())
         {
             golioth_sys_msleep(1000);
-            ESP_LOGW(TAG, "WiFi and golioth credentials are not set");
-            ESP_LOGW(TAG, "Use the shell settings commands to set them, then restart");
-            golioth_sys_msleep(UINT32_MAX);
         }
     }
 

--- a/examples/esp_idf/hello/main/app_main.c
+++ b/examples/esp_idf/hello/main/app_main.c
@@ -43,12 +43,13 @@ void app_main(void)
     // to input them via the shell.
     if (!nvs_credentials_are_set())
     {
-        while (1)
+        ESP_LOGW(TAG,
+                 "WiFi and Golioth credentials are not set. "
+                 "Use the shell settings commands to set them.");
+
+        while (!nvs_credentials_are_set())
         {
             vTaskDelay(1000 / portTICK_PERIOD_MS);
-            GLTH_LOGW(TAG, "WiFi and golioth credentials are not set");
-            GLTH_LOGW(TAG, "Use the shell settings commands to set them, then restart");
-            vTaskDelay(UINT32_MAX);
         }
     }
 

--- a/examples/esp_idf/hello/pytest/test_sample.py
+++ b/examples/esp_idf/hello/pytest/test_sample.py
@@ -16,10 +16,7 @@ async def test_hello(board, device):
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Reset board
-    board.reset()
-
-    # Record timestamp and wait for fourth hello mesage
+    # Record timestamp and wait for fourth hello message
     start = datetime.datetime.utcnow()
     board.wait_for_regex_in_line('.*Sending hello! 3', timeout_s=90.0)
 

--- a/examples/esp_idf/lightdb/delete/main/app_main.c
+++ b/examples/esp_idf/lightdb/delete/main/app_main.c
@@ -86,12 +86,13 @@ void app_main(void)
     // to input them via the shell.
     if (!nvs_credentials_are_set())
     {
-        while (1)
+        ESP_LOGW(TAG,
+                 "WiFi and Golioth credentials are not set. "
+                 "Use the shell settings commands to set them.");
+
+        while (!nvs_credentials_are_set())
         {
             vTaskDelay(1000 / portTICK_PERIOD_MS);
-            GLTH_LOGW(TAG, "WiFi and golioth credentials are not set");
-            GLTH_LOGW(TAG, "Use the shell settings commands to set them, then restart");
-            vTaskDelay(UINT32_MAX);
         }
     }
 

--- a/examples/esp_idf/lightdb/delete/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/delete/pytest/test_sample.py
@@ -27,10 +27,7 @@ async def test_lightdb_delete(board, device):
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Reset board
-    board.reset()
-
-    # Wait for device to reboot and connect
+    # Wait for device to connect
     board.wait_for_regex_in_line(r'.*Golioth client connected', timeout_s=30.0)
 
     # Verify lightdb delete (async)

--- a/examples/esp_idf/lightdb/get/main/app_main.c
+++ b/examples/esp_idf/lightdb/get/main/app_main.c
@@ -156,12 +156,13 @@ void app_main(void)
     // to input them via the shell.
     if (!nvs_credentials_are_set())
     {
-        while (1)
+        ESP_LOGW(TAG,
+                 "WiFi and Golioth credentials are not set. "
+                 "Use the shell settings commands to set them.");
+
+        while (!nvs_credentials_are_set())
         {
             vTaskDelay(1000 / portTICK_PERIOD_MS);
-            GLTH_LOGW(TAG, "WiFi and golioth credentials are not set");
-            GLTH_LOGW(TAG, "Use the shell settings commands to set them, then restart");
-            vTaskDelay(UINT32_MAX);
         }
     }
 

--- a/examples/esp_idf/lightdb/get/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/get/pytest/test_sample.py
@@ -25,10 +25,7 @@ async def test_lightdb_get(board, device):
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Reset board
-    board.reset()
-
-    # Wait for device to reboot and connect
+    # Wait for device to connect
     board.wait_for_regex_in_line(r'.*Golioth client connected', timeout_s=30.0)
 
     # Verify lightdb reads

--- a/examples/esp_idf/lightdb/observe/main/app_main.c
+++ b/examples/esp_idf/lightdb/observe/main/app_main.c
@@ -62,12 +62,13 @@ void app_main(void)
     // to input them via the shell.
     if (!nvs_credentials_are_set())
     {
-        while (1)
+        ESP_LOGW(TAG,
+                 "WiFi and Golioth credentials are not set. "
+                 "Use the shell settings commands to set them.");
+
+        while (!nvs_credentials_are_set())
         {
             vTaskDelay(1000 / portTICK_PERIOD_MS);
-            GLTH_LOGW(TAG, "WiFi and golioth credentials are not set");
-            GLTH_LOGW(TAG, "Use the shell settings commands to set them, then restart");
-            vTaskDelay(UINT32_MAX);
         }
     }
 

--- a/examples/esp_idf/lightdb/observe/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/observe/pytest/test_sample.py
@@ -25,10 +25,7 @@ async def test_lightdb_observe(board, device):
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Reset board
-    board.reset()
-
-    # Wait for device to reboot and connect
+    # Wait for device to connect
     board.wait_for_regex_in_line('.*Golioth client connected', timeout_s=30.0)
 
     time.sleep(2)

--- a/examples/esp_idf/lightdb/set/main/app_main.c
+++ b/examples/esp_idf/lightdb/set/main/app_main.c
@@ -163,12 +163,13 @@ void app_main(void)
     // to input them via the shell.
     if (!nvs_credentials_are_set())
     {
-        while (1)
+        ESP_LOGW(TAG,
+                 "WiFi and Golioth credentials are not set. "
+                 "Use the shell settings commands to set them.");
+
+        while (!nvs_credentials_are_set())
         {
             vTaskDelay(1000 / portTICK_PERIOD_MS);
-            GLTH_LOGW(TAG, "WiFi and golioth credentials are not set");
-            GLTH_LOGW(TAG, "Use the shell settings commands to set them, then restart");
-            vTaskDelay(UINT32_MAX);
         }
     }
 

--- a/examples/esp_idf/lightdb/set/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/set/pytest/test_sample.py
@@ -25,10 +25,7 @@ async def test_lightdb_set(board, device):
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Reset board
-    board.reset()
-
-    # Wait for device to reboot and connect
+    # Wait for device to connect
     board.wait_for_regex_in_line('.*Golioth client connected', timeout_s=30.0)
 
     # Verify lightdb writes

--- a/examples/esp_idf/rpc/main/app_main.c
+++ b/examples/esp_idf/rpc/main/app_main.c
@@ -79,12 +79,13 @@ void app_main(void)
     // to input them via the shell.
     if (!nvs_credentials_are_set())
     {
-        while (1)
+        ESP_LOGW(TAG,
+                 "WiFi and Golioth credentials are not set. "
+                 "Use the shell settings commands to set them.");
+
+        while (!nvs_credentials_are_set())
         {
             vTaskDelay(1000 / portTICK_PERIOD_MS);
-            ESP_LOGW(TAG, "WiFi and golioth credentials are not set");
-            ESP_LOGW(TAG, "Use the shell settings commands to set them, then restart");
-            vTaskDelay(UINT32_MAX);
         }
     }
 

--- a/examples/esp_idf/rpc/pytest/test_sample.py
+++ b/examples/esp_idf/rpc/pytest/test_sample.py
@@ -15,9 +15,6 @@ async def test_rpc(board, device):
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Reset board
-    board.reset()
-
     # Wait for device to reboot and connect
     board.wait_for_regex_in_line('.*RPC observation established', timeout_s=90.0)
 

--- a/examples/zephyr/fw_update/pytest/test_sample.py
+++ b/examples/zephyr/fw_update/pytest/test_sample.py
@@ -27,9 +27,6 @@ async def test_fw_update(shell, project, device, wifi_ssid, wifi_psk, fw_info, r
     shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
     shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-
     # Wait for first manifest to arrive (no update expected)
 
     shell._device.readlines_until(regex=".*Nothing to do.", timeout=90.0)

--- a/examples/zephyr/hello/pytest/test_sample.py
+++ b/examples/zephyr/hello/pytest/test_sample.py
@@ -24,9 +24,6 @@ async def test_hello(shell, device, wifi_ssid, wifi_psk):
     shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
     shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-
     # Record timestamp and wait for fourth hello message
 
     start = datetime.datetime.utcnow()

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -29,9 +29,6 @@ async def test_lightdb_delete(shell, device, wifi_ssid, wifi_psk):
     shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
     shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-
     # Wait for Golioth connection
 
     shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=90.0)

--- a/examples/zephyr/lightdb/get/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/get/pytest/test_sample.py
@@ -27,9 +27,6 @@ async def test_lightdb_get(shell, device, wifi_ssid, wifi_psk):
     shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
     shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-
     # Wait for Golioth connection
 
     shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=90.0)

--- a/examples/zephyr/lightdb/observe/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/observe/pytest/test_sample.py
@@ -27,9 +27,6 @@ async def test_lightdb_observe(shell, device, wifi_ssid, wifi_psk):
     shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
     shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-
     # Wait for Golioth connection
 
     shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=90.0)

--- a/examples/zephyr/lightdb/set/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/set/pytest/test_sample.py
@@ -27,10 +27,6 @@ async def test_lightdb_set(shell, device, wifi_ssid, wifi_psk):
     shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
     shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-    shell._device.readlines_until(regex=".*Booting", timeout=10.0)
-
     # Wait for Golioth connection
 
     shell._device.readlines_until(regex=".*Golioth CoAP client connected", timeout=90.0)

--- a/examples/zephyr/lightdb_stream/pytest/test_sample.py
+++ b/examples/zephyr/lightdb_stream/pytest/test_sample.py
@@ -23,9 +23,6 @@ async def test_lightdb_stream(shell, device, wifi_ssid, wifi_psk):
     shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
     shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-
     # Verify temp messages
 
     temp = 20.0

--- a/examples/zephyr/logging/pytest/test_sample.py
+++ b/examples/zephyr/logging/pytest/test_sample.py
@@ -63,9 +63,6 @@ async def test_logging(shell, device, wifi_ssid, wifi_psk):
     shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
     shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-
     # Record timestamp and wait for fourth hello message
 
     start = datetime.datetime.utcnow()

--- a/examples/zephyr/rpc/pytest/test_sample.py
+++ b/examples/zephyr/rpc/pytest/test_sample.py
@@ -22,9 +22,6 @@ async def test_logging(shell, device, wifi_ssid, wifi_psk):
     shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
     shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-
     # Wait for device to reboot and connect
 
     shell._device.readlines_until(regex=".*rpc_sample: Golioth client connected", timeout=90.0)

--- a/examples/zephyr/settings/pytest/test_sample.py
+++ b/examples/zephyr/settings/pytest/test_sample.py
@@ -31,9 +31,6 @@ async def test_settings(shell, project, device, wifi_ssid, wifi_psk):
     shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
     shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-
     shell._device.readlines_until(regex=".*Setting loop delay to 1 s", timeout=90.0)
 
     # Set device-level setting

--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -1097,11 +1097,23 @@ static int credentials_set_psk(const struct golioth_psk_credential *psk)
 {
     int err;
 
+    err = tls_credential_delete(sec_tag_list[0], TLS_CREDENTIAL_PSK_ID);
+    if ((err) && (err != -ENOENT))
+    {
+        LOG_ERR("Failed to delete PSK ID: %d", err);
+    }
+
     err = tls_credential_add(sec_tag_list[0], TLS_CREDENTIAL_PSK_ID, psk->psk_id, psk->psk_id_len);
     if (err)
     {
         LOG_ERR("Failed to register PSK ID: %d", err);
         return err;
+    }
+
+    err = tls_credential_delete(sec_tag_list[0], TLS_CREDENTIAL_PSK);
+    if ((err) && (err != -ENOENT))
+    {
+        LOG_ERR("Failed to delete PSK: %d", err);
     }
 
     err = tls_credential_add(sec_tag_list[0], TLS_CREDENTIAL_PSK, psk->psk, psk->psk_len);

--- a/tests/hil/platform/esp-idf/main/app_main.c
+++ b/tests/hil/platform/esp-idf/main/app_main.c
@@ -27,12 +27,13 @@ void app_main(void)
     // to input them via the shell.
     if (!nvs_credentials_are_set())
     {
-        while (1)
+        ESP_LOGW(TAG,
+                 "WiFi and Golioth credentials are not set. "
+                 "Use the shell settings commands to set them.");
+
+        while (!nvs_credentials_are_set())
         {
             golioth_sys_msleep(1000);
-            ESP_LOGW(TAG, "WiFi and golioth credentials are not set");
-            ESP_LOGW(TAG, "Use the shell settings commands to set them, then restart");
-            golioth_sys_msleep(UINT32_MAX);
         }
     }
 

--- a/tests/hil/scripts/pytest-hil/linuxboard.py
+++ b/tests/hil/scripts/pytest-hil/linuxboard.py
@@ -58,6 +58,18 @@ class LinuxBoard(Board):
         pass
 
     def reset(self):
+        pass
+
+    def program(self):
+        pass
+
+    def set_wifi_credentials(self, ssid, psk):
+        pass
+
+    def set_golioth_psk_credentials(self, psk_id, psk):
+        self.golioth_psk_id = psk_id
+        self.golioth_psk = psk
+
         env = {
             "GOLIOTH_PSK_ID" : self.golioth_psk_id,
             "GOLIOTH_PSK" : self.golioth_psk
@@ -71,13 +83,3 @@ class LinuxBoard(Board):
 
         # Register atexit() handler to kill test program
         atexit.register(self.process.terminate)
-
-    def program(self):
-        pass
-
-    def set_wifi_credentials(self, ssid, psk):
-        pass
-
-    def set_golioth_psk_credentials(self, psk_id, psk):
-        self.golioth_psk_id = psk_id
-        self.golioth_psk = psk

--- a/tests/hil/tests/connection/test_connection.py
+++ b/tests/hil/tests/connection/test_connection.py
@@ -7,8 +7,5 @@ async def test_connect(board, device):
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Reset board
-    board.reset()
-
     # Confirm connection to Golioth
     assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)

--- a/tests/hil/tests/ota/test_ota.py
+++ b/tests/hil/tests/ota/test_ota.py
@@ -44,9 +44,6 @@ async def setup(board, device):
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Reset board
-    board.reset()
-
     # Confirm connection to Golioth
     assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=60)
 

--- a/tests/hil/tests/rpc/test_rpc.py
+++ b/tests/hil/tests/rpc/test_rpc.py
@@ -10,9 +10,6 @@ async def setup(project, board, device):
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Reset board
-    board.reset()
-
     # Confirm connection to Golioth
     assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 

--- a/tests/hil/tests/settings/test_settings.py
+++ b/tests/hil/tests/settings/test_settings.py
@@ -34,9 +34,6 @@ async def setup(project, board, device):
     golioth_cred = (await device.credentials.list())[0]
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Reset board
-    board.reset()
-
     # Confirm connection to Golioth
     assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 


### PR DESCRIPTION
Allow runtime credentials to be used immediately after being updated, without the need for a reboot.

Caveats:
- The ESP-IDF implementation of this requires that credentials not be present in NVS, otherwise the logic for updating them without reboot may be missed at runtime. I discussed this with @sam-golioth and we felt this meets the needs of CI which is the primary driver of this change
- In Zephyr, an error will be thrown whenever credentials are updated before the golioth client is client is created. This is because the SDK tries to set the tls_credential and finds it is already present, causing the -17 error as shown below.

```
uart:~$ [00:00:04.777,557] <err> golioth_coap_client_zephyr: Failed to register PSK ID: -17
```

Resolves https://github.com/golioth/firmware-issue-tracker/issues/454