### PR TITLE
ota: include target version when status is UPDATING

### DIFF
--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -282,7 +282,7 @@ static void fw_update_thread(void *arg)
                                             GOLIOTH_OTA_REASON_READY,
                                             _config.fw_package_name,
                                             _config.current_version,
-                                            NULL,
+                                            _main_component->version,
                                             GOLIOTH_SYS_WAIT_FOREVER);
 
         if (fw_update_change_boot_image() != GOLIOTH_OK)


### PR DESCRIPTION
Include the target firmware version when settings the UPDATING status on the server. This matches the behavior for the DOWNLOADING and DOWNLOADED statuses.

resolves https://github.com/golioth/firmware-issue-tracker/issues/567