### PR TITLE
 zephyr: backend logging: enable/disable using a context flag

### DIFF
--- a/examples/zephyr/certificate_provisioning/pytest/test_sample.py
+++ b/examples/zephyr/certificate_provisioning/pytest/test_sample.py
@@ -25,14 +25,14 @@ async def test_credentials(shell, project, device_name, device_port, certificate
     # Ensure there are no credentials currently stored on device
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())
-    shell._device.readlines_until(regex=".*Start certificate provisioning sample", timeout=90.0)
+    shell._device.readlines_until(regex=".*<inf>.*", timeout=90.0)
     sleep(5) # Time for fs bringup and in case nRF9160 reset loop reboot happens
     shell.exec_command(f'fs rm {FS_CRT_PATH}')
     shell.exec_command(f'fs rm {FS_KEY_PATH}')
     shell.exec_command(f'fs rm {FS_SUBDIR}')
     shell._device.clear_buffer()
     shell._device.write('kernel reboot cold\n\n'.encode())
-    shell._device.readlines_until(regex=".*Start certificate provisioning sample", timeout=90.0)
+    shell._device.readlines_until(regex=".*<inf>.*", timeout=90.0)
     sleep(5) # Time for fs bringup and in case nRF9160 reset loop reboot happens
 
     # Check cloud to verify device does not exist

--- a/port/zephyr/golioth_log_zephyr.c
+++ b/port/zephyr/golioth_log_zephyr.c
@@ -79,7 +79,7 @@ static void process(const struct log_backend* const backend, union log_msg_gener
     struct log_msg* log = &msg->log;
     struct golioth_log_ctx* ctx = backend->cb->ctx;
 
-    if (ctx->panic_mode) {
+    if ((ctx == NULL) || (ctx->panic_mode)) {
         return;
     }
 


### PR DESCRIPTION
The Zephyr port was using log_backend_enable()/disable() to prevent logs from generating CoAP events when not connected to Golioth. This interferes with applications using the same functions to enable or disable backend logging at runtime.

- test for null context before checking context members
- add an `enabled` flag to the backend context which is used to determine if a log should be processed
- format the code (I'm unsure how this file was missed during the giant code reformat PR awhile ago