### PR TITLE
settings: check for server error in settings callback

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -173,18 +173,16 @@ static int finalize_and_send_response(struct golioth_client *client,
                             response->zse->payload - response->buf,
                             GOLIOTH_DEBUG_LOG_LEVEL_DEBUG);
 
-    golioth_coap_client_set(client,
-                            SETTINGS_PATH_PREFIX,
-                            "status",
-                            GOLIOTH_CONTENT_TYPE_CBOR,
-                            response->buf,
-                            response->zse->payload - response->buf,
-                            NULL,
-                            NULL,
-                            false,
-                            GOLIOTH_SYS_WAIT_FOREVER);
-
-    return 0;
+    return golioth_coap_client_set(client,
+                                   SETTINGS_PATH_PREFIX,
+                                   SETTINGS_STATUS_PATH,
+                                   GOLIOTH_CONTENT_TYPE_CBOR,
+                                   response->buf,
+                                   response->zse->payload - response->buf,
+                                   NULL,
+                                   NULL,
+                                   false,
+                                   GOLIOTH_SYS_WAIT_FOREVER);
 }
 
 static int settings_decode(zcbor_state_t *zsd, void *value)

--- a/src/settings.c
+++ b/src/settings.c
@@ -372,6 +372,16 @@ static void on_settings(struct golioth_client *client,
                         size_t payload_size,
                         void *arg)
 {
+    if (GOLIOTH_OK != response->status)
+    {
+        GLTH_LOGE(TAG,
+                  "Settings callback received status error: %d  CoAP error: %d.%02d",
+                  response->status,
+                  response->status_class,
+                  response->status_code);
+        return;
+    }
+
     ZCBOR_STATE_D(zsd, 2, payload, payload_size, 1, 0);
     int64_t version;
     struct golioth_settings *settings = arg;


### PR DESCRIPTION
When the settings observation handler runs, first check the response status and log/return errors if necessary before trying to process a payload.

resolves https://github.com/golioth/firmware-issue-tracker/issues/639