### PR TITLE
zephyr: coap: run golioth_sys_client_disconnected()

### DIFF
--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -1079,6 +1079,7 @@ static void golioth_coap_client_thread(void *arg)
 
         LOG_INF("Ending session");
 
+        golioth_sys_client_disconnected(client);
         if (client->event_callback && client->session_connected)
         {
             client->event_callback(client,


### PR DESCRIPTION
Run the golioth_sys_client_disconnected() function when CoAP detects a disconnect event. This behavior is present in the libcoap support but was missing from the Zephyr coap support.