### PR TITLE
examples: esp-idf: fix premature post to connected semaphore

### DIFF
--- a/examples/esp_idf/hello/main/app_main.c
+++ b/examples/esp_idf/hello/main/app_main.c
@@ -86,7 +86,6 @@ void app_main(void)
     assert(client);
 
     _connected_sem = xSemaphoreCreateBinary();
-    xSemaphoreGive(_connected_sem);
 
     golioth_client_register_event_callback(client, on_client_event, NULL);
 

--- a/examples/esp_idf/lightdb/observe/main/app_main.c
+++ b/examples/esp_idf/lightdb/observe/main/app_main.c
@@ -96,7 +96,6 @@ void app_main(void)
     assert(client);
 
     _connected_sem = xSemaphoreCreateBinary();
-    xSemaphoreGive(_connected_sem);
 
     golioth_client_register_event_callback(client, on_client_event, NULL);
 

--- a/examples/esp_idf/rpc/main/app_main.c
+++ b/examples/esp_idf/rpc/main/app_main.c
@@ -113,7 +113,6 @@ void app_main(void)
     assert(client);
 
     connected = xSemaphoreCreateBinary();
-    xSemaphoreGive(connected);
 
     struct golioth_rpc *rpc = golioth_rpc_init(client);
 


### PR DESCRIPTION
Some examples posted to the connected semaphore immediately after creating it, which would cause the example to run immediately without waiting for the client to connect.

Fixes golioth/firmware-issue-tracker#477