### PR TITLE
examples: esp-idf: rpc: wait for RPC registered before calling in test

### DIFF
--- a/examples/esp_idf/rpc/main/app_main.c
+++ b/examples/esp_idf/rpc/main/app_main.c
@@ -123,7 +123,11 @@ void app_main(void)
 
     int err = golioth_rpc_register(rpc, "multiply", on_multiply, NULL);
 
-    if (err)
+    if (!err)
+    {
+        ESP_LOGI(TAG, "RPC successfully registered");
+    }
+    else
     {
         ESP_LOGE(TAG, "Failed to register RPC: %d", err);
     }

--- a/examples/esp_idf/rpc/pytest/test_sample.py
+++ b/examples/esp_idf/rpc/pytest/test_sample.py
@@ -19,7 +19,7 @@ async def test_logging(board, device):
     board.reset()
 
     # Wait for device to reboot and connect
-    board.wait_for_regex_in_line('.*rpc: Golioth client connected', timeout_s=90.0)
+    board.wait_for_regex_in_line('.*RPC observation established', timeout_s=90.0)
 
     # Test successful RPC
     result = await device.rpc.call("multiply", [ 7, 6 ])

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -108,6 +108,7 @@ static void on_rpc(struct golioth_client *client,
 
     if (payload_size == 3 && payload[1] == 'O' && payload[2] == 'K')
     {
+        GLTH_LOGI(TAG, "RPC observation established");
         /* Ignore "OK" response received after observing */
         return;
     }


### PR DESCRIPTION
Some failures in CI were caused by the test script attempting to call the RPC before the device had established an observation on the RPC endpoint. This commit adds a new message that the device prints when it has established the observation, and updates the test script to wait for that message.

Fixes golioth/firmware-issue-tracker#487