### PR TITLE
examples: zephyr: pytest: make --wifi-{ssid,psk} pytest args optional

### DIFF
--- a/examples/zephyr/certificate_provisioning/pytest/conftest.py
+++ b/examples/zephyr/certificate_provisioning/pytest/conftest.py
@@ -50,11 +50,11 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/fw_update/pytest/conftest.py
+++ b/examples/zephyr/fw_update/pytest/conftest.py
@@ -22,14 +22,14 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')
 
 @pytest.fixture(scope="session")
 def west_board(request):

--- a/examples/zephyr/fw_update/pytest/test_sample.py
+++ b/examples/zephyr/fw_update/pytest/test_sample.py
@@ -24,8 +24,11 @@ async def test_fw_update(shell, project, device, wifi_ssid, wifi_psk, fw_info, r
 
     # Set WiFi credential
 
-    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
-    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
+    if wifi_ssid is not None:
+        shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+
+    if wifi_psk is not None:
+        shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     # Wait for first manifest to arrive (no update expected)
 

--- a/examples/zephyr/hello/pytest/conftest.py
+++ b/examples/zephyr/hello/pytest/conftest.py
@@ -14,11 +14,11 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/hello/pytest/test_sample.py
+++ b/examples/zephyr/hello/pytest/test_sample.py
@@ -18,8 +18,11 @@ async def test_hello(shell, device, wifi_ssid, wifi_psk):
 
     # Set WiFi credential
 
-    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
-    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
+    if wifi_ssid is not None:
+        shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+
+    if wifi_psk is not None:
+        shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     # Record timestamp and wait for fourth hello message
 

--- a/examples/zephyr/lightdb/delete/pytest/conftest.py
+++ b/examples/zephyr/lightdb/delete/pytest/conftest.py
@@ -14,11 +14,11 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -26,8 +26,11 @@ async def test_lightdb_delete(shell, device, wifi_ssid, wifi_psk):
 
     # Set WiFi credential
 
-    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
-    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
+    if wifi_ssid is not None:
+        shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+
+    if wifi_psk is not None:
+        shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     # Wait for Golioth connection
 

--- a/examples/zephyr/lightdb/get/pytest/conftest.py
+++ b/examples/zephyr/lightdb/get/pytest/conftest.py
@@ -14,11 +14,11 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/lightdb/get/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/get/pytest/test_sample.py
@@ -24,8 +24,11 @@ async def test_lightdb_get(shell, device, wifi_ssid, wifi_psk):
 
     # Set WiFi credential
 
-    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
-    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
+    if wifi_ssid is not None:
+        shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+
+    if wifi_psk is not None:
+        shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     # Wait for Golioth connection
 

--- a/examples/zephyr/lightdb/observe/pytest/conftest.py
+++ b/examples/zephyr/lightdb/observe/pytest/conftest.py
@@ -14,11 +14,11 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/lightdb/observe/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/observe/pytest/test_sample.py
@@ -24,8 +24,11 @@ async def test_lightdb_observe(shell, device, wifi_ssid, wifi_psk):
 
     # Set WiFi credential
 
-    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
-    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
+    if wifi_ssid is not None:
+        shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+
+    if wifi_psk is not None:
+        shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     # Wait for Golioth connection
 

--- a/examples/zephyr/lightdb/set/pytest/conftest.py
+++ b/examples/zephyr/lightdb/set/pytest/conftest.py
@@ -14,11 +14,11 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/lightdb/set/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/set/pytest/test_sample.py
@@ -24,8 +24,11 @@ async def test_lightdb_set(shell, device, wifi_ssid, wifi_psk):
 
     # Set WiFi credential
 
-    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
-    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
+    if wifi_ssid is not None:
+        shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+
+    if wifi_psk is not None:
+        shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     # Wait for Golioth connection
 

--- a/examples/zephyr/lightdb_stream/pytest/conftest.py
+++ b/examples/zephyr/lightdb_stream/pytest/conftest.py
@@ -14,11 +14,11 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/lightdb_stream/pytest/test_sample.py
+++ b/examples/zephyr/lightdb_stream/pytest/test_sample.py
@@ -20,8 +20,11 @@ async def test_lightdb_stream(shell, device, wifi_ssid, wifi_psk):
 
     # Set WiFi credential
 
-    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
-    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
+    if wifi_ssid is not None:
+        shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+
+    if wifi_psk is not None:
+        shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     # Verify temp messages
 

--- a/examples/zephyr/logging/pytest/conftest.py
+++ b/examples/zephyr/logging/pytest/conftest.py
@@ -14,11 +14,11 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/logging/pytest/test_sample.py
+++ b/examples/zephyr/logging/pytest/test_sample.py
@@ -60,8 +60,11 @@ async def test_logging(shell, device, wifi_ssid, wifi_psk):
 
     # Set WiFi credential
 
-    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
-    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
+    if wifi_ssid is not None:
+        shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+
+    if wifi_psk is not None:
+        shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     # Record timestamp and wait for fourth hello message
 

--- a/examples/zephyr/rpc/pytest/conftest.py
+++ b/examples/zephyr/rpc/pytest/conftest.py
@@ -14,11 +14,11 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/rpc/pytest/test_sample.py
+++ b/examples/zephyr/rpc/pytest/test_sample.py
@@ -19,8 +19,11 @@ async def test_logging(shell, device, wifi_ssid, wifi_psk):
 
     # Set WiFi credential
 
-    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
-    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
+    if wifi_ssid is not None:
+        shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+
+    if wifi_psk is not None:
+        shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     # Wait for device to reboot and connect
 

--- a/examples/zephyr/settings/pytest/conftest.py
+++ b/examples/zephyr/settings/pytest/conftest.py
@@ -14,11 +14,11 @@ def wifi_ssid(request):
     if request.config.getoption("--wifi-ssid") is not None:
         return request.config.getoption("--wifi-ssid")
     else:
-        return os.environ['WIFI_SSID']
+        return os.environ.get('WIFI_SSID')
 
 @pytest.fixture(scope="session")
 def wifi_psk(request):
     if request.config.getoption("--wifi-psk") is not None:
         return request.config.getoption("--wifi-psk")
     else:
-        return os.environ['WIFI_PSK']
+        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/settings/pytest/test_sample.py
+++ b/examples/zephyr/settings/pytest/test_sample.py
@@ -28,8 +28,11 @@ async def test_settings(shell, project, device, wifi_ssid, wifi_psk):
 
     # Set WiFi credential
 
-    shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
-    shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
+    if wifi_ssid is not None:
+        shell.exec_command(f"settings set wifi/ssid \"{wifi_ssid}\"")
+
+    if wifi_psk is not None:
+        shell.exec_command(f"settings set wifi/psk \"{wifi_psk}\"")
 
     shell._device.readlines_until(regex=".*Setting loop delay to 1 s", timeout=90.0)
 


### PR DESCRIPTION
Those args are not used by most targets, so make those optional and
configure WiFi credentials over Zephyr shell only when those were
passed.