### PR TITLE
Add pytest-zephyr-samples plugin

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -164,6 +164,7 @@ jobs:
           pip3 install -r zephyr/scripts/requirements-build-test.txt
           pip3 install -r zephyr/scripts/requirements-run-test.txt
 
+          pip3 install tests/hil/scripts/pytest-zephyr-samples
           pip3 install git+https://github.com/golioth/python-golioth-tools@v0.6.3
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -212,6 +212,7 @@ jobs:
           pip3 install -r zephyr/scripts/requirements-build-test.txt
           pip3 install -r zephyr/scripts/requirements-run-test.txt
 
+          pip3 install modules/lib/golioth-firmware-sdk/tests/hil/scripts/pytest-zephyr-samples
           pip3 install git+https://github.com/golioth/python-golioth-tools@v0.6.3
 
       - name: Run tests

--- a/examples/zephyr/certificate_provisioning/pytest/conftest.py
+++ b/examples/zephyr/certificate_provisioning/pytest/conftest.py
@@ -14,8 +14,6 @@ WEST_TOPDIR = Path(west.configuration.west_dir()).parent
 def pytest_addoption(parser):
     parser.addoption("--device-port", type=str,
                      help="Device serial port path")
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 def get_device_port(request):
     if request.config.getoption("--device-port") is not None:
@@ -63,17 +61,3 @@ async def device_name(project):
         await project.delete_device_by_name(name)
     except:
         pass
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/fw_update/pytest/conftest.py
+++ b/examples/zephyr/fw_update/pytest/conftest.py
@@ -7,8 +7,6 @@ UPDATE_PACKAGE = 'main'
 
 
 def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
     parser.addoption("--west-board", type=str,
                      help="Name of the board as specified in the Zephyr tree")
 
@@ -16,20 +14,6 @@ def pytest_addoption(parser):
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')
 
 @pytest.fixture(scope="session")
 def west_board(request):

--- a/examples/zephyr/hello/pytest/conftest.py
+++ b/examples/zephyr/hello/pytest/conftest.py
@@ -1,24 +1,5 @@
-import os
 import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/hello_nrf91_offloaded/pytest/conftest.py
+++ b/examples/zephyr/hello_nrf91_offloaded/pytest/conftest.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import sys
 
@@ -8,10 +7,6 @@ import pytest
 WEST_TOPDIR = Path(west.configuration.west_dir()).parent
 sys.path.insert(0, str(WEST_TOPDIR / 'zephyr' / 'scripts' / 'west_commands'))
 from runners.core import BuildConfiguration
-
-def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():

--- a/examples/zephyr/lightdb/delete/pytest/conftest.py
+++ b/examples/zephyr/lightdb/delete/pytest/conftest.py
@@ -1,24 +1,5 @@
-import os
 import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/lightdb/get/pytest/conftest.py
+++ b/examples/zephyr/lightdb/get/pytest/conftest.py
@@ -1,24 +1,5 @@
-import os
 import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/lightdb/observe/pytest/conftest.py
+++ b/examples/zephyr/lightdb/observe/pytest/conftest.py
@@ -1,24 +1,5 @@
-import os
 import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/lightdb/set/pytest/conftest.py
+++ b/examples/zephyr/lightdb/set/pytest/conftest.py
@@ -1,24 +1,5 @@
-import os
 import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/logging/pytest/conftest.py
+++ b/examples/zephyr/logging/pytest/conftest.py
@@ -1,24 +1,5 @@
-import os
 import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/rpc/pytest/conftest.py
+++ b/examples/zephyr/rpc/pytest/conftest.py
@@ -1,24 +1,5 @@
-import os
 import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/settings/pytest/conftest.py
+++ b/examples/zephyr/settings/pytest/conftest.py
@@ -1,24 +1,5 @@
-import os
 import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')

--- a/examples/zephyr/stream/pytest/conftest.py
+++ b/examples/zephyr/stream/pytest/conftest.py
@@ -1,24 +1,5 @@
-import os
 import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--wifi-ssid", type=str, help="WiFi SSID")
-    parser.addoption("--wifi-psk",  type=str, help="WiFi PSK")
 
 @pytest.fixture(scope='session')
 def anyio_backend():
     return 'trio'
-
-@pytest.fixture(scope="session")
-def wifi_ssid(request):
-    if request.config.getoption("--wifi-ssid") is not None:
-        return request.config.getoption("--wifi-ssid")
-    else:
-        return os.environ.get('WIFI_SSID')
-
-@pytest.fixture(scope="session")
-def wifi_psk(request):
-    if request.config.getoption("--wifi-psk") is not None:
-        return request.config.getoption("--wifi-psk")
-    else:
-        return os.environ.get('WIFI_PSK')

--- a/tests/hil/scripts/pytest-zephyr-samples/plugin.py
+++ b/tests/hil/scripts/pytest-zephyr-samples/plugin.py
@@ -1,0 +1,20 @@
+import pytest
+import os
+
+def pytest_addoption(parser):
+    parser.addoption("--wifi-ssid",   type=str, help="WiFi SSID")
+    parser.addoption("--wifi-psk",    type=str, help="WiFi PSK")
+
+@pytest.fixture(scope="session")
+def wifi_ssid(request):
+    if request.config.getoption("--wifi-ssid") is not None:
+        return request.config.getoption("--wifi-ssid")
+    else:
+        return os.environ.get('WIFI_SSID')
+
+@pytest.fixture(scope="session")
+def wifi_psk(request):
+    if request.config.getoption("--wifi-psk") is not None:
+        return request.config.getoption("--wifi-psk")
+    else:
+        return os.environ.get('WIFI_PSK')

--- a/tests/hil/scripts/pytest-zephyr-samples/pyproject.toml
+++ b/tests/hil/scripts/pytest-zephyr-samples/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["hatchling>=1.19"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pytest-zephyr-samples"
+version = "0.1.0"
+classifiers = [
+    "Framework :: Pytest",
+]
+
+[tool.hatch.build.targets.wheel]
+include = [ "*.py" ]
+
+[project.entry-points.pytest11]
+zephyr-samples = "plugin"


### PR DESCRIPTION
This plug allows common options like WiFi credentials to be added to pytest from a central location rather than doing so in  every sample's contest.py file.

This plugin will be extended to add Allure reports to the samples in an upcoming PR.