### PR TITLE
ota: add `golioth_ota_download_component()` api

### DIFF
--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -129,6 +129,19 @@ enum golioth_status golioth_ota_observe_manifest_async(struct golioth_client *cl
                                                        golioth_get_cb_fn callback,
                                                        void *arg);
 
+typedef enum golioth_status (*ota_component_block_write_cb)(
+    const struct golioth_ota_component *component,
+    uint32_t offset,
+    uint8_t *block_buffer,
+    size_t block_size,
+    bool is_last,
+    void *arg);
+
+enum golioth_status golioth_ota_download_component(struct golioth_client *client,
+                                                   const struct golioth_ota_component *component,
+                                                   ota_component_block_write_cb cb,
+                                                   void *arg);
+
 /// Get a single artfifact block synchronously
 ///
 /// Since some artifacts (e.g. "main" firmware) are larger than the amount of RAM


### PR DESCRIPTION
Add a public API to the OTA service for downloading a single component of a release. This uses the new blockwise transfer module under the hood (as opposed to the fw_block_processor module used by the fw_update module). Users can use this new API, along with existing APIs around OTA manifests, to implement their own firmware update mechanism, including implementing support for multi-artifact updates.

~NOTE: I haven't actually tested this yet, but throwing it up early for feedback on the API and approach.~
This is ready for review