### PR TITLE
tests: hil: rpc: test re-establishment of observations

### DIFF
--- a/tests/hil/tests/rpc/test_rpc.py
+++ b/tests/hil/tests/rpc/test_rpc.py
@@ -70,3 +70,13 @@ async def test_invalid_arg(board, device):
         rsp = await device.rpc.basic_return_type("foo")
 
     assert e.value.status_code == RPCStatusCode.INVALID_ARGUMENT
+
+async def test_observation_reestablishment(board, device):
+    rsp = await device.rpc.disconnect()
+
+    # Confirm re-connection to Golioth
+    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+
+    rsp = await device.rpc.basic_return_type("int")
+
+    assert rsp['value'] == 42


### PR DESCRIPTION
Add a new case to the RPC HIL suite to test whether we reestablish observations after the client is disconnected.

These tests fail in this PR, but I ran a test on a branch on that includes @szczys's fix and those pass: https://github.com/golioth/golioth-firmware-sdk/actions/runs/8730075595