### PR TITLE
tests: hil: zephyr: return 0 from main()

### DIFF
--- a/tests/hil/platform/zephyr/src/main.c
+++ b/tests/hil/platform/zephyr/src/main.c
@@ -17,4 +17,6 @@ int main(void)
     net_connect();
 
     hil_test_entry(golioth_sample_credentials_get());
+
+    return 0;
 }


### PR DESCRIPTION
This suppressses warning about missing return statement from non-void
function.