### PR TITLE
examples: zephyr: simplify EVENTFD_MAX default value

### DIFF
--- a/examples/zephyr/common/Kconfig.defconfig
+++ b/examples/zephyr/common/Kconfig.defconfig
@@ -19,15 +19,9 @@ endif # DNS_RESOLVER
 if EVENTFD
 
 config EVENTFD_MAX
-    depends on !GOLIOTH_FW_UPDATE
+	default 14 if GOLIOTH_FW_UPDATE
 	default 7
 
-if GOLIOTH_FW_UPDATE
-
-config EVENTFD_MAX
-	default 14
-
-endif # GOLIOTH_FW_UPDATE
 endif # EVENTFD
 
 if LOG_BACKEND_GOLIOTH


### PR DESCRIPTION
Use the same logic, but implement it in more compact and readable way.