### PR TITLE
Add settings cancel API

### DIFF
--- a/include/golioth/settings.h
+++ b/include/golioth/settings.h
@@ -92,6 +92,16 @@ typedef enum golioth_settings_status (*golioth_string_setting_cb)(const char *ne
 /// @return NULL - Error initializing Settings service
 struct golioth_settings *golioth_settings_init(struct golioth_client *client);
 
+/// Deinitialize the Settings service
+///
+/// Cancel all registered settings and free the Golioth Settings service handle.
+///
+/// @param settings Golioth Settings service handle.
+///
+/// @return GOLIOTH_OK - RPC service successfully deinitialized
+/// @return otherwise - Error deinitializing the Settings service
+enum golioth_status golioth_settings_deinit(struct golioth_settings *settings);
+
 /// Register a specific setting of type int
 ///
 /// @param settings Settings handle

--- a/src/settings.c
+++ b/src/settings.c
@@ -467,6 +467,20 @@ finish:
     return gsettings;
 }
 
+enum golioth_status golioth_settings_deinit(struct golioth_settings *settings)
+{
+
+    if (settings == NULL)
+    {
+        GLTH_LOGE(TAG, "Settings service handle must not be NULL");
+        return GOLIOTH_ERR_NULL;
+    }
+
+    golioth_coap_client_cancel_observations_by_prefix(settings->client, SETTINGS_PATH_PREFIX);
+    free(settings);
+    return GOLIOTH_OK;
+}
+
 enum golioth_status golioth_settings_register_int(struct golioth_settings *settings,
                                                   const char *setting_name,
                                                   golioth_int_setting_cb callback,

--- a/tests/hil/tests/settings/test.c
+++ b/tests/hil/tests/settings/test.c
@@ -6,6 +6,7 @@
 LOG_TAG_DEFINE(test_settings);
 
 static golioth_sys_sem_t connected_sem;
+static golioth_sys_sem_t cancel_all_sem;
 
 static enum golioth_settings_status on_test_int(int32_t new_value, void *arg)
 {
@@ -44,6 +45,18 @@ static enum golioth_settings_status on_test_string(const char *new_value,
     return GOLIOTH_SETTINGS_SUCCESS;
 }
 
+static enum golioth_settings_status on_test_cancel(bool new_value, void *arg)
+{
+    GLTH_LOGI(TAG, "Received test_cancel: %d", new_value);
+
+    if (new_value)
+    {
+        golioth_sys_sem_give(cancel_all_sem);
+    }
+
+    return GOLIOTH_SETTINGS_SUCCESS;
+}
+
 static void on_client_event(struct golioth_client *client,
                             enum golioth_client_event event,
                             void *arg)
@@ -54,17 +67,8 @@ static void on_client_event(struct golioth_client *client,
     }
 }
 
-void hil_test_entry(const struct golioth_client_config *config)
+static struct golioth_settings *perform_settings_registration(struct golioth_client *client)
 {
-    connected_sem = golioth_sys_sem_create(1, 0);
-
-    golioth_debug_set_cloud_log_enabled(false);
-
-    struct golioth_client *client = golioth_client_create(config);
-    golioth_client_register_event_callback(client, on_client_event, NULL);
-
-    golioth_sys_sem_take(connected_sem, GOLIOTH_SYS_WAIT_FOREVER);
-
     struct golioth_settings *settings = golioth_settings_init(client);
 
     enum golioth_status status =
@@ -85,10 +89,50 @@ void hil_test_entry(const struct golioth_client_config *config)
 
     status = golioth_settings_register_int(settings, "TEST_WRONG_TYPE", on_test_int, NULL);
 
+    status = golioth_settings_register_bool(settings, "TEST_CANCEL", on_test_cancel, NULL);
+
     (void) status;
+
+    return settings;
+}
+
+void hil_test_entry(const struct golioth_client_config *config)
+{
+    connected_sem = golioth_sys_sem_create(1, 0);
+    cancel_all_sem = golioth_sys_sem_create(1, 0);
+
+    golioth_debug_set_cloud_log_enabled(false);
+
+    struct golioth_client *client = golioth_client_create(config);
+    golioth_client_register_event_callback(client, on_client_event, NULL);
+
+    golioth_sys_sem_take(connected_sem, GOLIOTH_SYS_WAIT_FOREVER);
+
+    struct golioth_settings *settings = perform_settings_registration(client);
 
     while (1)
     {
-        golioth_sys_msleep(5000);
+        if (golioth_sys_sem_take(cancel_all_sem, 0))
+        {
+            // Delay to ensure RPC response makes it to cloud
+            golioth_sys_msleep(1000);
+
+            GLTH_LOGI(TAG, "Cancelling settings");
+            golioth_settings_deinit(settings);
+            settings = NULL;
+
+            golioth_sys_msleep(5 * 1000);
+
+            GLTH_LOGI(TAG, "Settings have been cancelled");
+            golioth_sys_msleep(15 * 1000);
+
+            /* re-register for future tests */
+            settings = perform_settings_registration(client);
+
+            golioth_sys_msleep(5 * 1000);
+            GLTH_LOGI(TAG, "Settings have been reregistered");
+        }
+
+        golioth_sys_msleep(100);
     }
 }


### PR DESCRIPTION
Add API to cancel settings observations and free the settings service context.

Resolves https://github.com/golioth/firmware-issue-tracker/issues/521