### PR TITLE
zephyr: revert NXP Ethernet driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Workarounds:
+
+- The MIMXRT1024-EVK received a new upstream Ethernet driver that was
+  found to have sporadic "Link Down/Up" events that cause a loss of
+  connectivity when downloading binaries during OTA Firmware Update. All
+  Zephyr examples in this release include an overlay file for this board
+  that reverts to the old driver.
+
 ## [0.14.0] 2024-06-21
 
 ### Highlights:

--- a/examples/zephyr/fw_update/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/fw_update/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 

--- a/examples/zephyr/golioth_basics/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/golioth_basics/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 

--- a/examples/zephyr/hello/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/hello/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 

--- a/examples/zephyr/lightdb/delete/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/lightdb/delete/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 

--- a/examples/zephyr/lightdb/get/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/lightdb/get/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 

--- a/examples/zephyr/lightdb/observe/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/lightdb/observe/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 

--- a/examples/zephyr/lightdb/set/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/lightdb/set/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 

--- a/examples/zephyr/logging/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/logging/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 

--- a/examples/zephyr/rpc/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/rpc/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 

--- a/examples/zephyr/settings/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/settings/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 

--- a/examples/zephyr/stream/boards/mimxrt1024_evk.overlay
+++ b/examples/zephyr/stream/boards/mimxrt1024_evk.overlay
@@ -1,19 +1,4 @@
 / {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			mount-point = "/lfs1";
-			partition = <&storage_partition>;
-			automount;
-			read-size = <16>;
-			prog-size = <16>;
-			cache-size = <64>;
-			lookahead-size = <32>;
-			block-cycles = <512>;
-		};
-	};
-
 	soc {
 		/delete-node/ enet@402d8000;
 


### PR DESCRIPTION
Zephyr v3.7.0 moves to NXP Ethernet driver which was exhibiting Link Down/Up behavior during OTA Firmware Update that resulted in the inability to download new firmware. This behavior is similar to issues reported upstream:

- https://github.com/zephyrproject-rtos/zephyr/issues/76446
- https://github.com/zephyrproject-rtos/zephyr/issues/76965

Cherry-picking the suggested patch did not resolve the issue. This commit reverts to the old driver using an overlay file for the mimxrt1024_evk. When there is an upstream fix available, these overlay files may be removed (note the certificate_provisioning example still needs the stab node in its board overlay file).

resolves https://github.com/golioth/firmware-issue-tracker/issues/642