### PR TITLE
ci: use esptool.py from pip instead of hal_espressif

### DIFF
--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -126,7 +126,7 @@ jobs:
           - hil_board: esp32_devkitc_wrover
             west_board: esp32_devkitc_wrover/esp32/procpu
             manifest: .ci-west-zephyr.yml
-            extra_twister_args: '--flash-before'
+            extra_twister_args: '--flash-before --west-flash=--esp-tool=$(which esptool.py),--esp-device=${!PORT_VAR}'
             binary_blob: hal_espressif
             run_tests: true
 


### PR DESCRIPTION
By default, the esp32 west runner looks in the espressif HAL for the esptool.py script. Because we don't want to checkout the HAL during twister runs in CI (to save time), instead specify the path for esptool.py so that the runner will use the version installed from pip in the Docker container.

Resolves golioth/firmware-issue-tracker#652