### PR TITLE
coap_client: zephyr: handle connection stop

### DIFF
--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -1075,6 +1075,15 @@ static void golioth_coap_client_thread(void *arg)
                     client->end_session = true;
                 }
             }
+
+            // Check if we should still run (non-blocking)
+            if (!golioth_sys_sem_take(client->run_sem, 0))
+            {
+                GLTH_LOGI(TAG, "Stopping");
+                golioth_disconnect(client);
+                break;
+            }
+            golioth_sys_sem_give(client->run_sem);
         }
 
         LOG_INF("Ending session");

--- a/tests/hil/tests/connection/test.c
+++ b/tests/hil/tests/connection/test.c
@@ -11,6 +11,14 @@ void hil_test_entry(const struct golioth_client_config *config)
 
     while (1)
     {
-        golioth_sys_msleep(5000);
+        golioth_sys_msleep(10 * 1000);
+
+        GLTH_LOGI(TAG, "Stopping client");
+        golioth_client_stop(client);
+
+        golioth_sys_msleep(10 * 1000);
+
+        GLTH_LOGI(TAG, "Starting client");
+        golioth_client_start(client);
     }
 }

--- a/tests/hil/tests/connection/test_connection.py
+++ b/tests/hil/tests/connection/test_connection.py
@@ -9,3 +9,8 @@ async def test_connect(board, device):
 
     # Confirm connection to Golioth
     assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+
+    # Wait for reconnection
+    assert None != board.wait_for_regex_in_line('Stopping client', timeout_s=10)
+    assert None != board.wait_for_regex_in_line('Starting client', timeout_s=120)
+    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)


### PR DESCRIPTION
Monitor `client->run_sem` semaphore, similar to how libcoap implementation does.