### PR TITLE
zephyr: coap: prevent resend backend logs

### DIFF
--- a/src/zephyr_coap_req.c
+++ b/src/zephyr_coap_req.c
@@ -697,6 +697,8 @@ static int64_t golioth_coap_req_poll_prepare(struct golioth_coap_req *req, uint3
 
     if (send)
     {
+#ifndef CONFIG_LOG_BACKEND_GOLIOTH
+        /* Do not log if backend logging is enabled to avoid compounding network problems */
         if (resend)
         {
             LOG_WRN("Resending request %p (reply %p) (retries %d)",
@@ -704,6 +706,9 @@ static int64_t golioth_coap_req_poll_prepare(struct golioth_coap_req *req, uint3
                     &req->reply,
                     (int) req->pending.retries);
         }
+#else
+        (void) resend;
+#endif
 
         err = golioth_coap_req_send(req);
         if (err)


### PR DESCRIPTION
When a network connection is unstable, coap packets may be resent. Logging this information is useful, but if backend logging is enabled, these get added to the network queue, further compounding the problem. Check to ensure backend logging is disabled before creating a log message about a coap request being resent.