### PR TITLE
examples: zephyr: use 'sysbuild' with NCS

### DIFF
--- a/examples/zephyr/fw_update/README.md
+++ b/examples/zephyr/fw_update/README.md
@@ -171,7 +171,7 @@ On your host computer open a terminal window, locate the source code of
 this sample application (i.e., `examples/zephyr/fw_update`) and type:
 
 ```console
-$ west build -b nrf9160dk/nrf9160/ns examples/zephyr/fw_update
+$ west build -b nrf9160dk/nrf9160/ns --sysbuild examples/zephyr/fw_update
 $ west flash
 ```
 
@@ -220,28 +220,20 @@ update file will be uploaded to Golioth for the OTA update.
 # For esp32_devkitc_wrover/esp32/procpu
 $ west build -b esp32_devkitc_wrover/esp32/procpu --sysbuild examples/zephyr/fw_update
 
-# For nRF52840dk (Zephyr):
+# For nRF52840dk:
 $ west build -b nrf52840dk/nrf52840 --sysbuild examples/zephyr/fw_update
 
-# For nRF9160dk (NCS):
-$ west build -b nrf9160dk/nrf9160/ns examples/zephyr/fw_update
+# For nRF9160dk:
+$ west build -b nrf9160dk/nrf9160/ns --sysbuild examples/zephyr/fw_update
 ```
 
 ### Start FW Update using `goliothctl`
-
-FW update requires one of two files based on the which platform you are using:
-
-* Zephyr: `build/fw_update/zephyr/zephyr.signed.bin`
-* NCS (Nordic version of Zephyr): `build/zephyr/app_update.bin`
-
-Use the correct file from your build to replace `<binary_file>` in the
-commands below.
 
 1. Run the following command on a host PC to upload the new firmware as
    an artifact to Golioth:
 
     ```console
-    $ goliothctl dfu artifact create <binary_file> --version 1.2.4
+    $ goliothctl dfu artifact create build/fw_update/zephyr/zephyr.signed.bin --version 1.2.4
     ```
 
 2. Create a new release consisting of this single firmware and roll it

--- a/examples/zephyr/fw_update/README.md
+++ b/examples/zephyr/fw_update/README.md
@@ -168,7 +168,7 @@ $ west flash
 #### nRF9160 DK
 
 On your host computer open a terminal window, locate the source code of
-this sample application (i.e., `examples/zephyr/hello`) and type:
+this sample application (i.e., `examples/zephyr/fw_update`) and type:
 
 ```console
 $ west build -b nrf9160dk/nrf9160/ns examples/zephyr/fw_update

--- a/examples/zephyr/fw_update/pytest/README.md
+++ b/examples/zephyr/fw_update/pytest/README.md
@@ -33,5 +33,4 @@ $ west build -b mimxrt1024_evk --sysbuild examples/zephyr/fw_update
 3. Upload artifacts:
     1. Select the blueprint that matches the artifact.
     2. Use version number `255.8.9`.
-    3. For the nRF9160 upload `build/zephyr/app_update.bin`. For all
-       other boards upload `build/fw_update/zephyr/zephyr.signed.bin`
+    3. Upload `build/fw_update/zephyr/zephyr.signed.bin`.

--- a/examples/zephyr/fw_update/sample.yaml
+++ b/examples/zephyr/fw_update/sample.yaml
@@ -7,22 +7,17 @@ common:
     - socket
     - goliothd
 tests:
-  sample.golioth.fw_update.sysbuild:
-    harness: pytest
-    sysbuild: true
-    timeout: 600
-    extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
-    platform_allow:
-      - esp32_devkitc_wrover/esp32/procpu
-      - mimxrt1024_evk
-      - nrf52840dk/nrf52840
   sample.golioth.fw_update:
     harness: pytest
+    sysbuild: true
     timeout: 720
     extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
     extra_configs:
       - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
     platform_allow:
+      - esp32_devkitc_wrover/esp32/procpu
+      - mimxrt1024_evk
+      - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
   sample.golioth.fw_update.buildonly:
     build_only: true

--- a/examples/zephyr/golioth_basics/README.md
+++ b/examples/zephyr/golioth_basics/README.md
@@ -123,7 +123,7 @@ On your host computer open a terminal window, locate the source code of
 this sample application (i.e., `examples/zephyr/golioth_basics`) and type:
 
 ```console
-$ west build -b nrf9160dk/nrf9160/ns examples/zephyr/golioth_basics
+$ west build -b nrf9160dk/nrf9160/ns --sysbuild examples/zephyr/golioth_basics
 $ west flash
 ```
 
@@ -160,28 +160,20 @@ update file will be uploaded to Golioth for the OTA update.
 # For esp32_devkitc_wrover/esp32/procpu
 $ west build -b esp32_devkitc_wrover/esp32/procpu --sysbuild examples/zephyr/golioth_basics
 
-# For nRF52840dk (Zephyr):
+# For nRF52840dk:
 $ west build -b nrf52840dk/nrf52840 --sysbuild examples/zephyr/golioth_basics
 
-# For nRF9160dk (NCS):
-$ west build -b nrf9160dk/nrf9160/ns examples/zephyr/golioth_basics
+# For nRF9160dk:
+$ west build -b nrf9160dk/nrf9160/ns --sysbuild examples/zephyr/golioth_basics
 ```
 
 ### Start DFU using `goliothctl`
-
-DFU requires one of two files based on the which platform you are using:
-
-* Zephyr: `build/golioth_basics/zephyr/zephyr.signed.bin`
-* NCS (Nordic version of Zephyr): `build/zephyr/app_update.bin`
-
-Use the correct file from your build to replace `<binary_file>` in the
-commands below.
 
 1. Run the following command on a host PC to upload the new firmware as
    an artifact to Golioth:
 
     ```console
-    $ goliothctl dfu artifact create <binary_file> --version 1.2.6
+    $ goliothctl dfu artifact create build/golioth_basics/zephyr/zephyr.signed.bin --version 1.2.6
     ```
 
 2. Create a new release consisting of this single firmware and roll it


### PR DESCRIPTION
With NCS 2.7.0 comes support for 'sysbuild'. Use it, so there is the same
behavior with vanilla Zephyr and NCS.