### PR TITLE
ci: pass pytest args to twister via command line

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -162,10 +162,6 @@ jobs:
         env:
           hil_board: ${{ inputs.hil_board }}
           west_board: ${{ inputs.west_board }}
-          GOLIOTH_API_KEY: ${{ secrets[inputs.api-key-id] }}
-          GOLIOTH_API_URL: ${{ inputs.api-url }}
-          WIFI_SSID: ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}
-          WIFI_PSK: ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}
         run: |
           source /opt/credentials/runner_env.sh
           export PATH=$PATH:/opt/SEGGER/JLink
@@ -173,14 +169,17 @@ jobs:
           export PATH=$PATH:$(go env GOPATH)/bin
           PORT_VAR=CI_${hil_board^^}_PORT
           SNR_VAR=CI_${hil_board^^}_SNR
-          zephyr/scripts/twister                                    \
-                -p ${{ inputs.west_board }}                         \
-                -T modules/lib/golioth-firmware-sdk/examples/zephyr \
-                --device-testing                                    \
-                --device-serial ${!PORT_VAR}                        \
-                --test-only                                         \
-                --west-flash="--skip-rebuild,--dev-id=${!SNR_VAR}"
-
+          zephyr/scripts/twister                                                                  \
+                -p ${{ inputs.west_board }}                                                       \
+                -T modules/lib/golioth-firmware-sdk/examples/zephyr                               \
+                --device-testing                                                                  \
+                --device-serial ${!PORT_VAR}                                                      \
+                --test-only                                                                       \
+                --west-flash="--skip-rebuild,--dev-id=${!SNR_VAR}"                                \
+                --pytest-args="--api-url=${{ inputs.api-url }}"                                   \
+                --pytest-args="--api-key=${{ secrets[inputs.api-key-id] }}"                       \
+                --pytest-args="--wifi-ssid=${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}"  \
+                --pytest-args="--wifi-psk=${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}"
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: ${{ always() }}

--- a/examples/zephyr/certificate_provisioning/pytest/conftest.py
+++ b/examples/zephyr/certificate_provisioning/pytest/conftest.py
@@ -7,6 +7,8 @@ import subprocess
 def pytest_addoption(parser):
     parser.addoption("--device-port", type=str,
                      help="Device serial port path")
+    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope="session")
 def device_port(request):
@@ -42,3 +44,17 @@ async def device_name(project):
         await project.delete_device_by_name(name)
     except:
         pass
+
+@pytest.fixture(scope="session")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
+    else:
+        return os.environ['WIFI_SSID']
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ['WIFI_PSK']


### PR DESCRIPTION
Zephyr 3.6 added support for passing pytest arguments via the command line when using Twister. This allows us to standardize the way we push arguments into the tests between Twister and our HIL tests.