### PR TITLE
Format port files

### DIFF
--- a/port/esp_idf/fw_update_esp_idf.c
+++ b/port/esp_idf/fw_update_esp_idf.c
@@ -15,58 +15,66 @@
 #define TAG "fw_update_esp_idf"
 
 static esp_ota_handle_t _update_handle;
-static const esp_partition_t* _update_partition;
+static const esp_partition_t *_update_partition;
 
-bool fw_update_is_pending_verify(void) {
-    const esp_partition_t* running = esp_ota_get_running_partition();
+bool fw_update_is_pending_verify(void)
+{
+    const esp_partition_t *running = esp_ota_get_running_partition();
     esp_ota_img_states_t ota_state;
-    if (esp_ota_get_state_partition(running, &ota_state) == ESP_OK) {
-        if (ota_state == ESP_OTA_IMG_PENDING_VERIFY) {
+    if (esp_ota_get_state_partition(running, &ota_state) == ESP_OK)
+    {
+        if (ota_state == ESP_OTA_IMG_PENDING_VERIFY)
+        {
             return true;
         }
     }
     return false;
 }
 
-void fw_update_rollback(void) {
+void fw_update_rollback(void)
+{
     esp_ota_mark_app_invalid_rollback_and_reboot();
 }
 
-void fw_update_reboot(void) {
+void fw_update_reboot(void)
+{
     esp_restart();
 }
 
-void fw_update_cancel_rollback(void) {
+void fw_update_cancel_rollback(void)
+{
     esp_ota_mark_app_valid_cancel_rollback();
 }
 
-enum golioth_status fw_update_handle_block(
-        const uint8_t* block,
-        size_t block_size,
-        size_t offset,
-        size_t total_size) {
+enum golioth_status fw_update_handle_block(const uint8_t *block,
+                                           size_t block_size,
+                                           size_t offset,
+                                           size_t total_size)
+{
     esp_err_t err = ESP_OK;
 
-    if (offset == 0) {
+    if (offset == 0)
+    {
         _update_partition = esp_ota_get_next_update_partition(NULL);
         assert(_update_partition);
-        GLTH_LOGI(
-                TAG,
-                "Writing to partition subtype %d at offset 0x%" PRIx32,
-                _update_partition->subtype,
-                _update_partition->address);
+        GLTH_LOGI(TAG,
+                  "Writing to partition subtype %d at offset 0x%" PRIx32,
+                  _update_partition->subtype,
+                  _update_partition->address);
 
         GLTH_LOGI(TAG, "Erasing flash");
         err = esp_ota_begin(_update_partition, OTA_SIZE_UNKNOWN, &_update_handle);
-        if (err != ESP_OK) {
+        if (err != ESP_OK)
+        {
             GLTH_LOGE(TAG, "esp_ota_begin failed (%s)", esp_err_to_name(err));
             esp_ota_abort(_update_handle);
             return GOLIOTH_ERR_FAIL;
         }
     }
 
-    err = esp_ota_write(_update_handle, (const void*)block, block_size);
-    if (err != ESP_OK) {
+    err = esp_ota_write(_update_handle, (const void *) block, block_size);
+    if (err != ESP_OK)
+    {
         GLTH_LOGE(TAG, "esp_ota_write failed (%s)", esp_err_to_name(err));
         esp_ota_abort(_update_handle);
         return GOLIOTH_ERR_FAIL;
@@ -75,17 +83,23 @@ enum golioth_status fw_update_handle_block(
     return GOLIOTH_OK;
 }
 
-void fw_update_post_download(void) {
+void fw_update_post_download(void)
+{
     // Nothing to do
 }
 
-enum golioth_status fw_update_validate(void) {
+enum golioth_status fw_update_validate(void)
+{
     assert(_update_handle);
     esp_err_t err = esp_ota_end(_update_handle);
-    if (err != ESP_OK) {
-        if (err == ESP_ERR_OTA_VALIDATE_FAILED) {
+    if (err != ESP_OK)
+    {
+        if (err == ESP_ERR_OTA_VALIDATE_FAILED)
+        {
             GLTH_LOGE(TAG, "Image validation failed, image is corrupted");
-        } else {
+        }
+        else
+        {
             GLTH_LOGE(TAG, "esp_ota_end failed (%s)!", esp_err_to_name(err));
         }
 
@@ -95,20 +109,24 @@ enum golioth_status fw_update_validate(void) {
     return GOLIOTH_OK;
 }
 
-enum golioth_status fw_update_change_boot_image(void) {
+enum golioth_status fw_update_change_boot_image(void)
+{
     assert(_update_partition);
 
     GLTH_LOGI(TAG, "Setting boot partition");
     esp_err_t err = esp_ota_set_boot_partition(_update_partition);
-    if (err != ESP_OK) {
+    if (err != ESP_OK)
+    {
         GLTH_LOGE(TAG, "esp_ota_set_boot_partition failed (%s)!", esp_err_to_name(err));
         return GOLIOTH_ERR_FAIL;
     }
     return GOLIOTH_OK;
 }
 
-void fw_update_end(void) {
-    if (_update_handle) {
+void fw_update_end(void)
+{
+    if (_update_handle)
+    {
         esp_ota_end(_update_handle);
     }
 }

--- a/port/esp_idf/golioth_port_config.h
+++ b/port/esp_idf/golioth_port_config.h
@@ -37,30 +37,33 @@
 // TODO - should we hook into the ESP logging backend via esp_log_set_vprintf?
 // This would enable all logs to be sent to Golioth (not just the GLTH_LOGX logs).
 
-#define GLTH_LOGX(COLOR, LEVEL, LEVEL_STR, TAG, ...) \
-    do { \
-        if ((LEVEL) <= golioth_debug_get_log_level()) { \
-            uint64_t now_ms = golioth_sys_now_ms(); \
-            switch (LEVEL) { \
-                case GOLIOTH_DEBUG_LOG_LEVEL_ERROR: \
-                    ESP_LOGE(TAG, __VA_ARGS__); \
-                    break; \
-                case GOLIOTH_DEBUG_LOG_LEVEL_WARN: \
-                    ESP_LOGW(TAG, __VA_ARGS__); \
-                    break; \
-                case GOLIOTH_DEBUG_LOG_LEVEL_INFO: \
-                    ESP_LOGI(TAG, __VA_ARGS__); \
-                    break; \
-                case GOLIOTH_DEBUG_LOG_LEVEL_DEBUG: \
-                    ESP_LOGD(TAG, __VA_ARGS__); \
-                    break; \
-                case GOLIOTH_DEBUG_LOG_LEVEL_VERBOSE: \
-                    ESP_LOGV(TAG, __VA_ARGS__); \
-                    break; \
-                case GOLIOTH_DEBUG_LOG_LEVEL_NONE: \
-                default: \
-                    break; \
-            } \
+#define GLTH_LOGX(COLOR, LEVEL, LEVEL_STR, TAG, ...)               \
+    do                                                             \
+    {                                                              \
+        if ((LEVEL) <= golioth_debug_get_log_level())              \
+        {                                                          \
+            uint64_t now_ms = golioth_sys_now_ms();                \
+            switch (LEVEL)                                         \
+            {                                                      \
+                case GOLIOTH_DEBUG_LOG_LEVEL_ERROR:                \
+                    ESP_LOGE(TAG, __VA_ARGS__);                    \
+                    break;                                         \
+                case GOLIOTH_DEBUG_LOG_LEVEL_WARN:                 \
+                    ESP_LOGW(TAG, __VA_ARGS__);                    \
+                    break;                                         \
+                case GOLIOTH_DEBUG_LOG_LEVEL_INFO:                 \
+                    ESP_LOGI(TAG, __VA_ARGS__);                    \
+                    break;                                         \
+                case GOLIOTH_DEBUG_LOG_LEVEL_DEBUG:                \
+                    ESP_LOGD(TAG, __VA_ARGS__);                    \
+                    break;                                         \
+                case GOLIOTH_DEBUG_LOG_LEVEL_VERBOSE:              \
+                    ESP_LOGV(TAG, __VA_ARGS__);                    \
+                    break;                                         \
+                case GOLIOTH_DEBUG_LOG_LEVEL_NONE:                 \
+                default:                                           \
+                    break;                                         \
+            }                                                      \
             golioth_debug_printf(now_ms, LEVEL, TAG, __VA_ARGS__); \
-        } \
+        }                                                          \
     } while (0)

--- a/port/linux/fw_update_linux.c
+++ b/port/linux/fw_update_linux.c
@@ -16,19 +16,22 @@
 #define DOWNLOADED_FILE_NAME "downloaded.bin"
 
 #define FW_UPDATE_RETURN_IF_NEGATIVE(expr) \
-    do { \
-        int retval = (expr); \
-        if (retval < 0) { \
-            return retval; \
-        } \
+    do                                     \
+    {                                      \
+        int retval = (expr);               \
+        if (retval < 0)                    \
+        {                                  \
+            return retval;                 \
+        }                                  \
     } while (0)
 
-static FILE* _download_fp;
-static FILE* _current_fp;
-static uint8_t* _filebuf;
+static FILE *_download_fp;
+static FILE *_current_fp;
+static uint8_t *_filebuf;
 static bool _initialized;
 
-bool fw_update_is_pending_verify(void) {
+bool fw_update_is_pending_verify(void)
+{
     return false;
 }
 
@@ -39,54 +42,61 @@ void fw_update_reboot(void) {}
 void fw_update_cancel_rollback(void) {}
 
 #if ENABLE_DOWNLOAD_TO_FILE
-enum golioth_status fw_update_handle_block(
-        const uint8_t* block,
-        size_t block_size,
-        size_t offset,
-        size_t total_size) {
-    if (!_download_fp) {
+enum golioth_status fw_update_handle_block(const uint8_t *block,
+                                           size_t block_size,
+                                           size_t offset,
+                                           size_t total_size)
+{
+    if (!_download_fp)
+    {
         _download_fp = fopen(DOWNLOADED_FILE_NAME, "w");
     }
-    GLTH_LOGD(
-            TAG,
-            "block_size 0x%08lX, offset 0x%08lX, total_size 0x%08lX",
-            block_size,
-            offset,
-            total_size);
+    GLTH_LOGD(TAG,
+              "block_size 0x%08lX, offset 0x%08lX, total_size 0x%08lX",
+              block_size,
+              offset,
+              total_size);
     fwrite(block, block_size, 1, _download_fp);
     return GOLIOTH_OK;
 }
 #else
-enum golioth_status fw_update_handle_block(
-        const uint8_t* block,
-        size_t block_size,
-        size_t offset,
-        size_t total_size) {
+enum golioth_status fw_update_handle_block(const uint8_t *block,
+                                           size_t block_size,
+                                           size_t offset,
+                                           size_t total_size)
+{
     return GOLIOTH_OK;
 }
 #endif
 
-void fw_update_post_download(void) {
-    if (_download_fp) {
+void fw_update_post_download(void)
+{
+    if (_download_fp)
+    {
         fclose(_download_fp);
         _download_fp = NULL;
     }
-    if (_current_fp) {
+    if (_current_fp)
+    {
         fclose(_current_fp);
         _current_fp = NULL;
     }
 }
 
-enum golioth_status fw_update_validate(void) {
+enum golioth_status fw_update_validate(void)
+{
     return GOLIOTH_OK;
 }
 
-enum golioth_status fw_update_change_boot_image(void) {
+enum golioth_status fw_update_change_boot_image(void)
+{
     return GOLIOTH_OK;
 }
 
-void fw_update_end(void) {
-    if (_filebuf) {
+void fw_update_end(void)
+{
+    if (_filebuf)
+    {
         free(_filebuf);
         _filebuf = NULL;
     }
@@ -98,7 +108,8 @@ void fw_update_end(void) {
 //
 // On error, a negative value is returned
 // On success, the number of bytes read is returned.
-int read_file(const char* filepath, uint8_t** filebuf) {
+int read_file(const char *filepath, uint8_t **filebuf)
+{
     int fd = open(filepath, O_RDONLY, 0);
     FW_UPDATE_RETURN_IF_NEGATIVE(fd);
 
@@ -106,7 +117,8 @@ int read_file(const char* filepath, uint8_t** filebuf) {
     FW_UPDATE_RETURN_IF_NEGATIVE(filesize);
 
     *filebuf = malloc(filesize + 1);
-    if (!*filebuf) {
+    if (!*filebuf)
+    {
         GLTH_LOGE(TAG, "Failed to allocate");
         return -1;
     }
@@ -114,7 +126,8 @@ int read_file(const char* filepath, uint8_t** filebuf) {
     FW_UPDATE_RETURN_IF_NEGATIVE(lseek(fd, 0, SEEK_SET));
 
     int bytes_read = read(fd, *filebuf, filesize);
-    if (bytes_read != filesize) {
+    if (bytes_read != filesize)
+    {
         GLTH_LOGE(TAG, "Failed to read entire file");
         return -1;
     }

--- a/port/zephyr/golioth_fw_zephyr.c
+++ b/port/zephyr/golioth_fw_zephyr.c
@@ -15,8 +15,10 @@ LOG_MODULE_REGISTER(golioth_fw_zephyr);
 
 struct flash_img_context _flash_img_context;
 
-bool fw_update_is_pending_verify(void) {
-    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT)) {
+bool fw_update_is_pending_verify(void)
+{
+    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT))
+    {
         return false;
     }
 
@@ -25,8 +27,10 @@ bool fw_update_is_pending_verify(void) {
 
 void fw_update_rollback(void) {}
 
-void fw_update_reboot(void) {
-    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT)) {
+void fw_update_reboot(void)
+{
+    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT))
+    {
         return;
     }
 
@@ -43,7 +47,8 @@ void fw_update_reboot(void) {
  *
  * @note This is a copy of zephyr_img_mgmt_flash_check_empty() from mcumgr.
  */
-static int flash_area_check_empty(const struct flash_area* fa, bool* out_empty) {
+static int flash_area_check_empty(const struct flash_area *fa, bool *out_empty)
+{
     uint32_t data[16];
     off_t addr;
     off_t end;
@@ -59,21 +64,28 @@ static int flash_area_check_empty(const struct flash_area* fa, bool* out_empty) 
     erased_val_32 = ERASED_VAL_32(erased_val);
 
     end = fa->fa_size;
-    for (addr = 0; addr < end; addr += sizeof(data)) {
-        if (end - addr < sizeof(data)) {
+    for (addr = 0; addr < end; addr += sizeof(data))
+    {
+        if (end - addr < sizeof(data))
+        {
             bytes_to_read = end - addr;
-        } else {
+        }
+        else
+        {
             bytes_to_read = sizeof(data);
         }
 
         rc = flash_area_read(fa, addr, data, bytes_to_read);
-        if (rc != 0) {
+        if (rc != 0)
+        {
             flash_area_close(fa);
             return rc;
         }
 
-        for (i = 0; i < bytes_to_read / 4; i++) {
-            if (data[i] != erased_val_32) {
+        for (i = 0; i < bytes_to_read / 4; i++)
+        {
+            if (data[i] != erased_val_32)
+            {
                 *out_empty = false;
                 flash_area_close(fa);
                 return 0;
@@ -86,33 +98,40 @@ static int flash_area_check_empty(const struct flash_area* fa, bool* out_empty) 
     return 0;
 }
 
-static int flash_img_erase_if_needed(struct flash_img_context* ctx) {
+static int flash_img_erase_if_needed(struct flash_img_context *ctx)
+{
     bool empty;
     int err;
 
-    if (IS_ENABLED(CONFIG_IMG_ERASE_PROGRESSIVELY)) {
+    if (IS_ENABLED(CONFIG_IMG_ERASE_PROGRESSIVELY))
+    {
         return 0;
     }
 
     err = flash_area_check_empty(ctx->flash_area, &empty);
-    if (err) {
+    if (err)
+    {
         return err;
     }
 
-    if (empty) {
+    if (empty)
+    {
         return 0;
     }
 
     err = flash_area_erase(ctx->flash_area, 0, ctx->flash_area->fa_size);
-    if (err) {
+    if (err)
+    {
         return err;
     }
 
     return 0;
 }
 
-static const char* swap_type_str(int swap_type) {
-    switch (swap_type) {
+static const char *swap_type_str(int swap_type)
+{
+    switch (swap_type)
+    {
         case BOOT_SWAP_TYPE_NONE:
             return "none";
         case BOOT_SWAP_TYPE_TEST:
@@ -128,12 +147,14 @@ static const char* swap_type_str(int swap_type) {
     return "unknown";
 }
 
-static int flash_img_prepare(struct flash_img_context* flash) {
+static int flash_img_prepare(struct flash_img_context *flash)
+{
     int swap_type;
     int err;
 
     swap_type = mcuboot_swap_type();
-    switch (swap_type) {
+    switch (swap_type)
+    {
         case BOOT_SWAP_TYPE_REVERT:
             LOG_WRN("'revert' swap type detected, it is not safe to continue");
             return -EBUSY;
@@ -143,13 +164,15 @@ static int flash_img_prepare(struct flash_img_context* flash) {
     }
 
     err = flash_img_init(flash);
-    if (err) {
+    if (err)
+    {
         LOG_ERR("failed to init: %d", err);
         return err;
     }
 
     err = flash_img_erase_if_needed(flash);
-    if (err) {
+    if (err)
+    {
         LOG_ERR("failed to erase: %d", err);
         return err;
     }
@@ -157,34 +180,40 @@ static int flash_img_prepare(struct flash_img_context* flash) {
     return 0;
 }
 
-void fw_update_cancel_rollback(void) {
-    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT)) {
+void fw_update_cancel_rollback(void)
+{
+    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT))
+    {
         return;
     }
 
     boot_write_img_confirmed();
 }
 
-enum golioth_status fw_update_handle_block(
-        const uint8_t* block,
-        size_t block_size,
-        size_t offset,
-        size_t total_size) {
+enum golioth_status fw_update_handle_block(const uint8_t *block,
+                                           size_t block_size,
+                                           size_t offset,
+                                           size_t total_size)
+{
     int err;
 
-    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT)) {
+    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT))
+    {
         return GOLIOTH_OK;
     }
 
-    if (offset == 0) {
+    if (offset == 0)
+    {
         err = flash_img_prepare(&_flash_img_context);
-        if (err) {
+        if (err)
+        {
             return GOLIOTH_ERR_FAIL;
         }
     }
 
     err = flash_img_buffered_write(&_flash_img_context, block, block_size, false);
-    if (err) {
+    if (err)
+    {
         LOG_ERR("Failed to write to flash: %d", err);
         return GOLIOTH_ERR_FAIL;
     }
@@ -192,32 +221,39 @@ enum golioth_status fw_update_handle_block(
     return GOLIOTH_OK;
 }
 
-void fw_update_post_download(void) {
+void fw_update_post_download(void)
+{
     int err;
 
-    if (!_flash_img_context.stream.buf_bytes) {
+    if (!_flash_img_context.stream.buf_bytes)
+    {
         return;
     }
 
     err = flash_img_buffered_write(&_flash_img_context, NULL, 0, true);
-    if (err) {
+    if (err)
+    {
         LOG_ERR("Failed to write to flash: %d", err);
     }
 }
 
-enum golioth_status fw_update_validate(void) {
+enum golioth_status fw_update_validate(void)
+{
     return GOLIOTH_OK;
 }
 
-enum golioth_status fw_update_change_boot_image(void) {
+enum golioth_status fw_update_change_boot_image(void)
+{
     int err;
 
-    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT)) {
+    if (!IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT))
+    {
         return GOLIOTH_ERR_NOT_IMPLEMENTED;
     }
 
     err = boot_request_upgrade(BOOT_UPGRADE_TEST);
-    if (err) {
+    if (err)
+    {
         return GOLIOTH_ERR_FAIL;
     }
 

--- a/port/zephyr/golioth_log_zephyr.h
+++ b/port/zephyr/golioth_log_zephyr.h
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int log_backend_golioth_enable(void* client);
-int log_backend_golioth_disable(void* client);
+int log_backend_golioth_enable(void *client);
+int log_backend_golioth_disable(void *client);


### PR DESCRIPTION
Run clang-format on esp-idf, linux, and Zephyr .c and .h files.