### PR TITLE
examples: zephyr: drop 'default n'

### DIFF
--- a/examples/zephyr/common/Kconfig
+++ b/examples/zephyr/common/Kconfig
@@ -29,7 +29,6 @@ endchoice
 
 config GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS
 	bool "Hardcoded credentials"
-	default n
 	help
 	  Use hardcoded credentials in samples
 


### PR DESCRIPTION
Every bool option defaults to 'n' when not explicitly stated, so drop
`default n` inside `GOLIOTH_SAMPLE_HARDCODED_CREDENTIALS` definition.