### PR TITLE
examples: zephyr: README: use latest release tag for revision in man…

### DIFF
--- a/examples/zephyr/README.md
+++ b/examples/zephyr/README.md
@@ -62,7 +62,7 @@ based project (e.g. Zephyr RTOS):
 # Golioth repository.
 - name: golioth
   path: modules/lib/golioth-firmware-sdk
-  revision: main
+  revision: v0.14.0
   url: https://github.com/golioth/golioth-firmware-sdk.git
   submodules: true
 ```


### PR DESCRIPTION
…ifest snippet

The example snippet for including the SDK in an existing manifest should use the latest release tag as the revision instead of `main`.