### PR TITLE
kconfig: re-organize Kconfig symbols for menuconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Kconfig: reorganized how Kconfig options are presented in the
+  menuconfig interface.
+
 ## [0.12.2] - 2024-05-02
 
 ### Removed:

--- a/port/esp_idf/components/golioth_sdk/Kconfig
+++ b/port/esp_idf/components/golioth_sdk/Kconfig
@@ -8,4 +8,22 @@ menu "Golioth SDK Configuration"
 
 rsource '../../../../src/Kconfig'
 
+menu "Authentication"
+
+rsource '../../../../src/Kconfig.authentication'
+
+endmenu # Authentication
+
+menu "CoAP"
+
+rsource '../../../../src/Kconfig.coap'
+
+endmenu # CoAP
+
+menu "Logging"
+
+rsource '../../../../src/Kconfig.logging'
+
+endmenu # Logging
+
 endmenu # Golioth SDK Configuration

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2023 Golioth, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+module = GOLIOTH
+module-str = Golioth
+
 menuconfig GOLIOTH_FIRMWARE_SDK
 	bool "Golioth Firmware SDK"
 	select COAP
@@ -23,9 +26,11 @@ menuconfig GOLIOTH_FIRMWARE_SDK
 
 if GOLIOTH_FIRMWARE_SDK
 
-menu "Golioth SDK Configuration"
-
 source "${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/src/Kconfig"
+
+menu "Authentication"
+
+source "${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/src/Kconfig.authentication"
 
 config GOLIOTH_USE_CONNECTION_ID
 	bool "Use DTLS 1.2 Connection IDs"
@@ -139,6 +144,15 @@ config GOLIOTH_HOSTNAME_VERIFICATION_SKIP
 
 endif # GOLIOTH_HOSTNAME_VERIFICATION
 
+config GOLIOTH_HARDCODED_CA_CRT_PATH
+    default "${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/src/isrgrootx1.der"
+
+endmenu # authentication
+
+menu "CoAP"
+
+source "${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/src/Kconfig.coap"
+
 config GOLIOTH_COAP_CLIENT_PING_INTERVAL_SEC
 	int "Ping interval (seconds)"
 	default 9
@@ -159,22 +173,11 @@ config GOLIOTH_COAP_CLIENT_RX_BUF_SIZE
 	  Size of receive buffer, which is used for reading data from network
 	  socket.
 
-endmenu
+endmenu # CoAP Settings
 
-config GOLIOTH_HARDCODED_CA_CRT_PATH
-    default "${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/src/isrgrootx1.der"
+menu "Logging"
 
-config GOLIOTH_ZEPHYR_THREAD_STACKS
-	int "Number of thread stacks in Zephyr pool"
-	default 2
-	help
-	  Number of thread stacks statically allocated for the use in golioth_sys_thread_create().
-
-config GOLIOTH_ZEPHYR_THREAD_STACK_SIZE
-	int "Thread stack sizes in Zephyr pool"
-	default GOLIOTH_COAP_THREAD_STACK_SIZE
-	help
-	  Threads stacks sizes for the use in golioth_sys_thread_create().
+source "subsys/logging/Kconfig.template.log_config"
 
 config LOG_BACKEND_GOLIOTH
 	bool "Golioth logging backend"
@@ -197,10 +200,22 @@ config LOG_BACKEND_GOLIOTH_MAX_LOG_STRING_SIZE
 
 endif # LOG_BACKEND_GOLIOTH
 
-module = GOLIOTH
-module-str = Golioth
-source "subsys/logging/Kconfig.template.log_config"
+source "${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/src/Kconfig.logging"
+
+endmenu # Logging
 
 rsource '${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/examples/zephyr/common/Kconfig'
+
+config GOLIOTH_ZEPHYR_THREAD_STACKS
+	int "Number of thread stacks in Zephyr pool"
+	default 2
+	help
+	  Number of thread stacks statically allocated for the use in golioth_sys_thread_create().
+
+config GOLIOTH_ZEPHYR_THREAD_STACK_SIZE
+	int "Thread stack sizes in Zephyr pool"
+	default GOLIOTH_COAP_THREAD_STACK_SIZE
+	help
+	  Threads stacks sizes for the use in golioth_sys_thread_create().
 
 endif # GOLIOTH_FIRMWARE_SDK

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -1,10 +1,6 @@
 # Copyright (c) 2023 Golioth, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-config LIBCOAP_TLS_HOSTNAME_LEN_MAX
-	int "Maximum length for hostname of a TLS peer"
-	default 64
-
 menuconfig GOLIOTH_FIRMWARE_SDK
 	bool "Golioth Firmware SDK"
 	select COAP

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -261,12 +261,6 @@ config GOLIOTH_DEBUG_DEFAULT_LOG_LEVEL
 
         This value can be overriden at runtime with golioth_debug_set_log_level().
 
-config GOLIOTH_LIBCOAP_EXTRA_FDS_MAX
-	int "libcoap extra I/O file descriptors"
-	default 1
-	help
-	  Maximum number of extra I/O file descriptors passed to coap_io_process_with_fds() API.
-
 choice GOLIOTH_AUTH_METHOD
     prompt "Authentication method support"
 

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -4,76 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-config GOLIOTH_COAP_HOST_URI
-    string "CoAP server URI"
-    default "coaps://coap.golioth.io"
+config GOLIOTH_FW_UPDATE
+    bool "Golioth Firmware Update service"
     help
-        The URI of the CoAP server
+        Enable the Golioth Firmware Update service
 
-config GOLIOTH_COAP_RESPONSE_TIMEOUT_S
-    int "CoAP response timeout"
-    default 10
-    help
-        Maximum time, in seconds, the CoAP thread will block while waiting
-        for a response from the server.
-
-config GOLIOTH_COAP_REQUEST_QUEUE_TIMEOUT_MS
-    int "CoAP request queue timeout"
-    default 1000
-    help
-        Maximum time, in milliseconds, the CoAP thread will block while
-        waiting for something to arrive in the request queue.
-        This is also how often to poll for received observations.
-
-config GOLIOTH_COAP_REQUEST_QUEUE_MAX_ITEMS
-    int "CoAP request queue max num items"
-    default 10
-    help
-        The size, in items, of the CoAP thread request queue.
-        If the queue is full, any attempts to queue new messages
-        will fail.
-
-config GOLIOTH_COAP_THREAD_PRIORITY
-    int "Golioth CoAP thread priority"
-    default 5
-    help
-        Thread priority of the Golioth CoAP thread.
-
-config GOLIOTH_COAP_THREAD_STACK_SIZE
-    int "Golioth CoAP thread stack size"
-    default 6144
-    help
-        Thread stack size of the Golioth CoAP thread, in bytes.
-
-config GOLIOTH_COAP_KEEPALIVE_INTERVAL_S
-    int "Golioth CoAP keepalive interval, in seconds"
-    default 9
-    help
-        How often to send a "keepalive" dummy client request to the server.
-        If the session is idle for this amount of time, then the keepalive
-        request will be sent.
-        Can be useful to keep the CoAP session active, and to mitigate
-        against NAT and server timeouts.
-        Set to 0 to disable.
-
-config GOLIOTH_MAX_NUM_OBSERVATIONS
-    int "Golioth CoAP maximum number observations"
-    default 8
-    help
-        The maximum number of CoAP paths which can be simultaneously observed.
-
-config GOLIOTH_BLOCKWISE_UPLOAD_BLOCK_SIZE
-    int "Golioth blockwise uploads block size"
-    default 1024
-    help
-        Block size in Blockwise Uploads.
-
-config GOLIOTH_BLOCKWISE_DOWNLOAD_BUFFER_SIZE
-    int "Golioth blockwise downloads buffer size"
-    default 1024
-    help
-        Buffer size used in Blockwise Downloads. This size will also determine
-        the max size of each block.
+if GOLIOTH_FW_UPDATE
 
 config GOLIOTH_OTA_THREAD_STACK_SIZE
     int "Golioth OTA thread stack size"
@@ -134,17 +70,7 @@ config GOLIOTH_OTA_PATCH
         as patches, and will apply the bsdiff patching algorithm to them, using the currently
         running firmware image as the old/base version.
 
-config GOLIOTH_COAP_MAX_PATH_LEN
-    int "Golioth maximum CoAP path length"
-    default 39
-    help
-        Maximum length of a CoAP path (everything after
-        "coaps://coap.golioth.io/").
-
-config GOLIOTH_FW_UPDATE
-    bool "Golioth Firmware Update service"
-    help
-        Enable the Golioth Firmware Update service
+endif # GOLIOTH_FW_UPDATE
 
 config GOLIOTH_LIGHTDB_STATE
     bool "Golioth LightDB State service"
@@ -216,73 +142,3 @@ config GOLIOTH_MAX_NUM_SETTINGS
         by the application.
 
 endif # GOLIOTH_SETTINGS
-
-config GOLIOTH_DEBUG_LOG
-    bool "Enable internal debug logs"
-    default y
-    help
-        Enable/disable GLTH_LOGX log statements.
-
-        If disabled, then the GLTH_LOGX macros will
-        be removed/undefined.
-
-config GOLIOTH_AUTO_LOG_TO_CLOUD
-    bool "Enable automatic logging to Golioth"
-    default y
-    help
-        Enable/disable automatic logging to Golioth for GLTH_LOGX statements
-
-        If enabled, GLTH_LOGX statements will log to stdout as well as to
-        Golioth. If disabled, they will only go to stdout.
-
-        Enabling can result is a large amount of data transmitted to Golioth,
-        so use with caution.
-
-        If you enable this, it might be a good idea to increase
-        GOLIOTH_COAP_REQUEST_QUEUE_MAX_ITEMS, since there will be many
-        more CoAP requests (one per GLTH_LOGX statement). Otherwise you
-        will see warnings like "Failed to enqueue request, queue full".
-
-        There is an internal feature flag that is set by default to the value of this
-        configuration item. The flag can also be set at runtime.
-
-config GOLIOTH_DEBUG_DEFAULT_LOG_LEVEL
-    int "Default log level for Golioth SDK"
-    default 3
-    help
-        The default log level, which is used to filter GLTH_LOGX statements.
-
-        0: None
-        1: Error
-        2: Warn
-        3: Info
-        4: Debug
-        5: Verbose
-
-        This value can be overriden at runtime with golioth_debug_set_log_level().
-
-choice GOLIOTH_AUTH_METHOD
-    prompt "Authentication method support"
-
-config GOLIOTH_AUTH_METHOD_PSK
-    bool "PSK-ID / PSK only"
-    imply GOLIOTH_AUTH_PSK_MBEDTLS_DEPS
-    help
-      Only PSK based authentication will be supported.
-
-config GOLIOTH_AUTH_METHOD_CERT
-    bool "Certificate based only"
-    imply GOLIOTH_AUTH_CERT_MBEDTLS_DEPS
-    help
-      Only certificate based authentication will be supported.
-
-endchoice
-
-if GOLIOTH_AUTH_METHOD_CERT
-
-config GOLIOTH_HARDCODED_CA_CRT_PATH
-    string "Server CA certificate path"
-    help
-      Path to a certificate that will be used to authenticate the server
-
-endif

--- a/src/Kconfig.authentication
+++ b/src/Kconfig.authentication
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2024 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+choice GOLIOTH_AUTH_METHOD
+    prompt "Authentication method support"
+
+config GOLIOTH_AUTH_METHOD_PSK
+    bool "PSK-ID / PSK only"
+    imply GOLIOTH_AUTH_PSK_MBEDTLS_DEPS
+    help
+      Only PSK based authentication will be supported.
+
+config GOLIOTH_AUTH_METHOD_CERT
+    bool "Certificate based only"
+    imply GOLIOTH_AUTH_CERT_MBEDTLS_DEPS
+    help
+      Only certificate based authentication will be supported.
+
+endchoice
+
+if GOLIOTH_AUTH_METHOD_CERT
+
+config GOLIOTH_HARDCODED_CA_CRT_PATH
+    string "Server CA certificate path"
+    help
+      Path to a certificate that will be used to authenticate the server
+
+endif

--- a/src/Kconfig.coap
+++ b/src/Kconfig.coap
@@ -1,0 +1,84 @@
+#
+# Copyright (C) 2024 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+config GOLIOTH_COAP_HOST_URI
+    string "CoAP server URI"
+    default "coaps://coap.golioth.io"
+    help
+        The URI of the CoAP server
+
+config GOLIOTH_COAP_RESPONSE_TIMEOUT_S
+    int "CoAP response timeout"
+    default 10
+    help
+        Maximum time, in seconds, the CoAP thread will block while waiting
+        for a response from the server.
+
+config GOLIOTH_COAP_REQUEST_QUEUE_TIMEOUT_MS
+    int "CoAP request queue timeout"
+    default 1000
+    help
+        Maximum time, in milliseconds, the CoAP thread will block while
+        waiting for something to arrive in the request queue.
+        This is also how often to poll for received observations.
+
+config GOLIOTH_COAP_REQUEST_QUEUE_MAX_ITEMS
+    int "CoAP request queue max num items"
+    default 10
+    help
+        The size, in items, of the CoAP thread request queue.
+        If the queue is full, any attempts to queue new messages
+        will fail.
+
+config GOLIOTH_MAX_NUM_OBSERVATIONS
+    int "Golioth CoAP maximum number observations"
+    default 8
+    help
+        The maximum number of CoAP paths which can be simultaneously observed.
+
+config GOLIOTH_BLOCKWISE_UPLOAD_BLOCK_SIZE
+    int "Golioth blockwise uploads block size"
+    default 1024
+    help
+        Block size in Blockwise Uploads.
+
+config GOLIOTH_BLOCKWISE_DOWNLOAD_BUFFER_SIZE
+    int "Golioth blockwise downloads buffer size"
+    default 1024
+    help
+        Buffer size used in Blockwise Downloads. This size will also determine
+        the max size of each block.
+
+config GOLIOTH_COAP_THREAD_PRIORITY
+    int "Golioth CoAP thread priority"
+    default 5
+    help
+        Thread priority of the Golioth CoAP thread.
+
+config GOLIOTH_COAP_THREAD_STACK_SIZE
+    int "Golioth CoAP thread stack size"
+    default 6144
+    help
+        Thread stack size of the Golioth CoAP thread, in bytes.
+
+config GOLIOTH_COAP_KEEPALIVE_INTERVAL_S
+    int "Golioth CoAP keepalive interval, in seconds"
+    default 9
+    help
+        How often to send a "keepalive" dummy client request to the server.
+        If the session is idle for this amount of time, then the keepalive
+        request will be sent.
+        Can be useful to keep the CoAP session active, and to mitigate
+        against NAT and server timeouts.
+        Set to 0 to disable.
+
+config GOLIOTH_COAP_MAX_PATH_LEN
+    int "Golioth maximum CoAP path length"
+    default 39
+    help
+        Maximum length of a CoAP path (everything after
+        "coaps://coap.golioth.io/").

--- a/src/Kconfig.logging
+++ b/src/Kconfig.logging
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2024 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config GOLIOTH_DEBUG_LOG
+    bool "Enable internal debug logs"
+    default y
+    help
+        Enable/disable GLTH_LOGX log statements.
+
+        If disabled, then the GLTH_LOGX macros will
+        be removed/undefined.
+
+config GOLIOTH_AUTO_LOG_TO_CLOUD
+    bool "Enable automatic logging to Golioth"
+    default y
+    help
+        Enable/disable automatic logging to Golioth for GLTH_LOGX statements
+
+        If enabled, GLTH_LOGX statements will log to stdout as well as to
+        Golioth. If disabled, they will only go to stdout.
+
+        Enabling can result is a large amount of data transmitted to Golioth,
+        so use with caution.
+
+        If you enable this, it might be a good idea to increase
+        GOLIOTH_COAP_REQUEST_QUEUE_MAX_ITEMS, since there will be many
+        more CoAP requests (one per GLTH_LOGX statement). Otherwise you
+        will see warnings like "Failed to enqueue request, queue full".
+
+        There is an internal feature flag that is set by default to the value of this
+        configuration item. The flag can also be set at runtime.
+
+config GOLIOTH_DEBUG_DEFAULT_LOG_LEVEL
+    int "Default log level for Golioth SDK"
+    default 3
+    help
+        The default log level, which is used to filter GLTH_LOGX statements.
+
+        0: None
+        1: Error
+        2: Warn
+        3: Info
+        4: Debug
+        5: Verbose
+
+        This value can be overriden at runtime with golioth_debug_set_log_level().


### PR DESCRIPTION
Break Kconfig symbols out into files that group them by type. Update the Zephyr Kconfig to include the various new Kconfig groups into menus for better presentation in menuconfig.

resolves https://github.com/golioth/firmware-issue-tracker/issues/571