### PR TITLE
Add Allure reports to hil integration tests

### DIFF
--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -104,6 +104,7 @@ jobs:
         env:
           hil_board: ${{ inputs.hil_board }}
         run: |
+          rm -rf allure-reports
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
           for test in `ls tests/hil/tests`
@@ -118,9 +119,19 @@ jobs:
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
               --mask-secrets                                                    \
               --timeout=600                                                     \
+              --alluredir=allure-reports                                        \
+              --platform esp-idf                                                \
+              --runner-name ${{ runner.name }}                                  \
               || EXITCODE=$?
           done
           exit $EXITCODE
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: allure-reports-hil-espidf-${{ inputs.hil_board }}
+          path: allure-reports
+          retention-days: 1
       - name: Erase flash
         if: always()
         shell: bash

--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -63,6 +63,8 @@ jobs:
              --include "*/golioth-firmware-sdk/src/*"
         LCOV_FILES="-a baseline.info"
 
+        rm -rf allure-reports
+
         for test in `ls tests/hil/tests`
         do
           pytest --rootdir . tests/hil/tests/$test      \
@@ -73,6 +75,8 @@ jobs:
             --mask-secrets                              \
             -rP                                         \
             --timeout=600                               \
+            --alluredir=allure-reports                  \
+            --platform linux                            \
             || EXITCODE=$?
           lcov -c                                       \
                --directory build/${test}                \
@@ -104,6 +108,13 @@ jobs:
         echo "$coverage_summary" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
         exit $EXITCODE
+    - name: Upload reports
+      uses: actions/upload-artifact@v4
+      if: ${{ always() }}
+      with:
+        name: allure-reports-hil-linux
+        path: allure-reports
+        retention-days: 1
     - name: Find Comment
       uses: peter-evans/find-comment@v3
       if: github.event_name == 'pull_request'

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -140,6 +140,7 @@ jobs:
         env:
           hil_board: ${{ inputs.hil_board }}
         run: |
+          rm -rf allure-reports
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
           SNR_VAR=CI_${hil_board^^}_SNR
@@ -156,9 +157,19 @@ jobs:
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
               --mask-secrets                                                    \
               --timeout=600                                                     \
+              --alluredir=allure-reports                                        \
+              --platform zephyr                                                 \
+              --runner-name ${{ runner.name }}                                  \
               || EXITCODE=$?
           done
           exit $EXITCODE
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: allure-reports-hil-zephyr-${{ inputs.hil_board }}
+          path: allure-reports
+          retention-days: 1
       - name: Erase flash
         if: always()
         shell: bash

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -328,3 +328,28 @@ jobs:
       api-key-id: ${{ inputs.api-key-id }}
       coap_gateway_url: ${{ inputs.coap_gateway_url }}
     secrets: inherit
+
+  merge_reports:
+    runs-on: ubuntu-latest
+    needs:
+      - hil_sample_esp-idf
+      - hil_sample_zephyr
+      - hil_sample_zephyr_nsim
+      - hil_test_esp-idf
+      - hil_test_linux
+      - hil_test_zephyr
+
+    if: ${{ always() }}
+    steps:
+    - name: Gather reports
+      uses: actions/download-artifact@v4
+      with:
+        path: allure-reports
+        pattern: allure-reports-*
+        merge-multiple: true
+
+    - name: Upload reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: allure-reports-alltest
+        path: allure-reports

--- a/tests/hil/scripts/pytest-hil/pyproject.toml
+++ b/tests/hil/scripts/pytest-hil/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "pytest-hil"
 version = "0.1.0"
 dependencies = [
+  'allure-pytest',
   'esptool',
   'pylink-square',
   'pynrfjprog',


### PR DESCRIPTION
- Add Allure report fixtures to the pytest plugin used for our HIL integration testing
- Add pytest options to generate Allure report on each HIL integration workflow
- Gather reports from all workflows into a single archive. This archive uses the normal retention policy, while the individual files uses a 1 day retention as they are also present in  the single archive.

## Known Issues

- If the board fixture fails, all subsequent test cases will not be categorized by the board-name but instead be shown in Allure as the generic path to the test directory. I've opened [a separate ticket](https://github.com/golioth/firmware-issue-tracker/issues/665) to track this issue.

resolves https://github.com/golioth/firmware-issue-tracker/issues/580