### PR TITLE
Update remaining LightDB Stream links

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ instructions to build and run the examples.
 The `golioth_basics` example (`examples/<platform>/golioth_basics`) is recommended
 as a starting point, to learn how to connect to Golioth and use services like
 [LightDB State](https://docs.golioth.io/cloud/services/lightdb),
-[Stream](https://docs.golioth.io/cloud/services/lightdb-stream),
+[Stream](https://docs.golioth.io/data-routing),
 [Logging](https://docs.golioth.io/cloud/services/logging),
 and [OTA](https://docs.golioth.io/cloud/services/ota).
 

--- a/examples/zephyr/README.md
+++ b/examples/zephyr/README.md
@@ -99,8 +99,7 @@ west update
   - [Golioth Cloud](https://docs.golioth.io/cloud)
   - [LightDB
     state](https://docs.golioth.io/reference/protocols/coap/lightdb)
-  - [LightDB
-    Stream](https://docs.golioth.io/reference/protocols/coap/lightdb-stream)
+  - [Stream](https://docs.golioth.io/reference/protocols/coap/streaming-data)
   - [Logging](https://docs.golioth.io/reference/protocols/coap/logging)
   - [OTA](https://docs.golioth.io/reference/protocols/coap/ota)
   - [Authentication](https://docs.golioth.io/firmware/zephyr-device-sdk/authentication)


### PR DESCRIPTION
Fixes up a few straggling LightDB Stream links.

Mirrors changes made in https://github.com/golioth/golioth-firmware-sdk/commit/900678a3f363055258c4946b3be9c5222dad5ea4