### PR TITLE
tests: hil: rpc: wait for RPCs to be registered before running testcases

### DIFF
--- a/tests/hil/tests/rpc/test_rpc.py
+++ b/tests/hil/tests/rpc/test_rpc.py
@@ -10,7 +10,7 @@ async def setup(project, board, device):
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Confirm connection to Golioth
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+    assert None != board.wait_for_regex_in_line('RPC observation established', timeout_s=120)
 
 ##### Tests #####
 


### PR DESCRIPTION
Seems that most ESP32 boards are registering RPC significantly slower
pytest testcases are invoked. As a result first testcase timeouts due to
ESP32 boards being not ready to handle RPCs.

Fix that race condition by introducing waiting "for RPC observation
established" log message, which is generated after RPC registration has
been acknowledged by Golioth backend.