### PR TITLE
Add extern “C” block to header files

### DIFF
--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <stdbool.h>
@@ -286,3 +292,7 @@ void golioth_client_set_packet_loss_percent(uint8_t percent);
 golioth_sys_thread_t golioth_client_get_thread(struct golioth_client *client);
 
 /// @}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/config.h
+++ b/include/golioth/config.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 // This file defines default configuration values.
@@ -119,4 +125,8 @@
 
 #ifndef GOLIOTH_OVERRIDE_LIBCOAP_LOG_HANDLER
 #define GOLIOTH_OVERRIDE_LIBCOAP_LOG_HANDLER 1
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/golioth/fw_update.h
+++ b/include/golioth/fw_update.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <golioth/client.h>
@@ -156,3 +162,7 @@ void fw_update_end(void);
 //---------------------------------------------------------------------------
 
 /// @}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/golioth_debug.h
+++ b/include/golioth/golioth_debug.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <golioth/config.h>
@@ -43,3 +49,7 @@ void golioth_debug_printf(uint64_t tstamp_ms,
                           const char *tag,
                           const char *format,
                           ...);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/golioth_status.h
+++ b/include/golioth/golioth_status.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 /// Status code enum used throughout Golioth SDK
@@ -49,3 +55,7 @@ const char *golioth_status_to_str(enum golioth_status status);
             return status;                   \
         }                                    \
     } while (0)
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/golioth_sys.h
+++ b/include/golioth/golioth_sys.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <stdint.h>
@@ -195,3 +201,7 @@ void golioth_sys_client_disconnected(void *client);
 #define GLTH_LOG_BUFFER_HEXDUMP(TAG, ...)
 
 #endif /* CONFIG_GOLIOTH_DEBUG_LOG */
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/lightdb_state.h
+++ b/include/golioth/lightdb_state.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <golioth/golioth_status.h>
@@ -310,3 +316,7 @@ enum golioth_status golioth_lightdb_observe_async(struct golioth_client *client,
                                                   void *callback_arg);
 
 /// @}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/log.h
+++ b/include/golioth/log.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <golioth/golioth_status.h>
@@ -88,3 +94,7 @@ enum golioth_status golioth_log_debug_sync(struct golioth_client *client,
                                            int32_t timeout_s);
 
 /// @}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <stdint.h>
@@ -208,3 +214,7 @@ enum golioth_status golioth_ota_report_state_sync(struct golioth_client *client,
 enum golioth_ota_state golioth_ota_get_state(void);
 
 /// @}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/payload_utils.h
+++ b/include/golioth/payload_utils.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <stdbool.h>
@@ -49,3 +54,7 @@ bool golioth_payload_as_bool(const uint8_t *payload, size_t payload_size);
 bool golioth_payload_is_null(const uint8_t *payload, size_t payload_size);
 
 /// @}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/rpc.h
+++ b/include/golioth/rpc.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <zcbor_decode.h>
@@ -117,3 +123,7 @@ enum golioth_status golioth_rpc_register(struct golioth_rpc *grpc,
                                          void *callback_arg);
 
 /// @}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/settings.h
+++ b/include/golioth/settings.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <golioth/golioth_status.h>
@@ -148,3 +154,7 @@ enum golioth_status golioth_settings_register_string(struct golioth_settings *se
                                                      golioth_string_setting_cb callback,
                                                      void *callback_arg);
 /// @}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/stream.h
+++ b/include/golioth/stream.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <golioth/golioth_status.h>
@@ -98,3 +104,7 @@ enum golioth_status golioth_stream_set_blockwise_sync(struct golioth_client *cli
                                                       void *arg);
 
 /// @}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/golioth/zcbor_utils.h
+++ b/include/golioth/zcbor_utils.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <zcbor_decode.h>
 #include <zcbor_encode.h>
 
@@ -159,3 +164,7 @@ int zcbor_map_decode(zcbor_state_t *zsd, struct zcbor_map_entry *entries, size_t
             },                                                                \
         .decode = _decode, .value = _value,                                   \
     }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
By adding an extern "C" block to header files, we avoid linking problems when building C++ applications that come from name mangling since C++ supports function overloading.