### PR TITLE
examples: add extern C to headers

### DIFF
--- a/examples/common/golioth_basics.h
+++ b/examples/common/golioth_basics.h
@@ -3,8 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #include <golioth/client.h>
 
 void golioth_basics(struct golioth_client *client);
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/esp_idf/common/sample_credentials.h
+++ b/examples/esp_idf/common/sample_credentials.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef __GOLIOTH_INCLUDE_SAMPLE_CREDENTIALS_H__
 #define __GOLIOTH_INCLUDE_SAMPLE_CREDENTIALS_H__
 
@@ -18,3 +23,7 @@
 const struct golioth_client_config *golioth_sample_credentials_get(void);
 
 #endif /* __GOLIOTH_INCLUDE_SAMPLE_CREDENTIALS_H__ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/esp_idf/common/util.h
+++ b/examples/esp_idf/common/util.h
@@ -3,6 +3,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #pragma once
 
 #define COUNT_OF(x) ((sizeof(x) / sizeof(0 [x])) / ((size_t) (!(sizeof(x) % sizeof(0 [x])))))
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/zephyr/common/include/samples/common/net_connect.h
+++ b/examples/zephyr/common/include/samples/common/net_connect.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef __GOLIOTH_INCLUDE_GOLIOTH_NET_CONNECT_H__
 #define __GOLIOTH_INCLUDE_GOLIOTH_NET_CONNECT_H__
 
@@ -22,3 +27,7 @@ void net_connect(void);
 /** @} */
 
 #endif /* __GOLIOTH_INCLUDE_GOLIOTH_NET_CONNECT_H__ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/zephyr/common/include/samples/common/sample_credentials.h
+++ b/examples/zephyr/common/include/samples/common/sample_credentials.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef __GOLIOTH_INCLUDE_SAMPLE_CREDENTIALS_H__
 #define __GOLIOTH_INCLUDE_SAMPLE_CREDENTIALS_H__
 
@@ -24,3 +29,7 @@
 const struct golioth_client_config *golioth_sample_credentials_get(void);
 
 #endif /* __GOLIOTH_INCLUDE_SAMPLE_CREDENTIALS_H__ */
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Adds extern "C" declarations to headers to avoid name mangling when included in a C++ build.

> Note: a number of these example headers already had `extern "C"`. This is just adding to those that are missing it.