### PR TITLE
hil: ota: wait for firmware update state to propagate

### DIFF
--- a/tests/hil/tests/ota/test_ota.py
+++ b/tests/hil/tests/ota/test_ota.py
@@ -1,6 +1,5 @@
-import os
 import pytest
-import time
+import trio
 
 UPDATE_PACKAGE = 'main'
 DUMMY_VER_OLDER = '1.2.2'
@@ -179,6 +178,9 @@ async def test_reason_and_state(board, device, project, releases):
 
     for i, r in enumerate(golioth_ota_reason):
         board.wait_for_regex_in_line("OTA status reported successfully", timeout_s=20)
+
+        # Wait for state update to propagate
+        await trio.sleep(2)
 
         await device.refresh()
 


### PR DESCRIPTION
Introduces a short wait (2 seconds) for firmware update state changes to propagate. State changes are not guaranteed to be immediately reflected for a device after an OK response is received.

In the future, this stop-gap solution should be replaced by either polling in this test or synchronous behavior on the server. Currently the on-device test is waiting 7s between state updates, so the wait in this test must remain less than to avoid missing a state update.