### PR TITLE
zephyr_coap_req: reduce log level for "cancel and free" message

### DIFF
--- a/src/zephyr_coap_req.c
+++ b/src/zephyr_coap_req.c
@@ -173,7 +173,7 @@ static int golioth_coap_req_reply_handler(struct golioth_coap_req *req,
 
         (void) req->cb(&rsp);
 
-        LOG_INF("cancel and free req: %p", req);
+        LOG_DBG("cancel and free req: %p", req);
 
         goto cancel_and_free;
     }


### PR DESCRIPTION
When the devices has connectivity issues, the "cancel and free" request messages can flood the logs. Change the level for those messages from INF to DBG.