### PR TITLE
tests: hil: use async to communicate with HIL

### DIFF
--- a/tests/hil/scripts/pytest-hil/board.py
+++ b/tests/hil/scripts/pytest-hil/board.py
@@ -1,46 +1,82 @@
 from abc import ABC, abstractmethod
-import serial
-from time import time, sleep
+from contextlib import asynccontextmanager
 import re
 
+import trio
+from trio_serial import SerialStream
+
 class Board(ABC):
-    def __init__(self, port, baud, wifi_ssid, wifi_psk, fw_image, serial_number):
+    def __init__(self, port, baudrate, wifi_ssid, wifi_psk, fw_image, serial_number):
         if serial_number:
             self.serial_number = serial_number
         self.port = port
+        self.baudrate = baudrate
+        self.fw_image = fw_image
+        self.wifi_ssid = wifi_ssid
+        self.wifi_psk = wifi_psk
 
-        if fw_image:
-            self.program(fw_image)
+        self.received: bytes = b''
+
+        self.serial: SerialStream | None = None
+
+    @asynccontextmanager
+    async def started(self):
+        if self.fw_image:
+            self.program(self.fw_image)
+
+        async with SerialStream(port=self.port,
+                                baudrate=self.baudrate) as serial:
+            self.serial = serial
 
             # Wait for reboot
-            sleep(6)
+            await trio.sleep(6)
 
-        self.serial_device = serial.Serial(port, baud, timeout=1, write_timeout=1)
+            # Set WiFi credentials
+            if self.USES_WIFI:
+                await self.set_wifi_credentials(self.wifi_ssid, self.wifi_psk)
 
-        # Set WiFi credentials
-        if self.USES_WIFI:
-            self.set_wifi_credentials(wifi_ssid, wifi_psk)
+            yield self
 
-    def wait_for_regex_in_line(self, regex, timeout_s=20, log=True):
-        start_time = time()
-        while True:
-            self.serial_device.timeout=timeout_s
-            line = self.serial_device.read_until().decode('utf-8', errors='replace').replace("\r\n", "")
-            if line != "" and log:
-                print(line)
-            if time() - start_time > timeout_s:
-                raise RuntimeError('Timeout')
-            regex_search = re.search(regex, line)
-            if regex_search:
-                return regex_search
+    async def receive_some(self) -> bytes:
+        assert self.serial is not None
 
-    def send_cmd(self, cmd, wait_str=None):
+        return await self.serial.receive_some()
+
+    async def wait_for_regex_in_line(self, regex, timeout_s=20, log=True):
+        with trio.fail_after(timeout_s):
+            while True:
+                # Check in already received data
+                lines = self.received.splitlines(keepends=True)
+
+                for idx, line in enumerate(lines):
+                    regex_search = re.search(regex, line.replace(b'\r', b'').replace(b'\n', b'').decode('utf-8', errors='ignore'))
+                    if regex_search:
+                        # Drop this and any previous lines
+                        self.received = b''.join(lines[idx+1:])
+
+                        return regex_search
+
+                # Drop all but last line (in case it is not complete)
+                if len(lines) > 1:
+                    self.received = lines[-1]
+
+                # Receive more data
+                chunk = await self.receive_some()
+                if chunk == b'':
+                    return
+
+                if log:
+                    print(chunk.replace(b'\r', b'').decode('utf-8', errors='ignore'), end='')
+
+                self.received = self.received + chunk
+
+    async def send_cmd(self, cmd, wait_str=None):
         if wait_str == None:
             wait_str = self.PROMPT
-        self.serial_device.write('\r\n\r\n'.encode())
-        self.wait_for_regex_in_line(self.PROMPT)
-        self.serial_device.write('{}\r\n'.format(cmd).encode())
-        self.wait_for_regex_in_line(wait_str)
+        await self.serial.send_all('\r\n\r\n'.encode())
+        await self.wait_for_regex_in_line(self.PROMPT)
+        await self.serial.send_all('{}\r\n'.format(cmd).encode())
+        await self.wait_for_regex_in_line(wait_str)
 
     @property
     @abstractmethod
@@ -53,7 +89,7 @@ class Board(ABC):
         pass
 
     @abstractmethod
-    def reset(self):
+    async def reset(self):
         pass
 
     @abstractmethod
@@ -61,9 +97,9 @@ class Board(ABC):
         pass
 
     @abstractmethod
-    def set_wifi_credentials(self, ssid, psk):
+    async def set_wifi_credentials(self, ssid, psk):
         pass
 
     @abstractmethod
-    def set_golioth_psk_credentials(self, psk_id, psk):
+    async def set_golioth_psk_credentials(self, psk_id, psk):
         pass

--- a/tests/hil/scripts/pytest-hil/espidfboard.py
+++ b/tests/hil/scripts/pytest-hil/espidfboard.py
@@ -14,16 +14,16 @@ class ESPIDFBoard(ESPBoard):
     def USES_WIFI(self):
         return True
 
-    def set_setting(self, key, value):
-        self.send_cmd(f'settings set {key} {value}', wait_str='saved')
+    async def set_setting(self, key, value):
+        await self.send_cmd(f'settings set {key} {value}', wait_str='saved')
 
-    def reset(self):
-        self.send_cmd('reset', wait_str='Calling app_main*()')
+    async def reset(self):
+        await self.send_cmd('reset', wait_str='Calling app_main*()')
 
-    def set_wifi_credentials(self, ssid, psk):
-        self.set_setting('wifi/ssid', f'"{ssid}"')
-        self.set_setting('wifi/psk', f'"{psk}"')
+    async def set_wifi_credentials(self, ssid, psk):
+        await self.set_setting('wifi/ssid', f'"{ssid}"')
+        await self.set_setting('wifi/psk', f'"{psk}"')
 
-    def set_golioth_psk_credentials(self, psk_id, psk):
-        self.set_setting('golioth/psk-id', f'"{psk_id}"')
-        self.set_setting('golioth/psk', f'"{psk}"')
+    async def set_golioth_psk_credentials(self, psk_id, psk):
+        await self.set_setting('golioth/psk-id', f'"{psk_id}"')
+        await self.set_setting('golioth/psk', f'"{psk}"')

--- a/tests/hil/scripts/pytest-hil/linuxboard.py
+++ b/tests/hil/scripts/pytest-hil/linuxboard.py
@@ -1,50 +1,34 @@
-import atexit
-import re
-import select
+from contextlib import asynccontextmanager
+from functools import partial
 import subprocess
-from time import time
+
+import trio
 
 from board import Board
+
 
 class LinuxBoard(Board):
     def __init__(self, fw_image):
         self.binary = fw_image
-        self.rcvd_lines = []
+        self.received = b''
+        self.nursery: trio.Nursery | None = None
+        self.process: trio.Process | None = None
 
-    def wait_for_regex_in_line(self, regex, timeout_s=20, log=True):
-        start_time = time()
-        while True:
-            # Check for timeout
-            if time() - start_time > timeout_s:
-                raise RuntimeError('Timeout')
+    @asynccontextmanager
+    async def started(self):
+        async with trio.open_nursery() as nursery:
+            self.nursery = nursery
 
-            # Read input. We use communicate() because the other read
-            # read functions for pipes don't have timeouts, and poll()
-            # doesn't tell us how many lines (or bytes) are available to
-            # read. communicate() runs until the program terminates, so
-            # we use a short timeout to prevent blocking. The output
-            # received during the call is contained in the exception.
-            try:
-                self.process.communicate(timeout=0.1)
-            except subprocess.TimeoutExpired as e:
-                if e.output == None:
-                    continue
-                lines = e.output.decode("UTF-8")
+            yield self
 
-            for line in lines.splitlines():
-                # When communicate() times out, it leaves the data intact
-                # in the pipe, so we need to do our own filtering for
-                # repeated lines
-                if line in self.rcvd_lines:
-                    continue
-                self.rcvd_lines.append(line)
+            if self.process:
+                self.process.terminate()
 
-                if line != "" and log:
-                    print(f"time: {time()} log: {line}")
+    async def receive_some(self) -> bytes:
+        assert self.process is not None
+        assert self.process.stdout is not None
 
-                regex_search=re.search(regex, line)
-                if regex_search:
-                    return regex_search
+        return await self.process.stdout.receive_some()
 
     @property
     def PROMPT(self):
@@ -54,19 +38,19 @@ class LinuxBoard(Board):
     def USES_WIFI(self):
         return False
 
-    def set_setting(self, key, value):
+    async def set_setting(self, key, value):
         pass
 
-    def reset(self):
+    async def reset(self):
         pass
 
     def program(self):
         pass
 
-    def set_wifi_credentials(self, ssid, psk):
+    async def set_wifi_credentials(self, ssid, psk):
         pass
 
-    def set_golioth_psk_credentials(self, psk_id, psk):
+    async def set_golioth_psk_credentials(self, psk_id, psk):
         self.golioth_psk_id = psk_id
         self.golioth_psk = psk
 
@@ -75,11 +59,7 @@ class LinuxBoard(Board):
             "GOLIOTH_PSK" : self.golioth_psk
         }
 
-        self.process = subprocess.Popen(["stdbuf", "-o0", self.binary],
-                                        stdout=subprocess.PIPE,
-                                        bufsize=1,
-                                        universal_newlines=True,
-                                        env=env)
-
-        # Register atexit() handler to kill test program
-        atexit.register(self.process.terminate)
+        self.process = await self.nursery.start(partial(trio.run_process,
+                                                        ["stdbuf", "-o0", self.binary],
+                                                        stdout=subprocess.PIPE,
+                                                        env=env))

--- a/tests/hil/scripts/pytest-hil/ncsboard.py
+++ b/tests/hil/scripts/pytest-hil/ncsboard.py
@@ -1,5 +1,5 @@
 from zephyrboard import ZephyrBoard
 
 class NCSBoard(ZephyrBoard):
-    def reset(self):
-        self.send_cmd('kernel reboot cold', wait_str='Booting nRF Connect SDK')
+    async def reset(self):
+        await self.send_cmd('kernel reboot cold', wait_str='Booting nRF Connect SDK')

--- a/tests/hil/scripts/pytest-hil/plugin.py
+++ b/tests/hil/scripts/pytest-hil/plugin.py
@@ -50,20 +50,23 @@ def wifi_psk(request):
     return request.config.getoption("--wifi-psk")
 
 @pytest.fixture(scope="module")
-def board(board_name, port, baud, wifi_ssid, wifi_psk, fw_image, serial_number):
+async def board(board_name, port, baud, wifi_ssid, wifi_psk, fw_image, serial_number):
     if (board_name.lower() == "esp32s3_devkitc_espidf" or
         board_name.lower() == "esp32c3_devkitm_espidf" or
         board_name.lower() == "esp32_devkitc_wrover_espidf"):
-        return ESPIDFBoard(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
+        board = ESPIDFBoard(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     elif board_name.lower() == "esp32_devkitc_wrover":
-        return ESP32DevKitCWROVER(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
+        board = ESP32DevKitCWROVER(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     elif board_name.lower() == "nrf52840dk":
-        return nRF52840DK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
+        board = nRF52840DK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     elif board_name.lower() == "nrf9160dk":
-        return nRF9160DK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
+        board = nRF9160DK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     elif board_name.lower() == "mimxrt1024_evk":
-        return MIMXRT1024EVK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
+        board = MIMXRT1024EVK(port, baud, wifi_ssid, wifi_psk, fw_image, serial_number)
     elif board_name.lower() == "linux":
-        return LinuxBoard(fw_image)
+        board = LinuxBoard(fw_image)
     else:
         raise ValueError("Unknown board")
+
+    async with board.started():
+        yield board

--- a/tests/hil/scripts/pytest-hil/pyproject.toml
+++ b/tests/hil/scripts/pytest-hil/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   'pynrfjprog',
   'pyserial',
   'PyYAML',
+  'trio-serial',
 ]
 classifiers = [
     "Framework :: Pytest",

--- a/tests/hil/scripts/pytest-hil/zephyrboard.py
+++ b/tests/hil/scripts/pytest-hil/zephyrboard.py
@@ -5,16 +5,16 @@ class  ZephyrBoard(Board):
     def PROMPT(self):
         return 'uart:'
 
-    def set_setting(self, key, value):
-        self.send_cmd(f'settings set {key} {value}', wait_str='saved')
+    async def set_setting(self, key, value):
+        await self.send_cmd(f'settings set {key} {value}', wait_str='saved')
 
-    def reset(self):
-        self.send_cmd('kernel reboot cold', wait_str='Booting Zephyr OS')
+    async def reset(self):
+        await self.send_cmd('kernel reboot cold', wait_str='Booting Zephyr OS')
 
-    def set_wifi_credentials(self, ssid, psk):
-        self.set_setting('wifi/ssid', f'"{ssid}"')
-        self.set_setting('wifi/psk', f'"{psk}"')
+    async def set_wifi_credentials(self, ssid, psk):
+        await self.set_setting('wifi/ssid', f'"{ssid}"')
+        await self.set_setting('wifi/psk', f'"{psk}"')
 
-    def set_golioth_psk_credentials(self, psk_id, psk):
-        self.set_setting('golioth/psk-id', f'"{psk_id}"')
-        self.set_setting('golioth/psk', f'"{psk}"')
+    async def set_golioth_psk_credentials(self, psk_id, psk):
+        await self.set_setting('golioth/psk-id', f'"{psk_id}"')
+        await self.set_setting('golioth/psk', f'"{psk}"')

--- a/tests/hil/tests/connection/test_connection.py
+++ b/tests/hil/tests/connection/test_connection.py
@@ -5,17 +5,17 @@ pytestmark = pytest.mark.anyio
 async def test_connect(board, device):
     # Set Golioth credentials
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Confirm connection to Golioth
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+    assert None != await board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 
     # Wait for reconnection after golioth_client_stop();
-    assert None != board.wait_for_regex_in_line('Stopping client', timeout_s=15)
-    assert None != board.wait_for_regex_in_line('Starting client', timeout_s=120)
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+    assert None != await board.wait_for_regex_in_line('Stopping client', timeout_s=15)
+    assert None != await board.wait_for_regex_in_line('Starting client', timeout_s=120)
+    assert None != await board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 
     # Wait for reconnection after golioth_client_destroy();
-    assert None != board.wait_for_regex_in_line('Destroying client', timeout_s=15)
-    assert None != board.wait_for_regex_in_line('Starting client', timeout_s=120)
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+    assert None != await board.wait_for_regex_in_line('Destroying client', timeout_s=15)
+    assert None != await board.wait_for_regex_in_line('Starting client', timeout_s=120)
+    assert None != await board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)

--- a/tests/hil/tests/lightdb/test_lightdb.py
+++ b/tests/hil/tests/lightdb/test_lightdb.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.anyio
 async def setup(project, board, device):
     # Set Golioth credentials
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Setup data for replication
     await device.lightdb.delete('hil/lightdb')
@@ -39,10 +39,10 @@ async def setup(project, board, device):
     await device.lightdb.set('hil/lightdb/desired/ready', True)
 
     # Confirm connection to Golioth
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+    assert None != await board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 
     # Give some time to replicate desired state
-    assert None != board.wait_for_regex_in_line('LightDB State reported data is ready', timeout_s=30)
+    assert None != await board.wait_for_regex_in_line('LightDB State reported data is ready', timeout_s=30)
 
     # Give enough time for Golioth backend to propagate data
     await trio.sleep(5)

--- a/tests/hil/tests/rpc/test_rpc.py
+++ b/tests/hil/tests/rpc/test_rpc.py
@@ -7,10 +7,10 @@ pytestmark = pytest.mark.anyio
 async def setup(project, board, device):
     # Set Golioth credentials
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Confirm connection to Golioth
-    assert None != board.wait_for_regex_in_line('RPC observation established', timeout_s=120)
+    assert None != await board.wait_for_regex_in_line('RPC observation established', timeout_s=120)
 
 ##### Tests #####
 
@@ -23,17 +23,17 @@ async def test_not_registered(board, device):
 async def test_no_args(board, device):
     await device.rpc.no_response()
 
-    assert None != board.wait_for_regex_in_line('Received no_response with 0 args', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received no_response with 0 args', timeout_s=10)
 
 async def test_one_arg(board, device):
     await device.rpc.no_response("foo")
 
-    assert None != board.wait_for_regex_in_line('Received no_response with 1 args', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received no_response with 1 args', timeout_s=10)
 
 async def test_many_args(board, device):
     await device.rpc.no_response(1,2,3,4,5,6,7,8,9)
 
-    assert None != board.wait_for_regex_in_line('Received no_response with 9 args', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received no_response with 9 args', timeout_s=10)
 
 async def test_int_return(board, device):
     rsp = await device.rpc.basic_return_type("int")
@@ -75,11 +75,11 @@ async def test_observation_repeat_restart(board, device):
         rsp = await device.rpc.disconnect()
 
         # Confirm re-connection to Golioth
-        assert None != board.wait_for_regex_in_line('RPC observation established', timeout_s=120)
+        assert None != await board.wait_for_regex_in_line('RPC observation established', timeout_s=120)
 
         rsp = await device.rpc.basic_return_type("int")
 
-        assert None != board.wait_for_regex_in_line('Received basic_return_type RPC', timeout_s=10)
+        assert None != await board.wait_for_regex_in_line('Received basic_return_type RPC', timeout_s=10)
 
         assert rsp['value'] == 42
         print(f"Loop {i} successful!")
@@ -87,16 +87,16 @@ async def test_observation_repeat_restart(board, device):
 async def test_observation_cancel_all(board, device):
     rsp = await device.rpc.cancel_all()
 
-    assert None != board.wait_for_regex_in_line('Cancelling observations', timeout_s=10)
-    assert None != board.wait_for_regex_in_line('Observations cancelled', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Cancelling observations', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Observations cancelled', timeout_s=10)
 
     with pytest.raises(RPCTimeout):
         rsp = await device.rpc.basic_return_type("int")
 
-    assert None != board.wait_for_regex_in_line('RPC observation established', timeout_s=30)
+    assert None != await board.wait_for_regex_in_line('RPC observation established', timeout_s=30)
 
     rsp = await device.rpc.basic_return_type("int")
 
-    assert None != board.wait_for_regex_in_line('Received basic_return_type RPC', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received basic_return_type RPC', timeout_s=10)
 
     assert rsp['value'] == 42

--- a/tests/hil/tests/settings/test_settings.py
+++ b/tests/hil/tests/settings/test_settings.py
@@ -36,10 +36,10 @@ async def setup(project, board, device):
 
     # Set Golioth credentials
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Confirm connection to Golioth
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+    assert None != await board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 
 async def assert_settings_error(device, key, error):
     await device.refresh()
@@ -58,7 +58,7 @@ async def assert_settings_error(device, key, error):
 async def test_set_int(board, device):
     await device.settings.set('TEST_INT', 42)
 
-    assert None != board.wait_for_regex_in_line('Received test_int: 42', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_int: 42', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -68,8 +68,8 @@ async def test_set_int(board, device):
 async def test_int_too_large(board, device):
     await device.settings.set('TEST_INT', 2**33)
 
-    with pytest.raises(RuntimeError):
-        board.wait_for_regex_in_line('Received test_int: 8589934592', timeout_s=10)
+    with pytest.raises(trio.TooSlowError):
+        await board.wait_for_regex_in_line('Received test_int: 8589934592', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -79,8 +79,8 @@ async def test_int_too_large(board, device):
 async def test_int_too_small(board, device):
     await device.settings.set('TEST_INT', -1*(2**33))
 
-    with pytest.raises(RuntimeError):
-        board.wait_for_regex_in_line('Received test_int: -8589934592', timeout_s=10)
+    with pytest.raises(trio.TooSlowError):
+        await board.wait_for_regex_in_line('Received test_int: -8589934592', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -90,7 +90,7 @@ async def test_int_too_small(board, device):
 async def test_set_int_range(board, device):
     await device.settings.set('TEST_INT_RANGE', 5)
 
-    assert None != board.wait_for_regex_in_line('Received test_int_range: 5', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_int_range: 5', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -100,7 +100,7 @@ async def test_set_int_range(board, device):
 async def test_set_int_range_min(board, device):
     await device.settings.set('TEST_INT_RANGE', 0)
 
-    assert None != board.wait_for_regex_in_line('Received test_int_range: 0', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_int_range: 0', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -110,7 +110,7 @@ async def test_set_int_range_min(board, device):
 async def test_set_int_range_max(board, device):
     await device.settings.set('TEST_INT_RANGE', 100)
 
-    assert None != board.wait_for_regex_in_line('Received test_int_range: 100', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_int_range: 100', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -120,8 +120,8 @@ async def test_set_int_range_max(board, device):
 async def test_set_int_range_out_min(board, device):
     await device.settings.set('TEST_INT_RANGE', -1)
 
-    with pytest.raises(RuntimeError):
-        board.wait_for_regex_in_line('Received test_int_range: -1', timeout_s=10)
+    with pytest.raises(trio.TooSlowError):
+        await board.wait_for_regex_in_line('Received test_int_range: -1', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -131,8 +131,8 @@ async def test_set_int_range_out_min(board, device):
 async def test_set_int_range_out_max(board, device):
     await device.settings.set('TEST_INT_RANGE', 101)
 
-    with pytest.raises(RuntimeError):
-        assert None != board.wait_for_regex_in_line('Received test_int_range: 101', timeout_s=10)
+    with pytest.raises(trio.TooSlowError):
+        assert None != await board.wait_for_regex_in_line('Received test_int_range: 101', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -142,7 +142,7 @@ async def test_set_int_range_out_max(board, device):
 async def test_set_bool(board, device):
     await device.settings.set('TEST_BOOL', True)
 
-    assert None != board.wait_for_regex_in_line('Received test_bool: true', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_bool: true', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -152,7 +152,7 @@ async def test_set_bool(board, device):
 async def test_set_float(board, device):
     await device.settings.set('TEST_FLOAT', 3.14)
 
-    assert None != board.wait_for_regex_in_line('Received test_float: 3.14', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_float: 3.14', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -162,7 +162,7 @@ async def test_set_float(board, device):
 async def test_set_float_whole(board, device):
     await device.settings.set('TEST_FLOAT', 10)
 
-    assert None != board.wait_for_regex_in_line('Received test_float: 10', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_float: 10', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -172,7 +172,7 @@ async def test_set_float_whole(board, device):
 async def test_set_string(board, device):
     await device.settings.set('TEST_STRING', "bar")
 
-    assert None != board.wait_for_regex_in_line('Received test_string: bar', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_string: bar', timeout_s=10)
 
     # Wait for device to respond to server
     await trio.sleep(1)
@@ -189,43 +189,40 @@ async def test_cancel_all(board, device):
     # Cancel all settings
     await device.settings.set('TEST_CANCEL', True)
 
-    assert None != board.wait_for_regex_in_line('Cancelling settings', timeout_s=10)
-    assert None != board.wait_for_regex_in_line('Settings have been cancelled', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Cancelling settings', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Settings have been cancelled', timeout_s=10)
 
     # Check that we no longer receive this settings change
     await device.settings.set('TEST_INT', 1337)
 
-    with pytest.raises(RuntimeError) as e:
-        assert None != board.wait_for_regex_in_line('Received test_int', timeout_s=10)
-
-    assert str(e.value) == "Timeout"
+    with pytest.raises(trio.TooSlowError) as e:
+        assert None != await board.wait_for_regex_in_line('Received test_int', timeout_s=10)
 
     # Reset to expected value so we don't re-trigger test on settings registration
     await device.settings.set('TEST_CANCEL', False)
 
     # Wait for device to automatically re-register all settings
-    assert None != board.wait_for_regex_in_line('Settings have been reregistered', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Settings have been reregistered', timeout_s=10)
 
     await device.settings.set('TEST_INT', 72)
-    assert None != board.wait_for_regex_in_line('Received test_int: 72', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_int: 72', timeout_s=10)
 
 
 async def test_restart(board, device):
     await device.settings.set('TEST_RESTART', True)
-    assert None != board.wait_for_regex_in_line('Received test_restart: true', timeout_s=10)
-    assert None != board.wait_for_regex_in_line('Ending session', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_restart: true', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Ending session', timeout_s=10)
 
     # Check that we no longer receive this settings change
     await device.settings.set('TEST_RESTART', False)
-    with pytest.raises(RuntimeError) as e:
-        assert None != board.wait_for_regex_in_line('Received test_restart: false', timeout_s=5)
-    assert str(e.value) == "Timeout"
+    with pytest.raises(trio.TooSlowError) as e:
+        assert None != await board.wait_for_regex_in_line('Received test_restart: false', timeout_s=5)
 
     # Wait for client to restart
-    assert None != board.wait_for_regex_in_line('Client restarted', timeout_s=60)
+    assert None != await board.wait_for_regex_in_line('Client restarted', timeout_s=60)
 
     # Wait for rush of initial settings log messages to pass
     await trio.sleep(2)
 
     await device.settings.set('TEST_INT', 2320)
-    assert None != board.wait_for_regex_in_line('Received test_int: 2320', timeout_s=10)
+    assert None != await board.wait_for_regex_in_line('Received test_int: 2320', timeout_s=10)

--- a/tests/hil/tests/stream/test_stream.py
+++ b/tests/hil/tests/stream/test_stream.py
@@ -12,10 +12,10 @@ pytestmark = pytest.mark.anyio
 async def setup(board, device):
     # Set Golioth credentials
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Confirm connection to Golioth
-    assert None != board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+    assert None != await board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
 
 def hash_from_dict(dict_to_hash: dict) -> str:
     str_data = json.dumps(dict_to_hash, sort_keys=True)
@@ -37,7 +37,7 @@ def get_test_data_hash() -> str:
 ##### Tests #####
 
 async def test_block_upload(board, device):
-    assert None != board.wait_for_regex_in_line('Block upload successful', timeout_s=20)
+    assert None != await board.wait_for_regex_in_line('Block upload successful', timeout_s=20)
 
     # Wait for stream to propagate from CDG to LightDB Stream
     await trio.sleep(6)


### PR DESCRIPTION
Use `trio.run_process` to handle subprocess communication with
Linux (virtual) board. This simplifies receiving logic and handling
timeouts. Additionally it gives easier control over sending data to the
target (which was very difficult or impossible with
`subprocess.Popen.communicate()` API).

Use `trio-serial` for non-virtual (real hardware) boards, so the same
API and benefit as `trio.run_process()` gives is utilized for communicating
with them.

Share single `wait_for_regex_in_line()` implementation and just provide
target-specific (serial vs process) `receive_some()` API.