### PR TITLE
ci: mask generated secrets in GitHub Actions logs

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           pip install pytest pytest-timeout
           pip install tests/hil/scripts/pytest-hil
-          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.2
+          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.3
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
@@ -113,6 +113,7 @@ jobs:
               --api-key ${{ secrets[inputs.api-key-id] }}                       \
               --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
+              --mask-secrets                                                    \
               --timeout=600
           done
       - name: Erase flash

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -147,7 +147,7 @@ jobs:
           pip3 install -r zephyr/scripts/requirements-build-test.txt
           pip3 install -r zephyr/scripts/requirements-run-test.txt
 
-          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.6.2
+          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.6.3
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
@@ -179,7 +179,8 @@ jobs:
                 --pytest-args="--api-url=${{ inputs.api-url }}"                                   \
                 --pytest-args="--api-key=${{ secrets[inputs.api-key-id] }}"                       \
                 --pytest-args="--wifi-ssid=${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}"  \
-                --pytest-args="--wifi-psk=${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}"
+                --pytest-args="--wifi-psk=${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}"    \
+                --pytest-args="--mask-secrets"
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: ${{ always() }}

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           pip install pytest pytest-timeout
           pip install tests/hil/scripts/pytest-hil
-          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.2
+          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.3
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
@@ -110,6 +110,7 @@ jobs:
               --api-key ${{ secrets[inputs.api-key-id] }}                       \
               --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
+              --mask-secrets                                                    \
               --timeout=600
           done
       - name: Erase flash

--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -49,7 +49,7 @@ jobs:
         pip install --upgrade pip
         pip install pytest pytest-timeout
         pip install tests/hil/scripts/pytest-hil
-        pip install git+https://github.com/golioth/python-golioth-tools@v0.6.2
+        pip install git+https://github.com/golioth/python-golioth-tools@v0.6.3
     - name: Install Linux dependencies
       run: |
         sudo apt-get install lcov
@@ -70,6 +70,7 @@ jobs:
             --fw-image build/${test}/hil                \
             --api-url ${{ inputs.api-url }}             \
             --api-key ${{ secrets[inputs.api-key-id] }} \
+            --mask-secrets                              \
             --timeout=600
           lcov -c                                       \
                --directory build/${test}                \

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           pip install pytest pytest-timeout
           pip install tests/hil/scripts/pytest-hil
-          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.2
+          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.3
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
@@ -154,6 +154,7 @@ jobs:
               --api-key ${{ secrets[inputs.api-key-id] }}                       \
               --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
+              --mask-secrets                                                    \
               --timeout=600
           done
       - name: Erase flash


### PR DESCRIPTION
Use the `--mask-secrets` option for the Golioth pytest plugin to mask generated PSK-ID/PSK secrets during GitHub Actions runs.

Fixes golioth/firmware-issue-tracker#507