### PR TITLE
ci: don't fail fast

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -114,8 +114,10 @@ jobs:
               --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
               --mask-secrets                                                    \
-              --timeout=600
+              --timeout=600                                                     \
+              || EXITCODE=$?
           done
+          exit $EXITCODE
       - name: Erase flash
         if: always()
         shell: bash

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -117,8 +117,10 @@ jobs:
               --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
               --mask-secrets                                                    \
-              --timeout=600
+              --timeout=600                                                     \
+              || EXITCODE=$?
           done
+          exit $EXITCODE
       - name: Erase flash
         if: always()
         shell: bash

--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -72,7 +72,8 @@ jobs:
             --api-key ${{ secrets[inputs.api-key-id] }} \
             --mask-secrets                              \
             -rP                                         \
-            --timeout=600
+            --timeout=600                               \
+            || EXITCODE=$?
           lcov -c                                       \
                --directory build/${test}                \
                --include "*/golioth-firmware-sdk/src/*" \
@@ -102,6 +103,7 @@ jobs:
         echo "| --- | --- |" >> $GITHUB_OUTPUT
         echo "$coverage_summary" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
+        exit $EXITCODE
     - name: Find Comment
       uses: peter-evans/find-comment@v3
       if: github.event_name == 'pull_request'

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -155,8 +155,10 @@ jobs:
               --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
               --mask-secrets                                                    \
-              --timeout=600
+              --timeout=600                                                     \
+              || EXITCODE=$?
           done
+          exit $EXITCODE
       - name: Erase flash
         if: always()
         shell: bash


### PR DESCRIPTION
Runs all HIL tests, even if one fails, instead of exiting after the first failure.

A test run in CI where I forced the OTA test to fail is here: https://github.com/golioth/golioth-firmware-sdk/actions/runs/9354727595

Resolves golioth/firmware-issue-tracker#577