### PR TITLE
examples: zephyr: extend twister test timeouts

### DIFF
--- a/examples/zephyr/hello/sample.yaml
+++ b/examples/zephyr/hello/sample.yaml
@@ -5,7 +5,7 @@ tests:
   sample.golioth.hello:
     harness: pytest
     tags: golioth socket goliothd
-    timeout: 90
+    timeout: 180
     extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128
@@ -19,7 +19,7 @@ tests:
   sample.golioth.hello.cid:
     harness: pytest
     tags: golioth socket goliothd
-    timeout: 90
+    timeout: 180
     extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_GOLIOTH_USE_CONNECTION_ID=y

--- a/examples/zephyr/lightdb/delete/sample.yaml
+++ b/examples/zephyr/lightdb/delete/sample.yaml
@@ -6,7 +6,7 @@ common:
   tags: golioth lightdb socket goliothd
 tests:
   sample.golioth.lightdb_delete:
-    timeout: 90
+    timeout: 180
     extra_args: EXTRA_CONF_FILE="../../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128

--- a/examples/zephyr/lightdb/get/sample.yaml
+++ b/examples/zephyr/lightdb/get/sample.yaml
@@ -6,7 +6,7 @@ common:
   tags: golioth lightdb socket goliothd
 tests:
   sample.golioth.lightdb_get:
-    timeout: 90
+    timeout: 180
     extra_args: EXTRA_CONF_FILE="../../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128

--- a/examples/zephyr/lightdb/observe/sample.yaml
+++ b/examples/zephyr/lightdb/observe/sample.yaml
@@ -6,7 +6,7 @@ common:
   tags: golioth lightdb socket goliothd
 tests:
   sample.golioth.lightdb_observe:
-    timeout: 90
+    timeout: 180
     extra_args: EXTRA_CONF_FILE="../../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128

--- a/examples/zephyr/lightdb/set/sample.yaml
+++ b/examples/zephyr/lightdb/set/sample.yaml
@@ -6,7 +6,7 @@ common:
   tags: golioth lightdb socket goliothd
 tests:
   sample.golioth.lightdb_set:
-    timeout: 90
+    timeout: 180
     extra_args: EXTRA_CONF_FILE="../../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128

--- a/examples/zephyr/lightdb_stream/sample.yaml
+++ b/examples/zephyr/lightdb_stream/sample.yaml
@@ -6,7 +6,7 @@ common:
   tags: golioth socket goliothd
 tests:
   sample.golioth.lightdb_stream:
-    timeout: 90
+    timeout: 180
     extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128

--- a/examples/zephyr/logging/sample.yaml
+++ b/examples/zephyr/logging/sample.yaml
@@ -6,7 +6,7 @@ common:
   tags: golioth logger socket goliothd
 tests:
   sample.golioth.logging:
-    timeout: 90
+    timeout: 180
     extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128

--- a/examples/zephyr/rpc/sample.yaml
+++ b/examples/zephyr/rpc/sample.yaml
@@ -6,7 +6,7 @@ common:
   tags: golioth socket goliothd
 tests:
   sample.golioth.rpc:
-    timeout: 90
+    timeout: 180
     extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128

--- a/examples/zephyr/settings/sample.yaml
+++ b/examples/zephyr/settings/sample.yaml
@@ -6,7 +6,7 @@ common:
   tags: golioth socket goliothd
 tests:
   sample.golioth.settings:
-    timeout: 90
+    timeout: 180
     extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=128


### PR DESCRIPTION
The nrf9160 was sometimes hitting twister timeouts before it was able to establish a cell connection. This overall timeout was shorter than the sum of the individual timeouts in the pytest file. This timeout is a last case timeout to detect a hung board, not to ensure compliance with any deadline, so it doesn't need to be particularly tight. Extending it to 180 seconds should give plenty of time for the board to connect to the cell network and complete the test.

Fixes golioth/firmware-issue-tracker#479