### PR TITLE
ota: better error message on manifest decode error

### DIFF
--- a/src/ota.c
+++ b/src/ota.c
@@ -260,7 +260,9 @@ static int components_decode(zcbor_state_t *zsd, void *value)
     ok = zcbor_list_end_decode(zsd);
     if (!ok)
     {
-        GLTH_LOGW(TAG, "Did not end CBOR list correctly");
+        /* Most likely reason for this error is that server sent multiple components but device was
+         * configured to receive fewer */
+        GLTH_LOGW(TAG, "Can't end CBOR list (check GOLIOTH_OTA_MAX_NUM_COMPONENTS)");
         return -EBADMSG;
     }
 


### PR DESCRIPTION
hint that the GOLIOTH_OTA_MAX_NUM_COMPONENTS setting is the most likely cause of a manifest decoding error.

Message displays as follow:
![image](https://github.com/user-attachments/assets/aad2b498-215d-4904-925d-e9bfb6fe7a3a)

resolves: https://github.com/golioth/firmware-issue-tracker/issues/612