### PR TITLE
Add Allure reports to Zephyr twister tests

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -181,6 +181,7 @@ jobs:
           hil_board: ${{ inputs.hil_board }}
           west_board: ${{ inputs.west_board }}
         run: |
+          rm -rf allure-reports
           source /opt/credentials/runner_env.sh
           export PATH=$PATH:/opt/SEGGER/JLink
           export PATH=$PATH:/usr/local/go/bin
@@ -199,6 +200,9 @@ jobs:
                 --pytest-args="--wifi-ssid=${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}"  \
                 --pytest-args="--wifi-psk=${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}"    \
                 --pytest-args="--mask-secrets"                                                    \
+                --pytest-args="--alluredir=allure-reports"                                        \
+                --pytest-args="--runner-name=${{ runner.name }}"                                  \
+                --pytest-args="--hil-board=${{ inputs.hil_board }}"                               \
                 -v
 
       - name: Mask secrets in logs
@@ -219,6 +223,14 @@ jobs:
             twister-out/**/report.xml
             twister-out/*.xml
             twister-out/*.json
+
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: allure-reports-samples-zephyr-${{ inputs.hil_board }}
+          path: allure-reports
+          retention-days: 1
 
       - name: Erase flash
         if: always()

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -217,6 +217,7 @@ jobs:
 
       - name: Run tests
         run: |
+          rm -rf allure-reports
           zephyr/scripts/twister                                                    \
               --platform ${{ matrix.west_board }}                                   \
               -T modules/lib/golioth-firmware-sdk/examples/zephyr                   \
@@ -225,7 +226,10 @@ jobs:
               -x=CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"    \
               --pytest-args="--api-url=${{ inputs.api-url }}"                       \
               --pytest-args="--api-key=${{ secrets[inputs.api-key-id] }}"           \
-              --pytest-args="--mask-secrets"
+              --pytest-args="--mask-secrets"                                        \
+              --pytest-args="--alluredir=allure-reports"                            \
+              --pytest-args="--runner-name=${{ runner.name }}"                      \
+              --pytest-args="--hil-board=${{ matrix.artifact_suffix }}"
 
       - name: Mask secrets in logs
         id: mask-logs
@@ -247,6 +251,14 @@ jobs:
             twister-out/**/report.xml
             twister-out/*.xml
             twister-out/*.json
+
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: allure-reports-samples-zephyr-${{ matrix.artifact_suffix }}
+          path: allure-reports
+          retention-days: 1
 
   hil_sample_zephyr_nsim_coverage:
     runs-on: ubuntu-latest

--- a/tests/hil/scripts/pytest-zephyr-samples/plugin.py
+++ b/tests/hil/scripts/pytest-zephyr-samples/plugin.py
@@ -1,9 +1,12 @@
 import pytest
+import allure
 import os
 
 def pytest_addoption(parser):
     parser.addoption("--wifi-ssid",   type=str, help="WiFi SSID")
     parser.addoption("--wifi-psk",    type=str, help="WiFi PSK")
+    parser.addoption("--hil-board",   type=str, help="Simple board name")
+    parser.addoption("--runner-name", type=str, help="Self-hosted runner name")
 
 @pytest.fixture(scope="session")
 def wifi_ssid(request):
@@ -18,3 +21,33 @@ def wifi_psk(request):
         return request.config.getoption("--wifi-psk")
     else:
         return os.environ.get('WIFI_PSK')
+
+@pytest.fixture(scope="session")
+def hil_board(request):
+    if request.config.getoption("--hil-board") is not None:
+        return request.config.getoption("--hil-board")
+    else:
+        return os.environ['hil_board']
+
+@pytest.fixture(scope="session")
+def runner_name(request):
+    return request.config.getoption("--runner-name")
+
+@pytest.fixture(autouse=True, scope="session")
+def add_allure_report_parent_suite(hil_board):
+    # Set the full Allure suite name in case there is a failure during a fixture (before a test
+    # function runs).
+    allure.dynamic.parent_suite(f"hil.zephyr.{hil_board}")
+
+@pytest.fixture(autouse=True, scope="function")
+def add_allure_report_device_and_platform(hil_board, runner_name):
+    # Set the Allure information for every test function.
+    # Especially important are the parameters which identify variants of the same test
+    allure.dynamic.tag(hil_board)
+    allure.dynamic.tag("zephyr")
+    allure.dynamic.parameter("board_name", hil_board)
+    allure.dynamic.parameter("platform_name", "zephyr")
+    allure.dynamic.parent_suite(f"hil.zephyr.{hil_board}")
+
+    if runner_name is not None:
+        allure.dynamic.tag(runner_name)

--- a/tests/hil/scripts/pytest-zephyr-samples/pyproject.toml
+++ b/tests/hil/scripts/pytest-zephyr-samples/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "hatchling.build"
 [project]
 name = "pytest-zephyr-samples"
 version = "0.1.0"
+dependencies = [
+  'allure-pytest',
+]
 classifiers = [
     "Framework :: Pytest",
 ]


### PR DESCRIPTION
Add Allure reports fixture to the pytest-zephyr-samples plugin so that reports are generated for all Twister tests.

#592 adds a workflow job that gathers individual reports from each job. That  will also gather these Zephyr sample reports once it and this PR are on main.

Depends on #593 
Resolved  https://github.com/golioth/firmware-issue-tracker/issues/660