### PR TITLE
hil: zephyr: lightdb: match pipe character exactly in regex

### DIFF
--- a/examples/zephyr/lightdb/observe/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/observe/pytest/test_sample.py
@@ -37,7 +37,7 @@ async def test_lightdb_observe(shell, device, wifi_ssid, wifi_psk):
     # Verify lightdb observe
 
     shell._device.readlines_until(regex=".*lightdb_observe: Counter \(async\)", timeout=10.0)
-    shell._device.readlines_until(regex=".*6e 75 6c 6c\s+|null", timeout=1.0)
+    shell._device.readlines_until(regex=".*6e 75 6c 6c\s+\|null", timeout=1.0)
 
     await device.lightdb.set("counter", 87)
 


### PR DESCRIPTION
Fixes regex to match the pipe character exactly by escaping it. Previously it was being interpreted as an OR operator in the regex.