### PR TITLE
Enable p384 curve

### DIFF
--- a/examples/zephyr/certificate_provisioning/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/certificate_provisioning/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/fw_update/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/fw_update/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/golioth_basics/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/golioth_basics/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/hello/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/hello/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/hello_nrf91_offloaded/prj.conf
+++ b/examples/zephyr/hello_nrf91_offloaded/prj.conf
@@ -33,5 +33,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/lightdb/delete/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/lightdb/delete/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/logging/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/logging/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/rpc/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/rpc/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/settings/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/settings/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/examples/zephyr/stream/boards/nrf9160dk_nrf9160_ns.conf
+++ b/examples/zephyr/stream/boards/nrf9160dk_nrf9160_ns.conf
@@ -28,5 +28,11 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
 CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
 
+# MbedTLS configuration to support p-384 curve. These options
+# enable using the MbedTLS built-in support for operations not
+# supported by the default nRF Oberon crypto backend
+CONFIG_NORDIC_SECURITY_BACKEND=n
+CONFIG_MBEDTLS_LEGACY_CRYPTO_C=y
+
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -59,8 +59,10 @@ config GOLIOTH_AUTH_PSK_MBEDTLS_DEPS
 config GOLIOTH_AUTH_CERT_MBEDTLS_DEPS
 	bool "mbedTLS dependencies for certificate based auth"
 	depends on MBEDTLS_BUILTIN || NRF_SECURITY
-	# At least one ECP needs to be selected. This was chosen arbitrarily.
+	# Enable P-256 and P-384 for broad compatibility. Disabling these curves
+	# may cause incompatibility with Golioth servers, now or in the future.
 	imply MBEDTLS_ECP_DP_SECP256R1_ENABLED
+	imply MBEDTLS_ECP_DP_SECP384R1_ENABLED
 	# Select at least one server supported cipher
 	imply MBEDTLS_CIPHER_GCM_ENABLED if (MBEDTLS_BUILTIN && !MBEDTLS_CIPHER_CCM_ENABLED)
 	select MBEDTLS_GCM_C if (NRF_SECURITY && !MBEDTLS_CCM_C)


### PR DESCRIPTION
This is the minimal set of changes to enable support for the P-384 curve in the Zephyr based ports. We may wish to enable further curves and algorithms at a later date, but for now this immediately restores certificate functionality.

TODO:
- [x] Test with offloaded sockets on nRF9160dk

Resolves golioth/firmware-issue-tracker#622