### PR TITLE
workflows: esp-idf: erase boards after tests

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -94,3 +94,12 @@ jobs:
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
               --timeout=600
           done
+      - name: Erase flash
+        if: always()
+        shell: bash
+        env:
+          hil_board: ${{ inputs.hil_board }}
+        run: |
+          source /opt/credentials/runner_env.sh
+          PORT_VAR=CI_${hil_board^^}_PORT
+          esptool.py --port ${!PORT_VAR} erase_flash

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -95,3 +95,12 @@ jobs:
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
               --timeout=600
           done
+      - name: Erase flash
+        if: always()
+        shell: bash
+        env:
+          hil_board: ${{ inputs.hil_board }}
+        run: |
+          source /opt/credentials/runner_env.sh
+          PORT_VAR=CI_${hil_board^^}_PORT
+          esptool.py --port ${!PORT_VAR} erase_flash

--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -153,3 +153,9 @@ jobs:
         cd examples/esp_idf/test
         source /opt/credentials/runner_env.sh
         python3 flash.py $CI_ESP32S3_DEVKITC_PORT && python3 verify.py $CI_ESP32S3_DEVKITC_PORT
+    - name: Erase flash
+      if: always()
+      shell: bash
+      run: |
+        source /opt/credentials/runner_env.sh
+        esptool.py --port $CI_ESP32S3_DEVKITC_PORT erase_flash


### PR DESCRIPTION
If a board had stored credentials when a test runs, the new credentials may not be used immediatel in some cases. For instance, if a WiFi-based board has already established a connection when new credentials are set, they will not be immediately used since a connetion is currently in place.

This commit erases board flash at the end of test runs to ensure all applications will be provisioned with the expected AP/Golioth device credentials the next time a test runs.