### PR TITLE
HIL: adjust OTA test timing

### DIFF
--- a/tests/hil/tests/ota/test.c
+++ b/tests/hil/tests/ota/test.c
@@ -95,7 +95,7 @@ static void test_reason_and_state(void)
         {
             GLTH_LOGE(TAG, "Unable to report ota state: %d", status);
         }
-        golioth_sys_msleep(5000);
+        golioth_sys_msleep(7000);
     }
 
     GLTH_LOGI(TAG, "golioth_ota_get_state: %d", golioth_ota_get_state());

--- a/tests/hil/tests/ota/test_ota.py
+++ b/tests/hil/tests/ota/test_ota.py
@@ -178,8 +178,8 @@ async def test_reason_and_state(board, device, project, releases):
     # Test reason and state code updates
 
     for i, r in enumerate(golioth_ota_reason):
-        board.wait_for_regex_in_line("Updating status", timeout_s=12)
-        time.sleep(1.5) # Wait for server to propagate
+        board.wait_for_regex_in_line("Updating status", timeout_s=20)
+        time.sleep(3) # Wait for server to propagate
 
         await device.refresh()
 


### PR DESCRIPTION
Adjust OTA test timing to reduce tests that fail due to propagation delay.

https://github.com/golioth/firmware-issue-tracker/issues/568