### PR TITLE
workflows: move esp32s2 test to different runner

### DIFF
--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -94,7 +94,7 @@ jobs:
   # ---
   hw_flash_and_test:
     needs: build_for_hw_test
-    runs-on: [is_active, has_esp32s3_devkitc, mikes_orange_pi]
+    runs-on: [is_active, has_esp32s3_devkitc, mikes_testbench]
 
     container:
       image: golioth/golioth-hil-base:e635559


### PR DESCRIPTION
This is a legacy test and is locked to a specific runner. The physical board was moved to a different runner and this update matches the change.