### PR TITLE
tests: hil: ota: wait for successful status report

### DIFF
--- a/tests/hil/tests/ota/test.c
+++ b/tests/hil/tests/ota/test.c
@@ -93,7 +93,11 @@ static void test_reason_and_state(void)
 
         if (status != GOLIOTH_OK)
         {
-            GLTH_LOGE(TAG, "Unable to report ota state: %d", status);
+            GLTH_LOGE(TAG, "Unable to report ota status: %d", status);
+        }
+        else
+        {
+            GLTH_LOGI(TAG, "OTA status reported successfully");
         }
         golioth_sys_msleep(7000);
     }

--- a/tests/hil/tests/ota/test_ota.py
+++ b/tests/hil/tests/ota/test_ota.py
@@ -178,8 +178,7 @@ async def test_reason_and_state(board, device, project, releases):
     # Test reason and state code updates
 
     for i, r in enumerate(golioth_ota_reason):
-        board.wait_for_regex_in_line("Updating status", timeout_s=20)
-        time.sleep(3) # Wait for server to propagate
+        board.wait_for_regex_in_line("OTA status reported successfully", timeout_s=20)
 
         await device.refresh()
 


### PR DESCRIPTION
Previously, the test script was waiting on a string printed by the device _before_ it reports it status, then waiting for a specific delay before retrieiving the reported status from the backend. Instead, the test script now waits for a string that is printed by the device after it receives an acknowledgement from the server that the status update has been posted successfully. This makes the timing of the test more explicit and should reduce timing related failures in CI.