### PR TITLE
ci: native_sim: generate coverage

### DIFF
--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -98,7 +98,7 @@ jobs:
         # Echo coverage summary into GitHub Output, with title
 
         echo "coverage_summary<<EOF" >> $GITHUB_OUTPUT
-        echo "# Code Coverage" >> $GITHUB_OUTPUT
+        echo "# Code Coverage (Linux)" >> $GITHUB_OUTPUT
         echo "| Type | Coverage |" >> $GITHUB_OUTPUT
         echo "| --- | --- |" >> $GITHUB_OUTPUT
         echo "$coverage_summary" >> $GITHUB_OUTPUT
@@ -111,7 +111,7 @@ jobs:
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
-        body-includes: Code Coverage
+        body-includes: Code Coverage (Linux)
     - name: Code coverage comment
       uses: peter-evans/create-or-update-comment@v4
       if: github.event_name == 'pull_request'

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -219,6 +219,8 @@ jobs:
           zephyr/scripts/twister                                                    \
               --platform ${{ matrix.west_board }}                                   \
               -T modules/lib/golioth-firmware-sdk/examples/zephyr                   \
+              -C --coverage-basedir modules/lib/golioth-firmware-sdk                \
+              --coverage-formats txt                                                \
               -x=CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"    \
               --pytest-args="--api-url=${{ inputs.api-url }}"                       \
               --pytest-args="--api-key=${{ secrets[inputs.api-key-id] }}"           \
@@ -231,10 +233,72 @@ jobs:
           name: twister-run-artifacts-${{ matrix.artifact_suffix }}
           path: |
             reports/*
+            twister-out/coverage.json
             twister-out/**/*.log
             twister-out/**/report.xml
             twister-out/*.xml
             twister-out/*.json
+
+  hil_sample_zephyr_nsim_coverage:
+    runs-on: ubuntu-latest
+    needs: hil_sample_zephyr_nsim
+    name: zephyr-coverage
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: twister-run-artifacts-native*
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install gcovr
+        shell: bash
+        run: |
+          pip install gcovr
+
+      - name: Merge coverage
+        shell: bash
+        run: |
+          tracefiles=$(for d in twister-run-artifacts-*; do
+            printf -- "--add-tracefile $d/twister-out/coverage.json "
+          done)
+
+          shopt -s expand_aliases
+
+          alias gcovr="gcovr \
+            $tracefiles \
+            -e examples -e external"
+
+          gcovr --txt-summary --xml coverage.xml
+
+      - name: Coverage report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage.xml
+          format: markdown
+          badge: true
+          output: file
+          hide_complexity: true
+
+      - name: Coverage summary
+        shell: bash
+        run: |
+          cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Append Coverage PR Comment title
+        shell: bash
+        run: |
+          echo "# Code Coverage (Zephyr)" > code-coverage-comment.md
+          cat code-coverage-results.md >> code-coverage-comment.md
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          path: code-coverage-comment.md
 
   hil_sample_esp-idf:
     if: ${{ inputs.workflow == 'all' || inputs.workflow == 'esp_idf_sample' }}

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -220,7 +220,7 @@ jobs:
               --platform ${{ matrix.west_board }}                                   \
               -T modules/lib/golioth-firmware-sdk/examples/zephyr                   \
               -C --coverage-basedir modules/lib/golioth-firmware-sdk                \
-              --coverage-formats txt                                                \
+              --coverage-formats txt,html                                           \
               -x=CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"    \
               --pytest-args="--api-url=${{ inputs.api-url }}"                       \
               --pytest-args="--api-key=${{ secrets[inputs.api-key-id] }}"           \
@@ -234,6 +234,7 @@ jobs:
           path: |
             reports/*
             twister-out/coverage.json
+            twister-out/coverage/*
             twister-out/**/*.log
             twister-out/**/report.xml
             twister-out/*.xml


### PR DESCRIPTION
Pass coverage data (twister generated coverage.json files) using artifacts.
Since there are multiple of those already (for 32 and 64 bit native_sim
variants) merge them in another job. Report coverage data in the job
summary GitHub Actions page. Additionally create a comment in PR using
XML (Cobertura) generated report.