### PR TITLE
zephyr: certificate_provisioning: enable log shell commands

### DIFF
--- a/examples/zephyr/certificate_provisioning/prj.conf
+++ b/examples/zephyr/certificate_provisioning/prj.conf
@@ -48,3 +48,6 @@ CONFIG_MAIN_STACK_SIZE=2048
 # Enable certificate authentication. Do not use hardcoded credentials.
 CONFIG_GOLIOTH_AUTH_METHOD_CERT=y
 CONFIG_GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS=n
+
+# Enable `log halt` and `log go` commands
+CONFIG_LOG_CMDS=y


### PR DESCRIPTION
To use `log halt` and `log go`, CONFIG_LOG_CMDS must be selected.

This is expected behavior following [an upstream change](https://github.com/zephyrproject-rtos/zephyr/pull/65307).

Resolves https://github.com/golioth/firmware-issue-tracker/issues/486