### PR TITLE
Stop client before destroying

### DIFF
--- a/port/freertos/golioth_sys_freertos.c
+++ b/port/freertos/golioth_sys_freertos.c
@@ -169,6 +169,15 @@ void golioth_sys_thread_destroy(golioth_sys_thread_t thread)
  * Misc
  *------------------------------------------------*/
 
-void golioth_sys_client_connected(void *client) {}
+void golioth_sys_client_connected(void *client)
+{
+    if (CONFIG_GOLIOTH_AUTO_LOG_TO_CLOUD != 0)
+    {
+        golioth_debug_set_cloud_log_enabled(true);
+    }
+}
 
-void golioth_sys_client_disconnected(void *client) {}
+void golioth_sys_client_disconnected(void *client)
+{
+    golioth_debug_set_cloud_log_enabled(false);
+}

--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -1241,6 +1241,7 @@ static void golioth_coap_client_thread(void *arg)
     cleanup:
         GLTH_LOGI(TAG, "Ending session");
 
+        golioth_sys_client_disconnected(client);
         if (client->event_callback && client->session_connected)
         {
             client->event_callback(client,
@@ -1387,6 +1388,10 @@ void golioth_client_destroy(struct golioth_client *client)
     if (!client)
     {
         return;
+    }
+    if (client->is_running)
+    {
+        golioth_client_stop(client);
     }
     if (client->keepalive_timer)
     {

--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -1374,6 +1374,11 @@ static void purge_request_mbox(golioth_mbox_t request_mbox)
             // free dynamically allocated user payload copy
             golioth_sys_free(request_msg.post.payload);
         }
+        else if (request_msg.type == GOLIOTH_COAP_REQUEST_POST_BLOCK)
+        {
+            // free dynamically allocated user payload copy
+            golioth_sys_free(request_msg.post_block.payload);
+        }
     }
 }
 

--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -1564,6 +1564,11 @@ static void purge_request_mbox(golioth_mbox_t request_mbox)
             // free dynamically allocated user payload copy
             golioth_sys_free(request_msg.post.payload);
         }
+        else if (request_msg.type == GOLIOTH_COAP_REQUEST_POST_BLOCK)
+        {
+            // free dynamically allocated user payload copy
+            golioth_sys_free(request_msg.post_block.payload);
+        }
     }
 }
 

--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -1578,6 +1578,10 @@ void golioth_client_destroy(struct golioth_client *client)
     {
         return;
     }
+    if (client->is_running)
+    {
+        golioth_client_stop(client);
+    }
     if (client->keepalive_timer)
     {
         golioth_sys_timer_destroy(client->keepalive_timer);

--- a/tests/hil/tests/connection/test.c
+++ b/tests/hil/tests/connection/test.c
@@ -3,22 +3,57 @@
 
 LOG_TAG_DEFINE(test_connect);
 
+static golioth_sys_sem_t _connected_sem = NULL;
+
+static void on_client_event(struct golioth_client *client,
+                            enum golioth_client_event event,
+                            void *arg)
+{
+    bool is_connected = (event == GOLIOTH_CLIENT_EVENT_CONNECTED);
+    if (is_connected)
+    {
+        golioth_sys_sem_give(_connected_sem);
+    }
+    GLTH_LOGI(TAG, "Golioth client %s", is_connected ? "connected" : "disconnected");
+}
+
 void hil_test_entry(const struct golioth_client_config *config)
 {
+    _connected_sem = golioth_sys_sem_create(1, 0);
+
     struct golioth_client *client = golioth_client_create(config);
 
-    (void) client;
+    golioth_client_register_event_callback(client, on_client_event, NULL);
+    golioth_sys_sem_take(_connected_sem, GOLIOTH_SYS_WAIT_FOREVER);
 
-    while (1)
-    {
-        golioth_sys_msleep(10 * 1000);
+    /* Pause to ensure we don't have out-of-order logs */
+    golioth_sys_msleep(1 * 1000);
 
-        GLTH_LOGI(TAG, "Stopping client");
-        golioth_client_stop(client);
+    GLTH_LOGI(TAG, "Stopping client");
+    golioth_client_stop(client);
 
-        golioth_sys_msleep(10 * 1000);
+    golioth_sys_msleep(10 * 1000);
 
-        GLTH_LOGI(TAG, "Starting client");
-        golioth_client_start(client);
-    }
+    GLTH_LOGI(TAG, "Starting client");
+    golioth_client_start(client);
+
+    golioth_sys_sem_take(_connected_sem, GOLIOTH_SYS_WAIT_FOREVER);
+
+    /* Pause to ensure we don't have out-of-order logs */
+    golioth_sys_msleep(1 * 1000);
+
+    GLTH_LOGI(TAG, "Destroying client");
+    golioth_client_destroy(client);
+    client = NULL;
+
+    golioth_sys_msleep(10 * 1000);
+
+    GLTH_LOGI(TAG, "Starting client");
+    client = golioth_client_create(config);
+    golioth_client_start(client);
+
+    golioth_sys_sem_take(_connected_sem, GOLIOTH_SYS_WAIT_FOREVER);
+
+    /* Pause to ensure logs are show */
+    golioth_sys_msleep(1 * 1000);
 }

--- a/tests/hil/tests/connection/test_connection.py
+++ b/tests/hil/tests/connection/test_connection.py
@@ -10,7 +10,12 @@ async def test_connect(board, device):
     # Confirm connection to Golioth
     assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 
-    # Wait for reconnection
-    assert None != board.wait_for_regex_in_line('Stopping client', timeout_s=10)
+    # Wait for reconnection after golioth_client_stop();
+    assert None != board.wait_for_regex_in_line('Stopping client', timeout_s=15)
+    assert None != board.wait_for_regex_in_line('Starting client', timeout_s=120)
+    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+
+    # Wait for reconnection after golioth_client_destroy();
+    assert None != board.wait_for_regex_in_line('Destroying client', timeout_s=15)
     assert None != board.wait_for_regex_in_line('Starting client', timeout_s=120)
     assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)


### PR DESCRIPTION
- Fix memory free for post_block requests in both libcoap and Zephyr coap
- Stop client before destroying it in both libcoap and Zephyr coap
- libcoap: call golioth_sys_client_disconnected() when ending a session
- libcoap: disable automatic cloud logging when the client is disconnected

resolves https://github.com/golioth/firmware-issue-tracker/issues/584