### PR TITLE
hil: ota: increase initial timeout to 120s

### DIFF
--- a/tests/hil/tests/ota/test_ota.py
+++ b/tests/hil/tests/ota/test_ota.py
@@ -45,7 +45,7 @@ async def setup(board, device):
     board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Confirm connection to Golioth
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=60)
+    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 
 @pytest.fixture(scope="module")
 async def tag(project, device):


### PR DESCRIPTION
We were seeing the nrf9160dk timeout during the initial connection on the OTA test with a timeout of 60 seconds. This increases that value to 120 seconds, which matches what the other integrations tests use.