### PR TITLE
zephyr: coap: periodically report resend count

### DIFF
--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -1502,6 +1502,9 @@ struct golioth_client *golioth_client_create(const struct golioth_client_config 
     new_client->tls.sec_tag_list = sec_tag_list;
     new_client->tls.sec_tag_count = ARRAY_SIZE(sec_tag_list);
 
+    new_client->resend_report_count = 0;
+    new_client->resend_report_last_ms = 0;
+
     fds[POLLFD_EVENT].fd = eventfd(0, EFD_NONBLOCK);
     fds[POLLFD_EVENT].events = ZSOCK_POLLIN;
 

--- a/src/coap_client_zephyr.h
+++ b/src/coap_client_zephyr.h
@@ -91,6 +91,9 @@ struct golioth_client
     bool coap_reqs_connected;
     struct k_mutex coap_reqs_lock;
 
+    uint16_t resend_report_count;
+    uint32_t resend_report_last_ms;
+
     void (*on_connect)(struct golioth_client *client);
     void (*wakeup)(struct golioth_client *client);
 


### PR DESCRIPTION
Sum the number of coap request resends over a period of time and report as an INF log message. Change the existing resend message to DBG level so it is still available when that log level is selected via Kconfig.

I'm proposing this approach as an alternative to #500. We had originally discussed changing the log level of `zephyr_coap_req.c` in only the golioth log backend so the messages are reported in the terminal but not sent to the cloud. This has two disadvantages:
- Setting a runtime level for that backend felt a little bit convoluted as it needs to be done after the backend is initialized and we don't initialize until after we connect to Golioth
- When only a few resend messsages occur, they're pretty handy to have (even on remote logs).

This PR is a rather small resource change (adds 6 bytes to the Golioth client) and low overhead (we already have the uptime value so it's just a some subtraction/multiplication on each conditional).

resolves https://github.com/golioth/firmware-issue-tracker/issues/576
closes #500 