### PR TITLE
ci: catch ram/rom overflow build errors

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -114,10 +114,11 @@ jobs:
               --platform ${{ inputs.west_board }}                             \
               -T modules/lib/golioth-firmware-sdk/examples/zephyr             \
               --prep-artifacts-for-testing                                    \
-              --package-artifacts test_artifacts_${{ inputs.hil_board }}.tar \
+              --package-artifacts test_artifacts_${{ inputs.hil_board }}.tar  \
               $EXTRA_BUILD_ARGS
 
     - name: Save artifacts
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: test_artifacts_${{ inputs.hil_board }}
@@ -125,7 +126,7 @@ jobs:
 
   test:
     name: zephyr-${{ inputs.hil_board }}-twister-run
-    if: ${{ inputs.run_tests }}
+    if: ${{ inputs.run_tests && always() }}
     needs: build
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
     timeout-minutes: 30

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -110,6 +110,7 @@ jobs:
         export EXTRA_BUILD_ARGS=-x=CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"
 
         zephyr/scripts/twister                                                \
+              --overflow-as-errors                                            \
               --platform ${{ inputs.west_board }}                             \
               -T modules/lib/golioth-firmware-sdk/examples/zephyr             \
               --prep-artifacts-for-testing                                    \


### PR DESCRIPTION
By default, Twister marks tests that fail to build due to being out of ROM or RAM as "skipped" instead of "failed". This option was previously enabled for the deprecated "twister-build" workflow in 963df80 but we missed it when creating the current HIL workflow.

This also updates the workflow to run Twister tests even if some of them failed to build. This way, we can get as much information as possible. In particular, for the moment, this allows us to run Twister for ESP32_DevKitC_WROVER on most of the examples while the certificate examples remain broken due to bugs in Zephyr that prevent us from using either the second internal RAM bank or the external SPIRAM.