### PR TITLE
tests: hil: rpc: wait for RPC establishment before sending RPCs

### DIFF
--- a/tests/hil/tests/rpc/test.c
+++ b/tests/hil/tests/rpc/test.c
@@ -47,6 +47,8 @@ static enum golioth_rpc_status on_basic_return_type(zcbor_state_t *request_param
     // one of {int, string, float, bool}
     struct zcbor_string type;
 
+    GLTH_LOGI(TAG, "Received basic_return_type RPC");
+
     bool ok = zcbor_tstr_decode(request_params_array, &type);
     if (!ok)
     {
@@ -139,6 +141,8 @@ static enum golioth_rpc_status on_disconnect(zcbor_state_t *request_params_array
                                              zcbor_state_t *response_detail_map,
                                              void *callback_arg)
 {
+    GLTH_LOGI(TAG, "Received disconnect RPC");
+
     golioth_sys_sem_give(disconnect_sem);
 
     return GOLIOTH_RPC_OK;
@@ -148,6 +152,8 @@ static enum golioth_rpc_status on_cancel_all(zcbor_state_t *request_params_array
                                              zcbor_state_t *response_detail_map,
                                              void *callback_arg)
 {
+    GLTH_LOGI(TAG, "Received cancel_all RPC");
+
     golioth_sys_sem_give(cancel_all_sem);
 
     return GOLIOTH_RPC_OK;

--- a/tests/hil/tests/rpc/test_rpc.py
+++ b/tests/hil/tests/rpc/test_rpc.py
@@ -79,6 +79,8 @@ async def test_observation_repeat_restart(board, device):
 
         rsp = await device.rpc.basic_return_type("int")
 
+        assert None != board.wait_for_regex_in_line('Received basic_return_type RPC', timeout_s=10)
+
         assert rsp['value'] == 42
         print(f"Loop {i} successful!")
 
@@ -94,4 +96,7 @@ async def test_observation_cancel_all(board, device):
     assert None != board.wait_for_regex_in_line('RPC observation established', timeout_s=30)
 
     rsp = await device.rpc.basic_return_type("int")
+
+    assert None != board.wait_for_regex_in_line('Received basic_return_type RPC', timeout_s=10)
+
     assert rsp['value'] == 42

--- a/tests/hil/tests/rpc/test_rpc.py
+++ b/tests/hil/tests/rpc/test_rpc.py
@@ -75,7 +75,7 @@ async def test_observation_repeat_restart(board, device):
         rsp = await device.rpc.disconnect()
 
         # Confirm re-connection to Golioth
-        assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+        assert None != board.wait_for_regex_in_line('RPC observation established', timeout_s=120)
 
         rsp = await device.rpc.basic_return_type("int")
 


### PR DESCRIPTION
In the observation_repeat_restart test, we were waiting for the device to establish a connection to Golioth before the test script sends an RPC to the device. This creates a small window between when the device establishes a connection and when it establishes an observation on the RPC path where attempts to send an RPC will fail. Instead, we should wait for the device to report that is successfully established an observation before the test script attempts to send any RPCs to the device. This matches the behavior in other parts of the test script.