### PR TITLE
examples: zephyr: Fix get_temperature with temp0 DT alias

### DIFF
--- a/examples/zephyr/lightdb_stream/src/main.c
+++ b/examples/zephyr/lightdb_stream/src/main.c
@@ -63,6 +63,7 @@ static int get_temperature(struct sensor_value *val)
             LOG_ERR("Failed to get temperature: %d", err);
             return err;
         }
+        break;
     }
 
     return err;


### PR DESCRIPTION
When a `temp0` devicetree alias is added to the board overlay, the `get_temperature` function was looping through all sensor channels, always returning the result of reading the last one, even if it was not a supported channel.

This fixes the function so that it returns after the first successful read from a temperature channel.