### PR TITLE
examples: use trio.sleep() and wait 2s in lightdb/delete

### DIFF
--- a/examples/esp_idf/lightdb/delete/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/delete/pytest/test_sample.py
@@ -2,13 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import contextlib
 import logging
 import pytest
-import time
-import yaml
-import datetime
-import re
+import trio
 
 LOGGER = logging.getLogger(__name__)
 
@@ -21,7 +17,7 @@ async def test_lightdb_delete(board, device):
     counter = await device.lightdb.get("counter")
     assert counter == 34
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]

--- a/examples/esp_idf/lightdb/get/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/get/pytest/test_sample.py
@@ -2,13 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import contextlib
 import logging
+
 import pytest
-import time
-import yaml
-import datetime
-import re
+import trio
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,7 +16,7 @@ async def test_lightdb_get(board, device):
 
     await device.lightdb.delete("counter")
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]

--- a/examples/esp_idf/lightdb/observe/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/observe/pytest/test_sample.py
@@ -2,13 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import contextlib
 import logging
-import pytest
-import time
-import yaml
-import datetime
 import re
+
+import pytest
+import trio
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,7 +17,7 @@ async def test_lightdb_observe(board, device):
 
     await device.lightdb.delete("counter")
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
@@ -28,7 +26,7 @@ async def test_lightdb_observe(board, device):
     # Wait for device to connect
     board.wait_for_regex_in_line('.*Golioth client connected', timeout_s=30.0)
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     pattern = re.compile(r'.*6e 75 6c 6c\s+\|null')
     success_pattern = board.wait_for_regex_in_line(pattern, timeout_s=10.0)
@@ -37,7 +35,7 @@ async def test_lightdb_observe(board, device):
 
     await device.lightdb.set("counter", 87)
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     pattern = re.compile(r'.*38 37\s+\|87')
     success_pattern = board.wait_for_regex_in_line(pattern, timeout_s=10.0)

--- a/examples/esp_idf/lightdb/set/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/set/pytest/test_sample.py
@@ -2,13 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import contextlib
 import logging
-import pytest
-import time
-import yaml
-import datetime
 import re
+
+import pytest
+import trio
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,7 +17,7 @@ async def test_lightdb_set(board, device):
 
     await device.lightdb.delete("counter")
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
@@ -34,6 +32,6 @@ async def test_lightdb_set(board, device):
         pattern = re.compile(fr"Setting counter to {i}")
         board.wait_for_regex_in_line(pattern, timeout_s=30.0)
         board.wait_for_regex_in_line('Counter successfully set', timeout_s=5.0)
-        time.sleep(1)
+        await trio.sleep(1)
         counter = await device.lightdb.get("counter")
         assert counter == i

--- a/examples/esp_idf/settings/pytest/test_sample.py
+++ b/examples/esp_idf/settings/pytest/test_sample.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+
 import pytest
-import pprint
-import time
-import yaml
+import trio
 
 LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +23,7 @@ async def test_settings(board, project, device):
 
     await project.settings.set('LOOP_DELAY_S', 1)
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]

--- a/examples/esp_idf/stream/pytest/test_sample.py
+++ b/examples/esp_idf/stream/pytest/test_sample.py
@@ -4,15 +4,16 @@
 
 import contextlib
 import logging
+
 import pytest
-import time
+import trio
 
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
 async def test_stream(board, device):
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -1,9 +1,7 @@
-import contextlib
 import logging
+
 import pytest
-import time
-import yaml
-import datetime
+import trio
 
 LOGGER = logging.getLogger(__name__)
 
@@ -16,7 +14,7 @@ async def test_lightdb_delete(shell, device, wifi_ssid, wifi_psk):
     counter = await device.lightdb.get("counter")
     assert counter == 34
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
 

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -37,6 +37,7 @@ async def test_lightdb_delete(shell, device, wifi_ssid, wifi_psk):
     # Verify lightdb delete (async)
 
     shell._device.readlines_until(regex=".*Counter deleted successfully", timeout=10.0)
+    await trio.sleep(2)
     counter = await device.lightdb.get("counter")
     assert counter is None
 
@@ -49,5 +50,6 @@ async def test_lightdb_delete(shell, device, wifi_ssid, wifi_psk):
     # Verify lightdb delete (sync)
 
     shell._device.readlines_until(regex=".*Counter deleted successfully", timeout=10.0)
+    await trio.sleep(2)
     counter = await device.lightdb.get("counter")
     assert counter is None

--- a/examples/zephyr/lightdb/observe/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/observe/pytest/test_sample.py
@@ -1,9 +1,7 @@
-import contextlib
 import logging
+
 import pytest
-import time
-import yaml
-import datetime
+import trio
 
 LOGGER = logging.getLogger(__name__)
 
@@ -14,7 +12,7 @@ async def test_lightdb_observe(shell, device, wifi_ssid, wifi_psk):
 
     await device.lightdb.delete("counter")
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
 

--- a/examples/zephyr/lightdb/set/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/set/pytest/test_sample.py
@@ -1,9 +1,7 @@
-import contextlib
 import logging
+
 import pytest
-import time
-import yaml
-import datetime
+import trio
 
 LOGGER = logging.getLogger(__name__)
 
@@ -14,7 +12,7 @@ async def test_lightdb_set(shell, device, wifi_ssid, wifi_psk):
 
     await device.lightdb.delete("counter")
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
 

--- a/examples/zephyr/logging/pytest/test_sample.py
+++ b/examples/zephyr/logging/pytest/test_sample.py
@@ -1,9 +1,10 @@
-from golioth import LogLevel, LogEntry
-import logging
-import pytest
-import time
-import yaml
 import datetime
+import logging
+
+import pytest
+import trio
+
+from golioth import LogLevel, LogEntry
 
 LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ def verify_log_messages(logs):
 
 
 async def test_logging(shell, device, wifi_ssid, wifi_psk):
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
 

--- a/examples/zephyr/rpc/pytest/test_sample.py
+++ b/examples/zephyr/rpc/pytest/test_sample.py
@@ -1,15 +1,16 @@
-from golioth import RPCStatusCode
 import logging
+
 import pytest
-import time
-import yaml
+import trio
+
+from golioth import RPCStatusCode
 
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
 async def test_logging(shell, device, wifi_ssid, wifi_psk):
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
 

--- a/examples/zephyr/settings/pytest/test_sample.py
+++ b/examples/zephyr/settings/pytest/test_sample.py
@@ -1,8 +1,5 @@
-import logging
 import pytest
-import pprint
-import time
-import yaml
+import trio
 
 pytestmark = pytest.mark.anyio
 
@@ -18,7 +15,7 @@ async def test_settings(shell, project, device, wifi_ssid, wifi_psk):
 
     await project.settings.set('LOOP_DELAY_S', 1)
 
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
 

--- a/examples/zephyr/stream/pytest/test_sample.py
+++ b/examples/zephyr/stream/pytest/test_sample.py
@@ -1,16 +1,15 @@
 import contextlib
 import logging
+
 import pytest
-import time
-import yaml
-import datetime
+import trio
 
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
 async def test_stream(shell, device, wifi_ssid, wifi_psk):
-    time.sleep(2)
+    await trio.sleep(2)
 
     # Set Golioth credential
 

--- a/tests/hil/tests/settings/test_settings.py
+++ b/tests/hil/tests/settings/test_settings.py
@@ -1,5 +1,5 @@
 import pytest
-import time
+import trio
 
 SUCCESS = 0
 KEY_NOT_RECOGNIZED = 1
@@ -60,7 +60,7 @@ async def test_set_int(board, device):
     assert None != board.wait_for_regex_in_line('Received test_int: 42', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_INT', None)
 
@@ -71,7 +71,7 @@ async def test_int_too_large(board, device):
         board.wait_for_regex_in_line('Received test_int: 8589934592', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_INT', VALUE_OUTSIDE_RANGE)
 
@@ -82,7 +82,7 @@ async def test_int_too_small(board, device):
         board.wait_for_regex_in_line('Received test_int: -8589934592', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_INT', VALUE_OUTSIDE_RANGE)
 
@@ -92,7 +92,7 @@ async def test_set_int_range(board, device):
     assert None != board.wait_for_regex_in_line('Received test_int_range: 5', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_INT_RANGE', None)
 
@@ -102,7 +102,7 @@ async def test_set_int_range_min(board, device):
     assert None != board.wait_for_regex_in_line('Received test_int_range: 0', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_INT_RANGE', None)
 
@@ -112,7 +112,7 @@ async def test_set_int_range_max(board, device):
     assert None != board.wait_for_regex_in_line('Received test_int_range: 100', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_INT_RANGE', None)
 
@@ -123,7 +123,7 @@ async def test_set_int_range_out_min(board, device):
         board.wait_for_regex_in_line('Received test_int_range: -1', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_INT_RANGE', VALUE_OUTSIDE_RANGE)
 
@@ -134,7 +134,7 @@ async def test_set_int_range_out_max(board, device):
         assert None != board.wait_for_regex_in_line('Received test_int_range: 101', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_INT_RANGE', VALUE_OUTSIDE_RANGE)
 
@@ -144,7 +144,7 @@ async def test_set_bool(board, device):
     assert None != board.wait_for_regex_in_line('Received test_bool: true', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_BOOL', None)
 
@@ -154,7 +154,7 @@ async def test_set_float(board, device):
     assert None != board.wait_for_regex_in_line('Received test_float: 3.14', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_FLOAT', None)
 
@@ -164,7 +164,7 @@ async def test_set_float_whole(board, device):
     assert None != board.wait_for_regex_in_line('Received test_float: 10', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_FLOAT', None)
 
@@ -174,7 +174,7 @@ async def test_set_string(board, device):
     assert None != board.wait_for_regex_in_line('Received test_string: bar', timeout_s=10)
 
     # Wait for device to respond to server
-    time.sleep(1)
+    await trio.sleep(1)
 
     await assert_settings_error(device, 'TEST_STRING', None)
 


### PR DESCRIPTION
`trio.sleep()` will just wait in async I/O loop, instead of freezing whole Python process. It also
makes more sense to be consistent and always use async APIs when needed. While at it sort imports
alphabetically.

Device might report that value is already deleted, but that state might still not be reflected
immediately with REST APIs. Sleep 2s before checking value with REST API, so test passes after
successful value deletion in lightdb.