### PR TITLE
examples: zephyr: Add CBOR examples to lightdb_stream example app

### DIFF
--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -176,7 +176,7 @@ int main(void)
             continue;
         }
 
-        LOG_DBG("Sending temperature %d.%06d (as object async)", temp.val1, abs(temp.val2));
+        LOG_DBG("Sending temperature %d.%06d (as object sync)", temp.val1, abs(temp.val2));
 
         temperature_push_sync(&temp);
 
@@ -190,7 +190,7 @@ int main(void)
             continue;
         }
 
-        LOG_DBG("Sending temperature %d.%06d (as object sync)", temp.val1, abs(temp.val2));
+        LOG_DBG("Sending temperature %d.%06d (as object async)", temp.val1, abs(temp.val2));
 
         temperature_push_async(&temp);
         k_sleep(K_SECONDS(5));

--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(stream, LOG_LEVEL_DBG);
 #include <samples/common/net_connect.h>
 #include <stdlib.h>
 #include <string.h>
+#include <zcbor_encode.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
 
@@ -102,7 +103,7 @@ static void temperature_push_handler(struct golioth_client *client,
     return;
 }
 
-static void temperature_push_async(const struct sensor_value *temp)
+static void temperature_push_async_json(const struct sensor_value *temp)
 {
     char sbuf[sizeof("{\"temp\":-4294967295.123456}")];
     int err;
@@ -123,7 +124,7 @@ static void temperature_push_async(const struct sensor_value *temp)
     }
 }
 
-static void temperature_push_sync(const struct sensor_value *temp)
+static void temperature_push_sync_json(const struct sensor_value *temp)
 {
     char sbuf[sizeof("{\"temp\":-4294967295.123456}")];
     int err;
@@ -135,6 +136,120 @@ static void temperature_push_sync(const struct sensor_value *temp)
                                   GOLIOTH_CONTENT_TYPE_JSON,
                                   sbuf,
                                   strlen(sbuf),
+                                  1);
+
+    if (err)
+    {
+        LOG_WRN("Failed to push temperature: %d", err);
+        return;
+    }
+
+    LOG_DBG("Temperature successfully pushed");
+}
+
+static void temperature_push_async_cbor(const struct sensor_value *temp)
+{
+    uint8_t buf[32];
+    int err;
+
+    /* Create zcbor state variable for encoding */
+    ZCBOR_STATE_E(zse, 1, buf, sizeof(buf), 1);
+
+    /* Encode the CBOR map header */
+    bool ok = zcbor_map_start_encode(zse, 1);
+    if (!ok)
+    {
+        LOG_ERR("Failed to start CBOR encoding");
+        return;
+    }
+
+    /* Encode the map key "temp" into buf as a text string */
+    ok = zcbor_tstr_put_lit(zse, "temp");
+    if (!ok)
+    {
+        LOG_ERR("CBOR: Failed to encode temp name");
+        return;
+    }
+
+    /* Encode the temperature value into buf as a float */
+    ok = zcbor_float32_put(zse, sensor_value_to_float(temp));
+    if (!ok)
+    {
+        LOG_ERR("CBOR: failed to encode temp value");
+        return;
+    }
+
+    /* Close the CBOR map */
+    ok = zcbor_map_end_encode(zse, 1);
+    if (!ok)
+    {
+        LOG_ERR("Failed to close CBOR map");
+        return;
+    }
+
+    size_t payload_size = (intptr_t) zse->payload - (intptr_t) buf;
+
+    err = golioth_stream_set_async(client,
+                                   "sensor",
+                                   GOLIOTH_CONTENT_TYPE_CBOR,
+                                   buf,
+                                   payload_size,
+                                   temperature_push_handler,
+                                   NULL);
+    if (err)
+    {
+        LOG_WRN("Failed to push temperature: %d", err);
+        return;
+    }
+}
+
+static void temperature_push_sync_cbor(const struct sensor_value *temp)
+{
+    uint8_t buf[32];
+    int err;
+
+    /* Create zcbor state variable for encoding */
+    ZCBOR_STATE_E(zse, 1, buf, sizeof(buf), 1);
+
+    /* Encode the CBOR map header */
+    bool ok = zcbor_map_start_encode(zse, 1);
+    if (!ok)
+    {
+        LOG_ERR("Failed to start encoding CBOR map");
+        return;
+    }
+
+    /* Encode the map key "temp" into buf as a text string */
+    ok = zcbor_tstr_put_lit(zse, "temp");
+    if (!ok)
+    {
+        LOG_ERR("CBOR: Failed to encode temp name");
+        return;
+    }
+
+    /* Encode the temperature value into buf as a float */
+    ok = zcbor_float32_put(zse, sensor_value_to_float(temp));
+    if (!ok)
+    {
+        LOG_ERR("CBOR: failed to encode temp value");
+        return;
+    }
+
+    /* Close the CBOR map */
+    ok = zcbor_map_end_encode(zse, 1);
+    if (!ok)
+    {
+        LOG_ERR("Failed to close CBOR map");
+        return;
+    }
+
+    size_t payload_size = (intptr_t) zse->payload - (intptr_t) buf;
+
+    err = golioth_stream_set_sync(client,
+                                  "sensor",
+                                  GOLIOTH_CONTENT_TYPE_CBOR,
+                                  buf,
+                                  payload_size,
                                   1);
 
     if (err)
@@ -176,9 +291,9 @@ int main(void)
             continue;
         }
 
-        LOG_DBG("Sending temperature %d.%06d (as object sync)", temp.val1, abs(temp.val2));
+        LOG_DBG("Sending temperature %d.%06d (as JSON object sync)", temp.val1, abs(temp.val2));
 
-        temperature_push_sync(&temp);
+        temperature_push_sync_json(&temp);
 
         k_sleep(K_SECONDS(5));
 
@@ -190,9 +305,38 @@ int main(void)
             continue;
         }
 
-        LOG_DBG("Sending temperature %d.%06d (as object async)", temp.val1, abs(temp.val2));
+        LOG_DBG("Sending temperature %d.%06d (as JSON object async)", temp.val1, abs(temp.val2));
 
-        temperature_push_async(&temp);
+        temperature_push_async_json(&temp);
+
+        k_sleep(K_SECONDS(5));
+
+        /* Synchronous using CBOR map */
+        err = get_temperature(&temp);
+        if (err)
+        {
+            k_sleep(K_SECONDS(1));
+            continue;
+        }
+
+        LOG_DBG("Sending temperature %d.%06d (as CBOR map sync)", temp.val1, abs(temp.val2));
+
+        temperature_push_sync_cbor(&temp);
+
+        k_sleep(K_SECONDS(5));
+
+        /* Callback-based using CBOR map */
+        err = get_temperature(&temp);
+        if (err)
+        {
+            k_sleep(K_SECONDS(1));
+            continue;
+        }
+
+        LOG_DBG("Sending temperature %d.%06d (as CBOR map async)", temp.val1, abs(temp.val2));
+
+        temperature_push_async_cbor(&temp);
+
         k_sleep(K_SECONDS(5));
     }
 

--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -103,20 +103,30 @@ static void temperature_push_handler(struct golioth_client *client,
     return;
 }
 
-static void temperature_push_async_json(const struct sensor_value *temp)
+static void temperature_push_json(const struct sensor_value *temp, bool async)
 {
     char sbuf[sizeof("{\"temp\":-4294967295.123456}")];
     int err;
 
     snprintk(sbuf, sizeof(sbuf), "{\"temp\":%d.%06d}", temp->val1, abs(temp->val2));
 
-    err = golioth_stream_set_async(client,
-                                   "sensor",
-                                   GOLIOTH_CONTENT_TYPE_JSON,
-                                   sbuf,
-                                   strlen(sbuf),
-                                   temperature_push_handler,
-                                   NULL);
+    if (async) {
+        err = golioth_stream_set_async(client,
+                                    "sensor",
+                                    GOLIOTH_CONTENT_TYPE_JSON,
+                                    sbuf,
+                                    strlen(sbuf),
+                                    temperature_push_handler,
+                                    NULL);
+    } else {
+        err = golioth_stream_set_sync(client,
+                                    "sensor",
+                                    GOLIOTH_CONTENT_TYPE_JSON,
+                                    sbuf,
+                                    strlen(sbuf),
+                                    1);
+    }
+
     if (err)
     {
         LOG_WRN("Failed to push temperature: %d", err);
@@ -124,86 +134,7 @@ static void temperature_push_async_json(const struct sensor_value *temp)
     }
 }
 
-static void temperature_push_sync_json(const struct sensor_value *temp)
-{
-    char sbuf[sizeof("{\"temp\":-4294967295.123456}")];
-    int err;
-
-    snprintk(sbuf, sizeof(sbuf), "{\"temp\":%d.%06d}", temp->val1, abs(temp->val2));
-
-    err = golioth_stream_set_sync(client,
-                                  "sensor",
-                                  GOLIOTH_CONTENT_TYPE_JSON,
-                                  sbuf,
-                                  strlen(sbuf),
-                                  1);
-
-    if (err)
-    {
-        LOG_WRN("Failed to push temperature: %d", err);
-        return;
-    }
-
-    LOG_DBG("Temperature successfully pushed");
-}
-
-static void temperature_push_async_cbor(const struct sensor_value *temp)
-{
-    uint8_t buf[32];
-    int err;
-
-    /* Create zcbor state variable for encoding */
-    ZCBOR_STATE_E(zse, 1, buf, sizeof(buf), 1);
-
-    /* Encode the CBOR map header */
-    bool ok = zcbor_map_start_encode(zse, 1);
-    if (!ok)
-    {
-        LOG_ERR("Failed to start CBOR encoding");
-        return;
-    }
-
-    /* Encode the map key "temp" into buf as a text string */
-    ok = zcbor_tstr_put_lit(zse, "temp");
-    if (!ok)
-    {
-        LOG_ERR("CBOR: Failed to encode temp name");
-        return;
-    }
-
-    /* Encode the temperature value into buf as a float */
-    ok = zcbor_float32_put(zse, sensor_value_to_float(temp));
-    if (!ok)
-    {
-        LOG_ERR("CBOR: failed to encode temp value");
-        return;
-    }
-
-    /* Close the CBOR map */
-    ok = zcbor_map_end_encode(zse, 1);
-    if (!ok)
-    {
-        LOG_ERR("Failed to close CBOR map");
-        return;
-    }
-
-    size_t payload_size = (intptr_t) zse->payload - (intptr_t) buf;
-
-    err = golioth_stream_set_async(client,
-                                   "sensor",
-                                   GOLIOTH_CONTENT_TYPE_CBOR,
-                                   buf,
-                                   payload_size,
-                                   temperature_push_handler,
-                                   NULL);
-    if (err)
-    {
-        LOG_WRN("Failed to push temperature: %d", err);
-        return;
-    }
-}
-
-static void temperature_push_sync_cbor(const struct sensor_value *temp)
+static void temperature_push_cbor(const struct sensor_value *temp, bool async)
 {
     uint8_t buf[32];
     int err;
@@ -245,20 +176,28 @@ static void temperature_push_sync_cbor(const struct sensor_value *temp)
 
     size_t payload_size = (intptr_t) zse->payload - (intptr_t) buf;
 
-    err = golioth_stream_set_sync(client,
-                                  "sensor",
-                                  GOLIOTH_CONTENT_TYPE_CBOR,
-                                  buf,
-                                  payload_size,
-                                  1);
+    if (async) {
+        err = golioth_stream_set_async(client,
+                                "sensor",
+                                GOLIOTH_CONTENT_TYPE_CBOR,
+                                buf,
+                                payload_size,
+                                temperature_push_handler,
+                                NULL);
+    } else {
+        err = golioth_stream_set_sync(client,
+                                    "sensor",
+                                    GOLIOTH_CONTENT_TYPE_CBOR,
+                                    buf,
+                                    payload_size,
+                                    1);
+    }
 
     if (err)
     {
         LOG_WRN("Failed to push temperature: %d", err);
         return;
     }
-
-    LOG_DBG("Temperature successfully pushed");
 }
 
 int main(void)
@@ -293,7 +232,7 @@ int main(void)
 
         LOG_DBG("Sending temperature %d.%06d (as JSON object sync)", temp.val1, abs(temp.val2));
 
-        temperature_push_sync_json(&temp);
+        temperature_push_json(&temp, false);
 
         k_sleep(K_SECONDS(5));
 
@@ -307,7 +246,7 @@ int main(void)
 
         LOG_DBG("Sending temperature %d.%06d (as JSON object async)", temp.val1, abs(temp.val2));
 
-        temperature_push_async_json(&temp);
+        temperature_push_json(&temp, true);
 
         k_sleep(K_SECONDS(5));
 
@@ -321,7 +260,7 @@ int main(void)
 
         LOG_DBG("Sending temperature %d.%06d (as CBOR map sync)", temp.val1, abs(temp.val2));
 
-        temperature_push_sync_cbor(&temp);
+        temperature_push_cbor(&temp, false);
 
         k_sleep(K_SECONDS(5));
 
@@ -335,7 +274,7 @@ int main(void)
 
         LOG_DBG("Sending temperature %d.%06d (as CBOR map async)", temp.val1, abs(temp.val2));
 
-        temperature_push_async_cbor(&temp);
+        temperature_push_cbor(&temp, true);
 
         k_sleep(K_SECONDS(5));
     }


### PR DESCRIPTION
Update the `lightdb_stream` example app to include sync & async examples showing how to send CBOR-encoded sensor data to LightDB Stream.

If you don't want the last commit (dc055c6464d0c34445f1a53275033b6e1dea2ca6) just LMK and I can drop it (was just trying to consolidate duplicate code)