### PR TITLE
zephyr: coap: fix keepalive behavior

### DIFF
--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -153,13 +153,6 @@ menu "CoAP"
 
 source "${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/src/Kconfig.coap"
 
-config GOLIOTH_COAP_CLIENT_PING_INTERVAL_SEC
-	int "Ping interval (seconds)"
-	default 9
-	help
-	  Periodic interval between consecutive ping messages being sent to
-	  Golioth.
-
 config GOLIOTH_COAP_CLIENT_RX_TIMEOUT_SEC
 	int "Receive timeout (seconds)"
 	default 30


### PR DESCRIPTION
- ensure keepalive timer is reset after callback
- reset keepalive timer whenever a response is received
- remove ping timer logic and Kconfig symbol

The ping timer was duplicating the keepalive timer functionality. The keepalive is used by the libcoap platforms so this change brings better parity.

resolves https://github.com/golioth/firmware-issue-tracker/issues/592