### PR TITLE
examples: improve test reliability

### DIFF
--- a/examples/esp_idf/lightdb/delete/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/delete/pytest/test_sample.py
@@ -49,4 +49,10 @@ async def test_lightdb_delete(board, device):
 
     board.wait_for_regex_in_line(r'.*Counter deleted successfully', timeout_s=10.0)
     counter = await device.lightdb.get("counter")
+    if counter is not None:
+        # Try again, since previous counter value might get reassigned in counter_set_and_verify()
+        board.wait_for_regex_in_line(r'.*Counter deleted successfully', timeout_s=10.0)
+        await trio.sleep(2)
+        counter = await device.lightdb.get("counter")
+
     assert counter is None

--- a/examples/esp_idf/lightdb/delete/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/delete/pytest/test_sample.py
@@ -10,12 +10,21 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
+async def counter_set_and_verify(device, counter_desired: int):
+    for _ in range(3):
+        await device.lightdb.set("counter", counter_desired)
+        counter_reported = await device.lightdb.get("counter")
+        if counter_reported == counter_desired:
+            break
+
+        await trio.sleep(1)
+
+    assert counter_reported == counter_desired
+
 async def test_lightdb_delete(board, device):
     # Set counter in lightdb state
 
-    await device.lightdb.set("counter", 34)
-    counter = await device.lightdb.get("counter")
-    assert counter == 34
+    await counter_set_and_verify(device, 34)
 
     await trio.sleep(2)
 
@@ -34,9 +43,7 @@ async def test_lightdb_delete(board, device):
 
     # Set and verify counter
 
-    await device.lightdb.set("counter", 62)
-    counter = await device.lightdb.get("counter")
-    assert counter == 62
+    await counter_set_and_verify(device, 62)
 
     # Verify lightdb delete (sync)
 

--- a/examples/esp_idf/lightdb/set/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/set/pytest/test_sample.py
@@ -32,6 +32,11 @@ async def test_lightdb_set(board, device):
         pattern = re.compile(fr"Setting counter to {i}")
         board.wait_for_regex_in_line(pattern, timeout_s=30.0)
         board.wait_for_regex_in_line('Counter successfully set', timeout_s=5.0)
-        await trio.sleep(1)
-        counter = await device.lightdb.get("counter")
+
+        for _ in range(3):
+            counter = await device.lightdb.get("counter")
+            if counter == i:
+                break
+            await trio.sleep(1)
+
         assert counter == i

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -7,12 +7,21 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
+async def counter_set_and_verify(device, counter_desired: int):
+    for _ in range(3):
+        await device.lightdb.set("counter", counter_desired)
+        counter_reported = await device.lightdb.get("counter")
+        if counter_reported == counter_desired:
+            break
+
+        await trio.sleep(1)
+
+    assert counter_reported == counter_desired
+
 async def test_lightdb_delete(shell, device, wifi_ssid, wifi_psk):
     # Set counter in lightdb state
 
-    await device.lightdb.set("counter", 34)
-    counter = await device.lightdb.get("counter")
-    assert counter == 34
+    await counter_set_and_verify(device, 34)
 
     await trio.sleep(2)
 
@@ -43,9 +52,7 @@ async def test_lightdb_delete(shell, device, wifi_ssid, wifi_psk):
 
     # Set and verify counter
 
-    await device.lightdb.set("counter", 62)
-    counter = await device.lightdb.get("counter")
-    assert counter == 62
+    await counter_set_and_verify(device, 62)
 
     # Verify lightdb delete (sync)
 

--- a/examples/zephyr/lightdb/delete/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/delete/pytest/test_sample.py
@@ -59,4 +59,10 @@ async def test_lightdb_delete(shell, device, wifi_ssid, wifi_psk):
     shell._device.readlines_until(regex=".*Counter deleted successfully", timeout=10.0)
     await trio.sleep(2)
     counter = await device.lightdb.get("counter")
+    if counter is not None:
+        # Try again, since previous counter value might get reassigned in counter_set_and_verify()
+        shell._device.readlines_until(regex=".*Counter deleted successfully", timeout=10.0)
+        await trio.sleep(2)
+        counter = await device.lightdb.get("counter")
+
     assert counter is None

--- a/examples/zephyr/lightdb/set/pytest/test_sample.py
+++ b/examples/zephyr/lightdb/set/pytest/test_sample.py
@@ -37,5 +37,11 @@ async def test_lightdb_set(shell, device, wifi_ssid, wifi_psk):
     for i in range(0,4):
         shell._device.readlines_until(regex=f".*Setting counter to {i}", timeout=10.0)
         shell._device.readlines_until(regex=f".*Counter successfully set", timeout=10.0)
-        counter = await device.lightdb.get("counter")
+
+        for _ in range(3):
+            counter = await device.lightdb.get("counter")
+            if counter == i:
+                break
+            await trio.sleep(1)
+
         assert counter == i

--- a/examples/zephyr/rpc/pytest/test_sample.py
+++ b/examples/zephyr/rpc/pytest/test_sample.py
@@ -28,7 +28,7 @@ async def test_logging(shell, device, wifi_ssid, wifi_psk):
 
     # Wait for device to reboot and connect
 
-    shell._device.readlines_until(regex=".*rpc_sample: Golioth client connected", timeout=90.0)
+    shell._device.readlines_until(regex=".*RPC observation established", timeout=90.0)
 
     # Test successful RPC
 


### PR DESCRIPTION
In case of RPC wait for "RPC observation established" message before proceeding with test. This
change is only for Zephyr, since there is already such logic implemented for ESP-IDF test script.

In case of lightdb, solve existing isues by retries with delays.