### PR TITLE
Linux hil tests

### DIFF
--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -1,0 +1,57 @@
+name: Linux "Hardware-in-the-Loop" Tests
+
+on:
+  workflow_call:
+    inputs:
+      api-url:
+        required: true
+        type: string
+      api-key-id:
+        required: true
+        type: string
+      coap_gateway_url:
+        required: true
+        type: string
+
+jobs:
+  hil:
+    name: linux-hil-tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v4
+      with:
+        path: .
+        submodules: 'recursive'
+    - name: Compile
+      shell: bash
+      run: |
+        rm -rf test_binaries
+        mkdir -p test_binaries
+
+        export EXTRA_BUILD_ARGS=-DCONFIG_GOLIOTH_COAP_HOST_URI=${{ inputs.coap_gateway_url }}
+
+        for test in `ls tests/hil/tests`
+        do
+          cmake -B build -S tests/hil/platform/linux $EXTRA_BUILD_ARGS -DGOLIOTH_HIL_TEST=$test
+          make -j8 -C build
+          mv build/hil test_binaries/${test}-test
+        done
+    - name: Setup Python dependencies
+      run: |
+        pip install --upgrade pip
+        pip install pytest pytest-timeout
+        pip install tests/hil/scripts/pytest-hil
+        pip install git+https://github.com/golioth/python-golioth-tools@v0.6.2
+    - name: Run test
+      shell: bash
+      run: |
+        for test in `ls tests/hil/tests`
+        do
+          pytest --rootdir . tests/hil/tests/$test      \
+            --board linux                               \
+            --fw-image test_binaries/${test}-test       \
+            --api-url ${{ inputs.api-url }}             \
+            --api-key ${{ secrets[inputs.api-key-id] }} \
+            --timeout=600
+        done

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -88,6 +88,14 @@ jobs:
       coap_gateway_url: ${{ inputs.coap_gateway_url }}
     secrets: inherit
 
+  hil_test_linux:
+    uses: ./.github/workflows/hil_test_linux.yml
+    with:
+      api-url: ${{ inputs.api-url }}
+      api-key-id: ${{ inputs.api-key-id }}
+      coap_gateway_url: ${{ inputs.coap_gateway_url }}
+    secrets: inherit
+
   hil_sample_zephyr:
     strategy:
       fail-fast: false

--- a/tests/hil/platform/linux/CMakeLists.txt
+++ b/tests/hil/platform/linux/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.5)
+set(projname "hil")
+project(${projname} C)
+
+set(CMAKE_BUILD_TYPE Debug)
+
+set(CONFIG_GOLIOTH_COAP_HOST_URI "coaps://coap.golioth.io" CACHE STRING "Golioth coap gateway URI")
+
+set(repo_root ../../../..)
+
+set(srcs
+    main.c
+    ${repo_root}/tests/hil/tests/${GOLIOTH_HIL_TEST}/test.c
+)
+
+get_filename_component(user_config_file "golioth_user_config.h" ABSOLUTE)
+add_definitions(-DCONFIG_GOLIOTH_USER_CONFIG_INCLUDE="${user_config_file}")
+add_definitions(-DCONFIG_GOLIOTH_COAP_HOST_URI="${CONFIG_GOLIOTH_COAP_HOST_URI}")
+
+add_subdirectory(${repo_root}/port/linux/golioth_sdk build)
+add_executable(${projname} ${srcs})
+target_link_libraries(${projname} golioth_sdk)

--- a/tests/hil/platform/linux/README.md
+++ b/tests/hil/platform/linux/README.md
@@ -1,0 +1,21 @@
+# Linux HIL Test Base
+
+This provides a base Linux application that can be used to run HIL tests. The
+application handles network connection and provides a shell interface for
+setting Golioth (PSK) credentials. The application must be combined with a test
+source file in order for it to compile correctly. The name of the test
+(corresponding to the name of the folder containing the source file) can be
+passed to the build system using the CMake variable `GOLIOTH_HIL_TEST`:
+
+```sh
+cmake . -B build -DGOLIOTH_HIL_TEST=<test_name>
+make -C build
+```
+
+For example, to compile the connection HIL test from the root of the SDK
+repository:
+
+```sh
+cmake -S tests/hil/platform/linux -B build -DGOLIOTH_HIL_TEST=connection
+make -C build
+```

--- a/tests/hil/platform/linux/golioth_user_config.h
+++ b/tests/hil/platform/linux/golioth_user_config.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#define CONFIG_GOLIOTH_AUTO_LOG_TO_CLOUD 1
+#define CONFIG_GOLIOTH_COAP_REQUEST_QUEUE_MAX_ITEMS 20
+#define CONFIG_GOLIOTH_DEBUG_LOG
+#define CONFIG_GOLIOTH_FW_UPDATE
+#define CONFIG_GOLIOTH_OTA_MAX_NUM_COMPONENTS 2
+#define CONFIG_GOLIOTH_RPC
+#define CONFIG_GOLIOTH_SETTINGS

--- a/tests/hil/platform/linux/main.c
+++ b/tests/hil/platform/linux/main.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <signal.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <golioth/client.h>
+
+#define TAG "main"
+
+void hil_test_entry(const struct golioth_client_config *config);
+
+static void term(int signum)
+{
+    exit(0);
+}
+
+int main(void)
+{
+    /* Register handler for SIGTERM so that we exit gracefuly
+       Without calling exit(), will not output code coverage
+       information. */
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = term;
+    sigaction(SIGTERM, &action, NULL);
+
+    char *golioth_psk_id = getenv("GOLIOTH_PSK_ID");
+    if ((!golioth_psk_id) || strlen(golioth_psk_id) <= 0)
+    {
+        fprintf(stderr, "PSK ID is not specified.\n");
+        return 1;
+    }
+    char *golioth_psk = getenv("GOLIOTH_PSK");
+    if ((!golioth_psk) || strlen(golioth_psk) <= 0)
+    {
+        fprintf(stderr, "PSK is not specified.\n");
+        return 1;
+    }
+
+    struct golioth_client_config config = {
+        .credentials =
+            {
+                .auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
+                .psk =
+                    {
+                        .psk_id = golioth_psk_id,
+                        .psk_id_len = strlen(golioth_psk_id),
+                        .psk = golioth_psk,
+                        .psk_len = strlen(golioth_psk),
+                    },
+            },
+    };
+
+    hil_test_entry(&config);
+
+    return 0;
+}

--- a/tests/hil/scripts/pytest-hil/linuxboard.py
+++ b/tests/hil/scripts/pytest-hil/linuxboard.py
@@ -1,0 +1,83 @@
+import atexit
+import re
+import select
+import subprocess
+from time import time
+
+from board import Board
+
+class LinuxBoard(Board):
+    def __init__(self, fw_image):
+        self.binary = fw_image
+        self.rcvd_lines = []
+
+    def wait_for_regex_in_line(self, regex, timeout_s=20, log=True):
+        start_time = time()
+        while True:
+            # Check for timeout
+            if time() - start_time > timeout_s:
+                raise RuntimeError('Timeout')
+
+            # Read input. We use communicate() because the other read
+            # read functions for pipes don't have timeouts, and poll()
+            # doesn't tell us how many lines (or bytes) are available to
+            # read. communicate() runs until the program terminates, so
+            # we use a short timeout to prevent blocking. The output
+            # received during the call is contained in the exception.
+            try:
+                self.process.communicate(timeout=0.1)
+            except subprocess.TimeoutExpired as e:
+                if e.output == None:
+                    continue
+                lines = e.output.decode("UTF-8")
+
+            for line in lines.splitlines():
+                # When communicate() times out, it leaves the data intact
+                # in the pipe, so we need to do our own filtering for
+                # repeated lines
+                if line in self.rcvd_lines:
+                    continue
+                self.rcvd_lines.append(line)
+
+                if line != "" and log:
+                    print(f"time: {time()} log: {line}")
+
+                regex_search=re.search(regex, line)
+                if regex_search:
+                    return regex_search
+
+    @property
+    def PROMPT(self):
+        return ''
+
+    @property
+    def USES_WIFI(self):
+        return False
+
+    def set_setting(self, key, value):
+        pass
+
+    def reset(self):
+        env = {
+            "GOLIOTH_PSK_ID" : self.golioth_psk_id,
+            "GOLIOTH_PSK" : self.golioth_psk
+        }
+
+        self.process = subprocess.Popen(["stdbuf", "-o0", self.binary],
+                                        stdout=subprocess.PIPE,
+                                        bufsize=1,
+                                        universal_newlines=True,
+                                        env=env)
+
+        # Register atexit() handler to kill test program
+        atexit.register(self.process.terminate)
+
+    def program(self):
+        pass
+
+    def set_wifi_credentials(self, ssid, psk):
+        pass
+
+    def set_golioth_psk_credentials(self, psk_id, psk):
+        self.golioth_psk_id = psk_id
+        self.golioth_psk = psk

--- a/tests/hil/scripts/pytest-hil/plugin.py
+++ b/tests/hil/scripts/pytest-hil/plugin.py
@@ -4,6 +4,7 @@ from esp32_devkitc_wrover import ESP32DevKitCWROVER
 from nrf52840dk import nRF52840DK
 from nrf9160dk  import nRF9160DK
 from mimxrt1024evk import MIMXRT1024EVK
+from linuxboard import LinuxBoard
 
 def pytest_addoption(parser):
     parser.addoption("--board", type=str,
@@ -60,5 +61,7 @@ def board(board_name, port, baud, wifi_ssid, wifi_psk, fw_image, serial_number):
         return nRF9160DK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     elif board_name.lower() == "mimxrt1024_evk":
         return MIMXRT1024EVK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
+    elif board_name.lower() == "linux":
+        return LinuxBoard(fw_image)
     else:
         raise ValueError("Unknown board")


### PR DESCRIPTION
This adds a Linux "board" target for our hil test framework, a Linux application base to run the test firmware, and a GH actions workflow to run these tests in CI. We'll use this target to gather code coverage numbers for our libcoap based ports.

Resolves golioth/firmware-issue-tracker#462