### PR TITLE
port: zephyr: honor CONFIG_GOLIOTH_DEBUG_LOG

### DIFF
--- a/port/zephyr/include/golioth_port_config.h
+++ b/port/zephyr/include/golioth_port_config.h
@@ -10,6 +10,8 @@
 
 #define LOG_TAG_DEFINE(tag) LOG_MODULE_REGISTER(tag, CONFIG_GOLIOTH_LOG_LEVEL)
 
+#ifdef CONFIG_GOLIOTH_DEBUG_LOG
+
 #define GLTH_LOGE(tag, ...) LOG_ERR(__VA_ARGS__)
 
 #define GLTH_LOGW(tag, ...) LOG_WRN(__VA_ARGS__)
@@ -21,3 +23,5 @@
 #define GLTH_LOGV(tag, ...) LOG_DBG(__VA_ARGS__)
 
 #define GLTH_LOG_BUFFER_HEXDUMP(tag, buf, size, level) LOG_HEXDUMP_DBG(buf, size, "buffer")
+
+#endif


### PR DESCRIPTION
Updates zephyr port config to only define the GLTH_LOGX macros if CONFIG_GOLIOTH_DEBUG_LOG is defined. Previously, a large number of redefinition warnings would be reported by the compiler due to definition of GLTH_LOGX macros to empty by the default system config when CONFIG_GOLIOTH_DEBUG_LOG=n.

Before this change when `CONFIG_GOLIOTH_DEBUG_LOG=n` in any Zephyr builds:
```
In file included from /home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/../../include/golioth/config.h:24,
                 from /home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/../../include/golioth/golioth_debug.h:14,
                 from /home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/src/coap_client_zephyr.c:7:
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/include/golioth_port_config.h:23: note: this is the location of the previous definition
   23 | #define GLTH_LOGV(tag, ...) LOG_DBG(__VA_ARGS__)
      | 
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/../../include/golioth/golioth_sys.h:197: warning: "GLTH_LOGD" redefined
  197 | #define GLTH_LOGD(TAG, ...)
      | 
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/include/golioth_port_config.h:21: note: this is the location of the previous definition
   21 | #define GLTH_LOGD(tag, ...) LOG_DBG(__VA_ARGS__)
      | 
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/../../include/golioth/golioth_sys.h:198: warning: "GLTH_LOGI" redefined
  198 | #define GLTH_LOGI(TAG, ...)
      | 
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/include/golioth_port_config.h:19: note: this is the location of the previous definition
   19 | #define GLTH_LOGI(tag, ...) LOG_INF(__VA_ARGS__)
      | 
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/../../include/golioth/golioth_sys.h:199: warning: "GLTH_LOGW" redefined
  199 | #define GLTH_LOGW(TAG, ...)
      | 
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/include/golioth_port_config.h:17: note: this is the location of the previous definition
   17 | #define GLTH_LOGW(tag, ...) LOG_WRN(__VA_ARGS__)
      | 
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/../../include/golioth/golioth_sys.h:200: warning: "GLTH_LOGE" redefined
  200 | #define GLTH_LOGE(TAG, ...)
      | 
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/include/golioth_port_config.h:15: note: this is the location of the previous definition
   15 | #define GLTH_LOGE(tag, ...) LOG_ERR(__VA_ARGS__)
      | 
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/../../include/golioth/golioth_sys.h:201: warning: "GLTH_LOG_BUFFER_HEXDUMP" redefined
  201 | #define GLTH_LOG_BUFFER_HEXDUMP(TAG, ...)
      | 
/home/hasheddan/code/github.com/golioth/customer-support/esp-at-zephyr-3.7/modules/lib/golioth-firmware-sdk/port/zephyr/include/golioth_port_config.h:25: note: this is the location of the previous definition
   25 | #define GLTH_LOG_BUFFER_HEXDUMP(tag, buf, size, level) LOG_HEXDUMP_DBG(buf, size, "buffer")
      | 
...
```