### PR TITLE
coap client: handle allocation errors with sync calls

### DIFF
--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -82,7 +82,6 @@ enum golioth_status golioth_coap_client_empty(struct golioth_client *client,
         {
             golioth_event_group_destroy(request_msg.request_complete_event);
             golioth_sys_sem_destroy(request_msg.request_complete_ack_sem);
-            request_msg.status = NULL;
         }
         return GOLIOTH_ERR_QUEUE_FULL;
     }
@@ -232,7 +231,6 @@ static enum golioth_status golioth_coap_client_set_internal(struct golioth_clien
         {
             golioth_event_group_destroy(request_msg.request_complete_event);
             golioth_sys_sem_destroy(request_msg.request_complete_ack_sem);
-            request_msg.status = NULL;
         }
         return GOLIOTH_ERR_QUEUE_FULL;
     }
@@ -398,7 +396,6 @@ enum golioth_status golioth_coap_client_delete(struct golioth_client *client,
         {
             golioth_event_group_destroy(request_msg.request_complete_event);
             golioth_sys_sem_destroy(request_msg.request_complete_ack_sem);
-            request_msg.status = NULL;
         }
         return GOLIOTH_ERR_QUEUE_FULL;
     }
@@ -506,7 +503,6 @@ static enum golioth_status golioth_coap_client_get_internal(struct golioth_clien
         {
             golioth_event_group_destroy(request_msg.request_complete_event);
             golioth_sys_sem_destroy(request_msg.request_complete_ack_sem);
-            request_msg.status = NULL;
         }
         return GOLIOTH_ERR_QUEUE_FULL;
     }

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -223,7 +223,7 @@ static enum golioth_status golioth_coap_client_set_internal(struct golioth_clien
          *       the mbox is full, so coap_client writes a log, which the
          *       logging thread attempts to send to the cloud, and so on.
          */
-        if (payload_size > 0)
+        if (request_payload)
         {
             golioth_sys_free(request_payload);
         }

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -55,9 +55,22 @@ enum golioth_status golioth_coap_client_empty(struct golioth_client *client,
 
     if (is_synchronous)
     {
-        // Created here, deleted by coap thread (or here if fail to enqueue
+        // Created here, deleted by coap thread (or here if fail to create or enqueue)
         request_msg.request_complete_event = golioth_event_group_create();
+        if (!request_msg.request_complete_event)
+        {
+            GLTH_LOGW(TAG, "Failed to create event group");
+            return GOLIOTH_ERR_MEM_ALLOC;
+        }
+
         request_msg.request_complete_ack_sem = golioth_sys_sem_create(1, 0);
+        if (!request_msg.request_complete_ack_sem)
+        {
+            GLTH_LOGW(TAG, "Failed to create semaphore");
+            golioth_event_group_destroy(request_msg.request_complete_event);
+            return GOLIOTH_ERR_MEM_ALLOC;
+        }
+
         request_msg.status = &status;
     }
 
@@ -162,9 +175,30 @@ static enum golioth_status golioth_coap_client_set_internal(struct golioth_clien
 
     if (is_synchronous)
     {
-        // Created here, deleted by coap thread (or here if fail to enqueue
+        // Created here, deleted by coap thread (or here if fail to create or enqueue)
         request_msg.request_complete_event = golioth_event_group_create();
+        if (!request_msg.request_complete_event)
+        {
+            GLTH_LOGW(TAG, "Failed to create event group");
+            if (request_payload)
+            {
+                golioth_sys_free(request_payload);
+            }
+            return GOLIOTH_ERR_MEM_ALLOC;
+        }
+
         request_msg.request_complete_ack_sem = golioth_sys_sem_create(1, 0);
+        if (!request_msg.request_complete_ack_sem)
+        {
+            GLTH_LOGW(TAG, "Failed to create semaphore");
+            golioth_event_group_destroy(request_msg.request_complete_event);
+            if (request_payload)
+            {
+                golioth_sys_free(request_payload);
+            }
+            return GOLIOTH_ERR_MEM_ALLOC;
+        }
+
         request_msg.status = &status;
     }
 
@@ -337,9 +371,22 @@ enum golioth_status golioth_coap_client_delete(struct golioth_client *client,
 
     if (is_synchronous)
     {
-        // Created here, deleted by coap thread (or here if fail to enqueue
+        // Created here, deleted by coap thread (or here if fail to create or enqueue)
         request_msg.request_complete_event = golioth_event_group_create();
+        if (!request_msg.request_complete_event)
+        {
+            GLTH_LOGW(TAG, "Failed to create event group");
+            return GOLIOTH_ERR_MEM_ALLOC;
+        }
+
         request_msg.request_complete_ack_sem = golioth_sys_sem_create(1, 0);
+        if (!request_msg.request_complete_ack_sem)
+        {
+            GLTH_LOGW(TAG, "Failed to create semaphore");
+            golioth_event_group_destroy(request_msg.request_complete_event);
+            return GOLIOTH_ERR_MEM_ALLOC;
+        }
+
         request_msg.status = &status;
     }
 
@@ -421,11 +468,25 @@ static enum golioth_status golioth_coap_client_get_internal(struct golioth_clien
 
     if (is_synchronous)
     {
-        // Created here, deleted by coap thread (or here if fail to enqueue
+        // Created here, deleted by coap thread (or here if fail to create or enqueue)
         request_msg.request_complete_event = golioth_event_group_create();
+        if (!request_msg.request_complete_event)
+        {
+            GLTH_LOGW(TAG, "Failed to create event group");
+            return GOLIOTH_ERR_MEM_ALLOC;
+        }
+
         request_msg.request_complete_ack_sem = golioth_sys_sem_create(1, 0);
+        if (!request_msg.request_complete_ack_sem)
+        {
+            GLTH_LOGW(TAG, "Failed to create semaphore");
+            golioth_event_group_destroy(request_msg.request_complete_event);
+            return GOLIOTH_ERR_MEM_ALLOC;
+        }
+
         request_msg.status = &status;
     }
+
     request_msg.ageout_ms = ageout_ms;
     if (type == GOLIOTH_COAP_REQUEST_GET_BLOCK)
     {

--- a/src/event_group.c
+++ b/src/event_group.c
@@ -11,11 +11,34 @@ golioth_event_group_t golioth_event_group_create(void)
 {
     golioth_event_group_t eg =
         (golioth_event_group_t) golioth_sys_malloc(sizeof(struct golioth_event_group));
+    if (!eg)
+    {
+        return NULL;
+    }
+
     memset(eg, 0, sizeof(struct golioth_event_group));
     eg->bitmap = 0;
+
     eg->bitmap_mutex = golioth_sys_sem_create(1, 1);
+    if (!eg->bitmap_mutex)
+    {
+        goto cleanup_eg;
+    }
+
     eg->sem = golioth_sys_sem_create(1, 0);
+    if (!eg->sem)
+    {
+        goto cleanup_eg_with_mutex;
+    }
+
     return eg;
+
+cleanup_eg_with_mutex:
+    golioth_sys_sem_destroy(eg->bitmap_mutex);
+
+cleanup_eg:
+    golioth_sys_free(eg);
+    return NULL;
 }
 
 void golioth_event_group_set_bits(golioth_event_group_t eg, uint32_t bits_to_set)


### PR DESCRIPTION
- When creating an event group, check for memory allocation and semaphore creation errors. Free memory as needed and return NULL
- During sync calls, check event group and sempahore for NULL. Free memory as needed and return GOLIOTH_ERROR_MEM_ALLOC

resolves https://github.com/golioth/firmware-issue-tracker/issues/582