### PR TITLE
ci: esp-idf: exit with error code in 'Build Test Firmware' job

### DIFF
--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -59,7 +59,13 @@ jobs:
         esp_idf_version: v5.2.1
         target: ${{ inputs.idf_target }}
         path: 'tests/hil/platform/esp-idf'
-        command: 'for test in ${{ steps.build_prep.outputs.test_list }}; do idf.py -DGOLIOTH_HIL_TEST=$test build && mv build/merged.bin ../../../../test_binaries/${test}.bin; done'
+        command: |
+          for test in ${{ steps.build_prep.outputs.test_list }}; do
+            idf.py -DGOLIOTH_HIL_TEST=$test build && \
+              mv build/merged.bin ../../../../test_binaries/${test}.bin || \
+              EXITCODE=$?
+          done
+          exit $EXITCODE
     - name: Save Artifacts
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This allows to stop CI pipeline early on build stage, instead of trying to execute those tests on HIL.

Example build failures:
- https://github.com/golioth/golioth-firmware-sdk/actions/runs/8799855533/job/24149764163?pr=460
- https://github.com/golioth/golioth-firmware-sdk/actions/runs/8799855533/job/24149763317?pr=460
- https://github.com/golioth/golioth-firmware-sdk/actions/runs/8799855533/job/24149763552?pr=460