### PR TITLE
zephyr_coap_req: directly index into header for coap response code

### DIFF
--- a/src/zephyr_coap_req.c
+++ b/src/zephyr_coap_req.c
@@ -146,7 +146,9 @@ static int golioth_coap_req_reply_handler(struct golioth_coap_req *req,
     int block2;
     int err;
 
-    code = coap_header_get_code(response);
+    // TODO: Replace with coap_header_get_code(response) after
+    // NCS update includes fix for TOO_MANY_REQUESTS
+    code = response->data[1];
 
     LOG_DBG("CoAP response code: 0x%x (class %u detail %u)",
             (unsigned int) code,


### PR DESCRIPTION
The Zephyr CoAP stack filters out unknown CoAP codes, but due to a bug, it incorrectly filters out the TOO_MANY_REQUESTS message. We log an error when we receive an unknown code, which results in us getting into a loop where the server responds with TOO_MANY_REQUESTS, the device logs an error in response, and the loop repeats.

This bug is fixed in Zephyr upstream, but not in the latest release of NCS. To workaraound the issue in NCS, we can retrieve the code by directly indexing into the header, bypassing the filtering done by the Zephyr CoAP stack. When NCS is updated to include the fix, we will revert this change.

This issue is currently being experienced by a customer: https://forum.golioth.io/t/sdk-0-10-0-sends-15million-logs-day-in-error-condition/504/4