### PR TITLE
examples: esp_idf: lightdb_set: wait for counter set message during test

### DIFF
--- a/examples/esp_idf/lightdb/set/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/set/pytest/test_sample.py
@@ -36,6 +36,7 @@ async def test_lightdb_set(board, device):
     for i in range(0,4):
         pattern = re.compile(fr"Setting counter to {i}")
         board.wait_for_regex_in_line(pattern, timeout_s=30.0)
+        board.wait_for_regex_in_line('Counter successfully set', timeout_s=5.0)
         time.sleep(1)
         counter = await device.lightdb.get("counter")
         assert counter == i


### PR DESCRIPTION
Pytest was querying the backend for the counter value before the device had successfully set the counter value. Now, the pytest script explicitly waits for the device to report the counter has been set before querying the backend for the value.

Fixes golioth/firmware-issue-tracker#478