### PR TITLE
CI: power USB hub on before test and off afterward

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
 
     container:
-      image: golioth/golioth-hil-base:af8e4f5
+      image: golioth/golioth-hil-base:e635559
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials
@@ -72,8 +72,8 @@ jobs:
           pip install pytest pytest-timeout
           pip install tests/hil/scripts/pytest-hil
           pip install git+https://github.com/golioth/python-golioth-tools@v0.6.2
-      - name: Power Cycle USB Hub
-        run: /opt/golioth-scripts/power-cycle-usb-hub.sh
+      - name: Power On USB Hub
+        run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
         uses: actions/download-artifact@v4
         with:
@@ -107,3 +107,6 @@ jobs:
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
           esptool.py --port ${!PORT_VAR} erase_flash
+      - name: Power Off USB Hub
+        if: always()
+        run: python3 /opt/golioth-scripts/usb_hub_power.py off

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -101,15 +101,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: modules/lib/golioth-firmware-sdk
-      - name: Install go and mcumgr
-        run: |
-          wget https://go.dev/dl/go1.21.6.linux-arm64.tar.gz
-          rm -rf /usr/local/go && tar -C /usr/local -xzf go1.21.6.linux-arm64.tar.gz
-          export PATH=$PATH:/usr/local/go/bin
-          go version
-          go install github.com/apache/mynewt-mcumgr-cli/mcumgr@latest
-          export PATH=$PATH:$(go env GOPATH)/bin
-          chmod +x $(go env GOPATH)/bin/mcumgr
       - name: Init and update west
         run: |
           rm -rf zephyr

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
 
     container:
-      image: golioth/golioth-twister-base:50cb4bc
+      image: golioth/golioth-twister-base:8307b9c
       env:
         ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
       volumes:
@@ -130,8 +130,8 @@ jobs:
           pip3 install -r zephyr/scripts/requirements-run-test.txt
 
           pip3 install git+https://github.com/golioth/python-golioth-tools@v0.6.2
-      - name: Power Cycle USB Hub
-        run: /opt/golioth-scripts/power-cycle-usb-hub.sh
+      - name: Power On USB Hub
+        run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
         uses: actions/download-artifact@v4
         with:
@@ -204,3 +204,6 @@ jobs:
             JLinkExe -nogui 1 -if swd -speed auto -device MIMXRT1024XXX5A -CommanderScript erase_mimxrt1024_evk.jlink -SelectEmuBySN ${!SNR_VAR}
 
           fi
+      - name: Power Off USB Hub
+        if: always()
+        run: python3 /opt/golioth-scripts/usb_hub_power.py off

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
 
     container:
-      image: golioth/golioth-hil-base:af8e4f5
+      image: golioth/golioth-hil-base:e635559
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials
@@ -69,8 +69,8 @@ jobs:
           pip install pytest pytest-timeout
           pip install tests/hil/scripts/pytest-hil
           pip install git+https://github.com/golioth/python-golioth-tools@v0.6.2
-      - name: Power Cycle USB Hub
-        run: /opt/golioth-scripts/power-cycle-usb-hub.sh
+      - name: Power On USB Hub
+        run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
         uses: actions/download-artifact@v4
         with:
@@ -104,3 +104,6 @@ jobs:
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
           esptool.py --port ${!PORT_VAR} erase_flash
+      - name: Power Off USB Hub
+        if: always()
+        run: python3 /opt/golioth-scripts/usb_hub_power.py off

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
 
     container:
-      image: golioth/golioth-hil-base:af8e4f5
+      image: golioth/golioth-hil-base:e635559
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials
@@ -102,8 +102,8 @@ jobs:
           pip install pytest pytest-timeout
           pip install tests/hil/scripts/pytest-hil
           pip install git+https://github.com/golioth/python-golioth-tools@v0.6.2
-      - name: Power Cycle USB Hub
-        run: /opt/golioth-scripts/power-cycle-usb-hub.sh
+      - name: Power On USB Hub
+        run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
         uses: actions/download-artifact@v4
         with:
@@ -161,3 +161,6 @@ jobs:
             JLinkExe -nogui 1 -if swd -speed auto -device MIMXRT1024XXX5A -CommanderScript erase_mimxrt1024_evk.jlink -SelectEmuBySN ${!SNR_VAR}
 
           fi
+      - name: Power Off USB Hub
+        if: always()
+        run: python3 /opt/golioth-scripts/usb_hub_power.py off

--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: [is_active, has_esp32s3_devkitc, mikes_orange_pi]
 
     container:
-      image: golioth/golioth-hil-base:ff78585
+      image: golioth/golioth-hil-base:e635559
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials
@@ -128,6 +128,8 @@ jobs:
         mkdir -p /tmp
         apt update -y --allow-insecure-repositories
         apt install goliothctl -y
+    - name: Power On USB Hub
+      run: python3 /opt/golioth-scripts/usb_hub_power.py on
     - name: Prepare goliothctl secret
       run: |
         mkdir -p ~/.golioth
@@ -159,3 +161,6 @@ jobs:
       run: |
         source /opt/credentials/runner_env.sh
         esptool.py --port $CI_ESP32S3_DEVKITC_PORT erase_flash
+    - name: Power Off USB Hub
+      if: always()
+      run: python3 /opt/golioth-scripts/usb_hub_power.py off


### PR DESCRIPTION
- Update workflows to turn USB hub on at the start of a test and off at the end of it.
- Update docker images with USB hub control that uses parameters for on/off/cycle control.

resolves https://github.com/golioth/firmware-issue-tracker/issues/389