### PR TITLE
docs: fix link to device API documentation

### DIFF
--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -25,9 +25,7 @@ extern "C"
 /// For authentication, you can use either pre-shared key (PSK) or
 /// X.509 certificates (aka Public Key Infrastructure, PKI).
 ///
-/// https://docs.golioth.io/reference/protocols/coap
-/// <br>
-/// https://docs.golioth.io/reference/protocols/device-auth
+/// https://docs.golioth.io/reference/device-api
 /// @{
 
 /// @brief Opaque Golioth client


### PR DESCRIPTION
Fixes broken links to device API documentation. The substructure of the device API docs may change in the future, so we opt to link to the index, which is unlikely to be moved.