### PR TITLE
No reset in cert provisioning sample

### DIFF
--- a/examples/zephyr/certificate_provisioning/README.md
+++ b/examples/zephyr/certificate_provisioning/README.md
@@ -146,10 +146,10 @@ Be sure to replace `<path/to/your/device>` with the appropriate serial
 device for your board, typically something like
 `/dev/cu.usbmodem0009600837441`.
 
-Finally, re-open a serial connection and reset your device:
+Finally, re-open a serial connection and restart the logs:
 
 ```console
-uart:-$ kernel reboot cold
+uart:-$ log go
 ```
 
 ### Sample output

--- a/examples/zephyr/certificate_provisioning/pytest/test_sample.py
+++ b/examples/zephyr/certificate_provisioning/pytest/test_sample.py
@@ -25,20 +25,6 @@ def subprocess_logger(result, log_msg):
         LOGGER.error(f'{log_msg} stderr: {result.stderr}')
 
 async def test_credentials(shell, project, device_name, device_port, certificate_cred, wifi_ssid, wifi_psk):
-
-    # Ensure there are no credentials currently stored on device
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-    shell._device.readlines_until(regex=".*Start certificate provisioning sample", timeout=90.0)
-    sleep(5) # Time for fs bringup and in case nRF9160 reset loop reboot happens
-    shell.exec_command(f'fs rm {FS_CRT_PATH}')
-    shell.exec_command(f'fs rm {FS_KEY_PATH}')
-    shell.exec_command(f'fs rm {FS_SUBDIR}')
-    shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
-    shell._device.readlines_until(regex=".*Start certificate provisioning sample", timeout=90.0)
-    sleep(5) # Time for fs bringup and in case nRF9160 reset loop reboot happens
-
     # Check cloud to verify device does not exist
 
     with pytest.raises(Exception):
@@ -59,6 +45,8 @@ async def test_credentials(shell, project, device_name, device_port, certificate
 
     # Set Golioth credential
 
+    shell._device.readlines_until(regex=".*Could not stat /lfs1/credentials/client_cert.der", timeout=180.0)
+
     shell.exec_command('fs mkdir /lfs1/credentials')
     shell.exec_command('log halt')
 
@@ -78,7 +66,6 @@ async def test_credentials(shell, project, device_name, device_port, certificate
 
     shell.exec_command('log go')
     shell._device.clear_buffer()
-    shell._device.write('kernel reboot cold\n\n'.encode())
 
     # Await connection
 

--- a/examples/zephyr/certificate_provisioning/sample.yaml
+++ b/examples/zephyr/certificate_provisioning/sample.yaml
@@ -16,7 +16,4 @@ tests:
       mimxrt1024_evk
       nrf52840dk_nrf52840
       nrf9160dk_nrf9160_ns
-  sample.golioth.certificate_provisioning.buildonly:
-    build_only: true
-    platform_allow: >
       rak5010_nrf52840


### PR DESCRIPTION
This changes the certificate provisioning sample to repeatedly check for the presence of PKI credentials in the filesystem, instead of just once at boot as it previously did. This allows users (and more importantly, CI) to run through the example without needing to reset the board. Board that use a virtual COM port over a USB peripheral (like the RAK5010) will drop their serial connection if they reboot, so this change is necessary in order to test this sample in CI on those boards. Note that the certificate provisioning test will continue to fail until #554 is merged, but a passing run with the changes from that PR and the changes in this one can be found [here](https://github.com/golioth/golioth-firmware-sdk/actions/runs/10293915260/job/28491326370#step:8:49).

Resolves golioth/firmware-issue-tracker#627