### PR TITLE
zephyr: coap: skip free for observations

### DIFF
--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -217,6 +217,11 @@ static int golioth_coap_cb(struct golioth_req_rsp *rsp)
         }
 
         err = rsp->err;
+        if (req->type == GOLIOTH_COAP_REQUEST_OBSERVE)
+        {
+            // don't free observations so we can reestablish later
+            return err;
+        }
         goto free_req;
     }
 

--- a/tests/hil/platform/zephyr/README.md
+++ b/tests/hil/platform/zephyr/README.md
@@ -17,3 +17,29 @@ root of the SDK repository:
 ```sh
 west build -p -b nrf52840dk_nrf52840 tests/hil/platform/zephyr -- -DGOLIOTH_HIL_TEST=connection
 ```
+
+## Example of running Zephyr RPC test locally on nRF52840dk
+
+```
+cd modules/lib/golioth-firmware-sdk
+
+# Dependencies
+pip install tests/hil/scripts/pytest-hil/
+
+# Build
+west build -p -b nrf52840dk tests/hil/platform/zephyr -- -DGOLIOTH_HIL_TEST=rpc
+
+# Run test
+pytest --rootdir . tests/hil/tests/rpc         \
+  --board nrf52840dk                           \
+  --port /dev/ttyACM0                          \
+  --fw-image build/zephyr/zephyr.hex           \
+  --serial-number 1050266122                   \
+  --api-url "https://api.golioth.io"           \
+  --api-key "i2u___GOLIOTHAPIKEY___uW2odN9avN" \
+  --wifi-ssid "WiFiAPssid"                     \
+  --wifi-psk "WifiAPpassword"                  \
+  -v -s
+```
+
+The last two flags show verbose output and print statements

--- a/tests/hil/tests/ota/README.md
+++ b/tests/hil/tests/ota/README.md
@@ -2,3 +2,7 @@
 
 This tests the Over-the-Air (OTA) firmware upgrade service on the
 device.
+
+See [the HIL docs for the Zephyr
+platform](../../platform/zephyr/README.md) for an example of running
+tests locally.

--- a/tests/hil/tests/rpc/README.md
+++ b/tests/hil/tests/rpc/README.md
@@ -1,3 +1,7 @@
 # RPC Test
 
 This tests the RPC service on the device.
+
+See [the HIL docs for the Zephyr
+platform](../../platform/zephyr/README.md) for an example of running
+tests locally.

--- a/tests/hil/tests/rpc/test_rpc.py
+++ b/tests/hil/tests/rpc/test_rpc.py
@@ -70,12 +70,14 @@ async def test_invalid_arg(board, device):
 
     assert e.value.status_code == RPCStatusCode.INVALID_ARGUMENT
 
-async def test_observation_reestablishment(board, device):
-    rsp = await device.rpc.disconnect()
+async def test_observation_repeat_restart(board, device):
+    for i in range(3):
+        rsp = await device.rpc.disconnect()
 
-    # Confirm re-connection to Golioth
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+        # Confirm re-connection to Golioth
+        assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 
-    rsp = await device.rpc.basic_return_type("int")
+        rsp = await device.rpc.basic_return_type("int")
 
-    assert rsp['value'] == 42
+        assert rsp['value'] == 42
+        print(f"Loop {i} successful!")


### PR DESCRIPTION
Observations are stored in the golioth client struct so that the data may be used to reestablish observations upon reconnect. When the Golioth client is stopped, all requests in the client->coap_reqs linked list are freed. This causes the client address in the stored observation to change, leading to a crash when trying to reestablish. This commit skips freeing observations so the data remains intact. This memory should only be freed when cancelling an observation.

resolves https://github.com/golioth/firmware-issue-tracker/issues/557