### PR TITLE
pre-commit: Update pre-commit repo revisions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: kiwicom/pre-commit:3.0.4
+      image: kiwicom/pre-commit:3.6.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^patches/'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.6.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -9,6 +9,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.10
+    rev: v1.5.5
     hooks:
       - id: forbid-crlf


### PR DESCRIPTION
I had some issues using `pre-commit` locally w/ Python 3.12, e.g.

```
ERROR: Failed building wheel for python-Levenshtein-wheels
```

Auto-upgrading the pre-commit dependencies (`pre-commit autoupdate`) to their latest versions fixed these issues.

I also had to upgrade the `pre-commit` docker image to `kiwicom/pre-commit:3.6.0` due to https://github.com/Lucas-C/pre-commit-hooks/issues/83