### PR TITLE
HIL: Wait for Client connection before establishing Observations

### DIFF
--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -71,6 +71,7 @@ jobs:
             --api-url ${{ inputs.api-url }}             \
             --api-key ${{ secrets[inputs.api-key-id] }} \
             --mask-secrets                              \
+            -rP                                         \
             --timeout=600
           lcov -c                                       \
                --directory build/${test}                \

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -107,7 +107,7 @@ enum golioth_status golioth_coap_client_empty(struct golioth_client *client,
 
     if (!client->is_running)
     {
-        GLTH_LOGW(TAG, "Client not running, dropping request");
+        GLTH_LOGW(TAG, "Client not running, dropping empty request");
         return GOLIOTH_ERR_INVALID_STATE;
     }
 
@@ -190,7 +190,7 @@ enum golioth_status golioth_coap_client_set(struct golioth_client *client,
 
     if (!client->is_running)
     {
-        GLTH_LOGW(TAG, "Client not running, dropping request for path %s", path);
+        GLTH_LOGW(TAG, "Client not running, dropping set request for path %s%s", path_prefix, path);
         return GOLIOTH_ERR_INVALID_STATE;
     }
 
@@ -303,7 +303,10 @@ enum golioth_status golioth_coap_client_delete(struct golioth_client *client,
 
     if (!client->is_running)
     {
-        GLTH_LOGW(TAG, "Client not running, dropping request for path %s", path);
+        GLTH_LOGW(TAG,
+                  "Client not running, dropping delete request for path %s%s",
+                  path_prefix,
+                  path);
         return GOLIOTH_ERR_INVALID_STATE;
     }
 
@@ -388,7 +391,7 @@ static enum golioth_status golioth_coap_client_get_internal(struct golioth_clien
 
     if (!client->is_running)
     {
-        GLTH_LOGW(TAG, "Client not running, dropping get request");
+        GLTH_LOGW(TAG, "Client not running, dropping get request for path %s%s", path_prefix, path);
         return GOLIOTH_ERR_INVALID_STATE;
     }
 
@@ -524,7 +527,10 @@ enum golioth_status golioth_coap_client_observe_async(struct golioth_client *cli
 
     if (!client->is_running)
     {
-        GLTH_LOGW(TAG, "Client not running, dropping request for path %s", path);
+        GLTH_LOGW(TAG,
+                  "Client not running, dropping observe request for path %s%s",
+                  path_prefix,
+                  path);
         return GOLIOTH_ERR_INVALID_STATE;
     }
 


### PR DESCRIPTION
The HIL tests were not waiting for the client to be connected before establishing observations. See for example [this test run](https://github.com/golioth/golioth-firmware-sdk/actions/runs/8791389071/job/24128163197#step:6:547):

```
time: 1713828580.7902908 log: W (0) golioth_coap_client: Client not running, dropping observe request for path .rpc/
```

This could cause some tests to fail to establish an observation, which would cause the test to fail. To fix, the test waits on a semaphore that is posted by a callback that is executed upon client connection, the same way as the examples.

Also, improve the logging around failures to send requests while the client is disconnected by logging the full path (including prefix) and disambiguating between request type.

Fixes golioth/firmware-issue-tracker#550