### PR TITLE
hil: zephyr: include esp32_devkitc_wrover in twister testing

### DIFF
--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -104,8 +104,9 @@ jobs:
           - hil_board: esp32_devkitc_wrover
             west_board: esp32_devkitc_wrover/esp32/procpu
             manifest: .ci-west-zephyr.yml
+            extra_twister_args: '--flash-before'
             binary_blob: hal_espressif
-            run_tests: false
+            run_tests: true
 
           - hil_board: mimxrt1024_evk
             west_board: mimxrt1024_evk


### PR DESCRIPTION
This adds the esp32 to twister tests with the following caveats:
- Starting with Zephyr v3.7.0 the fw_update test will target the blueprint `esp32_devkitc_wrover_esp32_procpu`. This is already set up on the server, along with an artifact (based on v0.14.0 of Golioth). New artifacts beginning with v0.15.0 must be uploaded using this blueprint name
- Many of these test will fail due to a issue with writing to flash on these devices. This issue is being worked on.

resolves https://github.com/golioth/firmware-issue-tracker/issues/336