### PR TITLE
zephyr: coap: add cancel observations

### DIFF
--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -124,6 +124,12 @@ static enum golioth_status golioth_coap_client_set_internal(struct golioth_clien
         return GOLIOTH_ERR_INVALID_STATE;
     }
 
+    if (strlen(path) > sizeof(request_msg.path) - 1)
+    {
+        GLTH_LOGE(TAG, "Path too long: %d > %d", strlen(path), sizeof(request_msg.path) - 1);
+        return GOLIOTH_ERR_INVALID_FORMAT;
+    }
+
     if (payload_size > 0)
     {
         // We will allocate memory and copy the payload
@@ -150,7 +156,9 @@ static enum golioth_status golioth_coap_client_set_internal(struct golioth_clien
     request_msg.type = type;
     request_msg.path_prefix = path_prefix;
     request_msg.ageout_ms = ageout_ms;
+
     strncpy(request_msg.path, path, sizeof(request_msg.path) - 1);
+
     if (is_synchronous)
     {
         // Created here, deleted by coap thread (or here if fail to enqueue
@@ -316,7 +324,14 @@ enum golioth_status golioth_coap_client_delete(struct golioth_client *client,
             },
         .ageout_ms = ageout_ms,
     };
+
+    if (strlen(path) > sizeof(request_msg.path) - 1)
+    {
+        GLTH_LOGE(TAG, "Path too long: %d > %d", strlen(path), sizeof(request_msg.path) - 1);
+        return GOLIOTH_ERR_INVALID_FORMAT;
+    }
     strncpy(request_msg.path, path, sizeof(request_msg.path) - 1);
+
     enum golioth_status status = GOLIOTH_OK;
 
     if (is_synchronous)
@@ -395,7 +410,14 @@ static enum golioth_status golioth_coap_client_get_internal(struct golioth_clien
     enum golioth_status status = GOLIOTH_OK;
     request_msg.type = type;
     request_msg.path_prefix = path_prefix;
+
+    if (strlen(path) > sizeof(request_msg.path) - 1)
+    {
+        GLTH_LOGE(TAG, "Path too long: %d > %d", strlen(path), sizeof(request_msg.path) - 1);
+        return GOLIOTH_ERR_INVALID_FORMAT;
+    }
     strncpy(request_msg.path, path, sizeof(request_msg.path) - 1);
+
     if (is_synchronous)
     {
         // Created here, deleted by coap thread (or here if fail to enqueue
@@ -535,6 +557,12 @@ enum golioth_status golioth_coap_client_observe_async(struct golioth_client *cli
                 .arg = arg,
             },
     };
+
+    if (strlen(path) > sizeof(request_msg.path) - 1)
+    {
+        GLTH_LOGE(TAG, "Path too long: %d > %d", strlen(path), sizeof(request_msg.path) - 1);
+        return GOLIOTH_ERR_INVALID_FORMAT;
+    }
     strncpy(request_msg.path, path, sizeof(request_msg.path) - 1);
 
     bool sent = golioth_mbox_try_send(client->request_queue, &request_msg);

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -525,12 +525,12 @@ enum golioth_status golioth_coap_client_get_block(struct golioth_client *client,
                                             timeout_s);
 }
 
-enum golioth_status golioth_coap_client_observe_async(struct golioth_client *client,
-                                                      const char *path_prefix,
-                                                      const char *path,
-                                                      enum golioth_content_type content_type,
-                                                      golioth_get_cb_fn callback,
-                                                      void *arg)
+enum golioth_status golioth_coap_client_observe(struct golioth_client *client,
+                                                const char *path_prefix,
+                                                const char *path,
+                                                enum golioth_content_type content_type,
+                                                golioth_get_cb_fn callback,
+                                                void *arg)
 {
     if (!client || !path)
     {

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -630,6 +630,11 @@ enum golioth_status golioth_coap_client_observe_release(struct golioth_client *c
     return GOLIOTH_OK;
 }
 
+void golioth_coap_client_cancel_all_observations(struct golioth_client *client)
+{
+    golioth_cancel_all_observations(client);
+}
+
 void golioth_client_register_event_callback(struct golioth_client *client,
                                             golioth_client_event_cb_fn callback,
                                             void *arg)

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -204,6 +204,8 @@ enum golioth_status golioth_coap_client_observe_release(struct golioth_client *c
                                                         size_t token_len,
                                                         void *arg);
 
+void golioth_coap_client_cancel_all_observations(struct golioth_client *client);
+
 /// Getters, for internal SDK code to access data within the
 /// coap client struct.
 golioth_sys_thread_t golioth_coap_client_get_thread(struct golioth_client *client);

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -188,12 +188,12 @@ enum golioth_status golioth_coap_client_get_block(struct golioth_client *client,
                                                   bool is_synchronous,
                                                   int32_t timeout_s);
 
-enum golioth_status golioth_coap_client_observe_async(struct golioth_client *client,
-                                                      const char *path_prefix,
-                                                      const char *path,
-                                                      enum golioth_content_type content_type,
-                                                      golioth_get_cb_fn callback,
-                                                      void *callback_arg);
+enum golioth_status golioth_coap_client_observe(struct golioth_client *client,
+                                                const char *path_prefix,
+                                                const char *path,
+                                                enum golioth_content_type content_type,
+                                                golioth_get_cb_fn callback,
+                                                void *callback_arg);
 
 /// Getters, for internal SDK code to access data within the
 /// coap client struct.

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -78,6 +78,7 @@ typedef enum
     GOLIOTH_COAP_REQUEST_POST_BLOCK,
     GOLIOTH_COAP_REQUEST_DELETE,
     GOLIOTH_COAP_REQUEST_OBSERVE,
+    GOLIOTH_COAP_REQUEST_OBSERVE_RELEASE,
 } golioth_coap_request_type_t;
 
 typedef struct
@@ -194,6 +195,14 @@ enum golioth_status golioth_coap_client_observe(struct golioth_client *client,
                                                 enum golioth_content_type content_type,
                                                 golioth_get_cb_fn callback,
                                                 void *callback_arg);
+
+enum golioth_status golioth_coap_client_observe_release(struct golioth_client *client,
+                                                        const char *path_prefix,
+                                                        const char *path,
+                                                        enum golioth_content_type content_type,
+                                                        uint8_t *token,
+                                                        size_t token_len,
+                                                        void *arg);
 
 /// Getters, for internal SDK code to access data within the
 /// coap client struct.

--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -672,6 +672,26 @@ static enum golioth_status add_observation(golioth_coap_request_msg_t *req,
     return GOLIOTH_OK;
 }
 
+void golioth_cancel_all_observations(struct golioth_client *client)
+{
+    golioth_coap_observe_info_t *obs_info = NULL;
+    for (int i = 0; i < CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS; i++)
+    {
+        obs_info = &client->observations[i];
+        if (obs_info->in_use)
+        {
+            obs_info->in_use = false;
+            golioth_coap_client_observe_release(client,
+                                                obs_info->req.path_prefix,
+                                                obs_info->req.path,
+                                                obs_info->req.observe.content_type,
+                                                obs_info->req.token,
+                                                obs_info->req.token_len,
+                                                NULL);
+        }
+    }
+}
+
 static void reestablish_observations(struct golioth_client *client, coap_session_t *session)
 {
     golioth_coap_observe_info_t *obs_info = NULL;

--- a/src/coap_client_libcoap.h
+++ b/src/coap_client_libcoap.h
@@ -21,3 +21,5 @@ struct golioth_client
     golioth_client_event_cb_fn event_callback;
     void *event_callback_arg;
 };
+
+void golioth_cancel_all_observations(struct golioth_client *client);

--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -530,6 +530,23 @@ static int add_observation(golioth_coap_request_msg_t *req, struct golioth_clien
     return 0;
 }
 
+void golioth_cancel_all_observations(struct golioth_client *client)
+{
+    for (int i = 0; i < CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS; i++)
+    {
+        golioth_coap_observe_info_t *obs_info = &client->observations[i];
+        if (obs_info->in_use)
+        {
+            int err = golioth_coap_req_find_and_cancel_observation(client, &obs_info->req);
+            if (err)
+            {
+                LOG_WRN("Error sending eager release for observation: %d", err);
+            }
+            obs_info->in_use = false;
+        }
+    }
+}
+
 static int golioth_deregister_observation(golioth_coap_request_msg_t *req,
                                           struct golioth_client *client)
 {

--- a/src/coap_client_zephyr.h
+++ b/src/coap_client_zephyr.h
@@ -99,3 +99,5 @@ struct golioth_client
 };
 
 int golioth_send_coap(struct golioth_client *client, struct coap_packet *packet);
+
+void golioth_cancel_all_observations(struct golioth_client *client);

--- a/src/lightdb_state.c
+++ b/src/lightdb_state.c
@@ -191,12 +191,12 @@ enum golioth_status golioth_lightdb_observe_async(struct golioth_client *client,
                                                   golioth_get_cb_fn callback,
                                                   void *arg)
 {
-    return golioth_coap_client_observe_async(client,
-                                             GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
-                                             path,
-                                             GOLIOTH_CONTENT_TYPE_JSON,
-                                             callback,
-                                             arg);
+    return golioth_coap_client_observe(client,
+                                       GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
+                                       path,
+                                       GOLIOTH_CONTENT_TYPE_JSON,
+                                       callback,
+                                       arg);
 }
 
 enum golioth_status golioth_lightdb_set_int_sync(struct golioth_client *client,

--- a/src/ota.c
+++ b/src/ota.c
@@ -86,12 +86,12 @@ enum golioth_status golioth_ota_observe_manifest_async(struct golioth_client *cl
                                                        golioth_get_cb_fn callback,
                                                        void *arg)
 {
-    return golioth_coap_client_observe_async(client,
-                                             "",
-                                             GOLIOTH_OTA_MANIFEST_PATH,
-                                             GOLIOTH_CONTENT_TYPE_CBOR,
-                                             callback,
-                                             arg);
+    return golioth_coap_client_observe(client,
+                                       "",
+                                       GOLIOTH_OTA_MANIFEST_PATH,
+                                       GOLIOTH_CONTENT_TYPE_CBOR,
+                                       callback,
+                                       arg);
 }
 
 enum golioth_status golioth_ota_report_state_sync(struct golioth_client *client,

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -256,12 +256,12 @@ enum golioth_status golioth_rpc_register(struct golioth_rpc *grpc,
     grpc->num_rpcs++;
     if (grpc->num_rpcs == 1)
     {
-        return golioth_coap_client_observe_async(grpc->client,
-                                                 GOLIOTH_RPC_PATH_PREFIX,
-                                                 "",
-                                                 GOLIOTH_CONTENT_TYPE_CBOR,
-                                                 on_rpc,
-                                                 grpc);
+        return golioth_coap_client_observe(grpc->client,
+                                           GOLIOTH_RPC_PATH_PREFIX,
+                                           "",
+                                           GOLIOTH_CONTENT_TYPE_CBOR,
+                                           on_rpc,
+                                           grpc);
     }
     return GOLIOTH_OK;
 }

--- a/src/settings.c
+++ b/src/settings.c
@@ -449,12 +449,12 @@ struct golioth_settings *golioth_settings_init(struct golioth_client *client)
     gsettings->client = client;
     gsettings->num_settings = 0;
 
-    enum golioth_status status = golioth_coap_client_observe_async(client,
-                                                                   SETTINGS_PATH_PREFIX,
-                                                                   "",
-                                                                   GOLIOTH_CONTENT_TYPE_CBOR,
-                                                                   on_settings,
-                                                                   gsettings);
+    enum golioth_status status = golioth_coap_client_observe(client,
+                                                             SETTINGS_PATH_PREFIX,
+                                                             "",
+                                                             GOLIOTH_CONTENT_TYPE_CBOR,
+                                                             on_settings,
+                                                             gsettings);
 
     if (status != GOLIOTH_OK)
     {

--- a/src/zephyr_coap_req.h
+++ b/src/zephyr_coap_req.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "coap_client.h"
 #include "coap_client_zephyr.h"
 
 /**
@@ -121,6 +122,22 @@ void golioth_coap_req_free(struct golioth_coap_req *req);
  * @retval <0 On failure
  */
 int golioth_coap_req_schedule(struct golioth_coap_req *req);
+
+/**
+ * @brief Cancel a CoAP observation
+ *
+ * Search the client coap_reqs array for a request that has a user_data pointer that matches the
+ * provided goloth_coap_request_msg_t pointer. Enqueue an observation release request to be sent to
+ * the server. Remove the request from the client coap_reqs list and free the memory.
+ *
+ * @param[in] client Client instance
+ * @param[in] cancel_req_msg pointer to request message used to match with CoAP request
+ *
+ * @retval 0 On success
+ * @retval <0 On failure
+ */
+int golioth_coap_req_find_and_cancel_observation(struct golioth_client *client,
+                                                 golioth_coap_request_msg_t *cancel_req_msg);
 
 /**
  * @brief Create and schedule CoAP request for sending

--- a/tests/hil/platform/zephyr/README.md
+++ b/tests/hil/platform/zephyr/README.md
@@ -27,7 +27,7 @@ cd modules/lib/golioth-firmware-sdk
 pip install tests/hil/scripts/pytest-hil/
 
 # Build
-west build -p -b nrf52840dk tests/hil/platform/zephyr -- -DGOLIOTH_HIL_TEST=rpc
+west build -p -b nrf52840dk_nrf52840 tests/hil/platform/zephyr -- -DGOLIOTH_HIL_TEST=rpc
 
 # Run test
 pytest --rootdir . tests/hil/tests/rpc         \

--- a/tests/hil/tests/rpc/test_rpc.py
+++ b/tests/hil/tests/rpc/test_rpc.py
@@ -81,3 +81,17 @@ async def test_observation_repeat_restart(board, device):
 
         assert rsp['value'] == 42
         print(f"Loop {i} successful!")
+
+async def test_observation_cancel_all(board, device):
+    rsp = await device.rpc.cancel_all()
+
+    assert None != board.wait_for_regex_in_line('Cancelling observations', timeout_s=10)
+    assert None != board.wait_for_regex_in_line('Observations cancelled', timeout_s=10)
+
+    with pytest.raises(RPCTimeout):
+        rsp = await device.rpc.basic_return_type("int")
+
+    assert None != board.wait_for_regex_in_line('RPC observation established', timeout_s=30)
+
+    rsp = await device.rpc.basic_return_type("int")
+    assert rsp['value'] == 42

--- a/tests/unit_tests/fakes/coap_client_fake.c
+++ b/tests/unit_tests/fakes/coap_client_fake.c
@@ -2,7 +2,7 @@
 #include "coap_client_fake.h"
 
 DEFINE_FAKE_VALUE_FUNC(enum golioth_status,
-                       golioth_coap_client_observe_async,
+                       golioth_coap_client_observe,
                        struct golioth_client *,
                        const char *,
                        const char *,

--- a/tests/unit_tests/fakes/coap_client_fake.h
+++ b/tests/unit_tests/fakes/coap_client_fake.h
@@ -3,7 +3,7 @@
 #include <coap_client.h>
 
 DECLARE_FAKE_VALUE_FUNC(enum golioth_status,
-                        golioth_coap_client_observe_async,
+                        golioth_coap_client_observe,
                         struct golioth_client *,
                         const char *,
                         const char *,

--- a/tests/unit_tests/test_rpc.c
+++ b/tests/unit_tests/test_rpc.c
@@ -57,7 +57,7 @@ void tearDown(void)
     last_err_msg = NULL;
     last_wrn_msg = NULL;
     last_coap_payload_size = 0;
-    RESET_FAKE(golioth_coap_client_observe_async);
+    RESET_FAKE(golioth_coap_client_observe);
     RESET_FAKE(golioth_coap_client_set);
     RESET_FAKE(test_rpc_method_fn);
     FFF_RESET_HISTORY();
@@ -69,7 +69,7 @@ void test_rpc_register(void)
 
     TEST_ASSERT_EQUAL(GOLIOTH_OK, ret);
     TEST_ASSERT_EQUAL(1, grpc.num_rpcs);
-    TEST_ASSERT_EQUAL(1, golioth_coap_client_observe_async_fake.call_count);
+    TEST_ASSERT_EQUAL(1, golioth_coap_client_observe_fake.call_count);
 }
 
 void test_rpc_register_multi(void)
@@ -81,7 +81,7 @@ void test_rpc_register_multi(void)
     }
 
     TEST_ASSERT_EQUAL(3, grpc.num_rpcs);
-    TEST_ASSERT_EQUAL(1, golioth_coap_client_observe_async_fake.call_count);
+    TEST_ASSERT_EQUAL(1, golioth_coap_client_observe_fake.call_count);
 }
 
 void test_rpc_register_too_many(void)


### PR DESCRIPTION
Add ability to remove observations from the client coap_reqs lists, and mark the observation slots as not in_use. The cancellation process sends an "eager release" coap packet to the server indicating the observation has been  cancelled.

This searches the coap_reqs linked list by matching the request message pointer which is why the `coap_client.h` header was included. I think a future improvement to how observations are handled should be storing crucial observation values instead of the the request message. If we store the coap token as one of those values, it can be used to search in the coap_reqs.

* This should be merged after #467
* This should be merged after #452
* resolves https://github.com/golioth/firmware-issue-tracker/issues/519