### PR TITLE
examples: esp_idf: await for coroutines

### DIFF
--- a/examples/esp_idf/fw_update/pytest/test_sample.py
+++ b/examples/esp_idf/fw_update/pytest/test_sample.py
@@ -17,17 +17,17 @@ async def test_fw_update(board, project, device, fw_info, release):
     # Wait for app to start running or 10 seconds to pass so runtime settings are ready.
 
     try:
-        board.wait_for_regex_in_line('.*Start FW Update sample.', timeout_s=10.0)
+        await board.wait_for_regex_in_line('.*Start FW Update sample.', timeout_s=10.0)
     except:
         pass
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Wait for first manifest to arrive (no update expected)
 
-    board.wait_for_regex_in_line('.*Nothing to do.', timeout_s=90.0)
+    await board.wait_for_regex_in_line('.*Nothing to do.', timeout_s=90.0)
 
     # Rollout the release
 
@@ -35,19 +35,19 @@ async def test_fw_update(board, project, device, fw_info, release):
 
     # Monitor block download and watch for reboot after update
 
-    board.wait_for_regex_in_line('.*Received block.', timeout_s=90.0)
+    await board.wait_for_regex_in_line('.*Received block.', timeout_s=90.0)
     LOGGER.info("Block download has begun!")
 
-    board.wait_for_regex_in_line('.*Rebooting into new image.', timeout_s=600.0)
+    await board.wait_for_regex_in_line('.*Rebooting into new image.', timeout_s=600.0)
     LOGGER.info("Download complete, restarting to perform update.")
 
     # Test for board to run new firmware and report to Golioth
 
-    board.wait_for_regex_in_line('.*Current firmware version: main - 255.8.9.',
+    await board.wait_for_regex_in_line('.*Current firmware version: main - 255.8.9.',
                                   timeout_s=120.0)
     LOGGER.info("Device reported expected update version")
 
-    board.wait_for_regex_in_line('.*Nothing to do.', timeout_s=30.0)
+    await board.wait_for_regex_in_line('.*Nothing to do.', timeout_s=30.0)
     LOGGER.info("Device received manifest confirming successful upgrade.")
 
     # Check cloud for reported firmware version

--- a/examples/esp_idf/hello/pytest/test_sample.py
+++ b/examples/esp_idf/hello/pytest/test_sample.py
@@ -14,11 +14,11 @@ pytestmark = pytest.mark.anyio
 async def test_hello(board, device):
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Record timestamp and wait for fourth hello message
     start = datetime.datetime.utcnow()
-    board.wait_for_regex_in_line('.*Sending hello! 3', timeout_s=90.0)
+    await board.wait_for_regex_in_line('.*Sending hello! 3', timeout_s=90.0)
 
     # Check logs for hello messages
     end = datetime.datetime.utcnow()

--- a/examples/esp_idf/lightdb/delete/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/delete/pytest/test_sample.py
@@ -30,14 +30,14 @@ async def test_lightdb_delete(board, device):
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Wait for device to connect
-    board.wait_for_regex_in_line(r'.*Golioth client connected', timeout_s=30.0)
+    await board.wait_for_regex_in_line(r'.*Golioth client connected', timeout_s=30.0)
 
     # Verify lightdb delete (async)
 
-    board.wait_for_regex_in_line(r'.*Counter deleted successfully', timeout_s=10.0)
+    await board.wait_for_regex_in_line(r'.*Counter deleted successfully', timeout_s=10.0)
     counter = await device.lightdb.get("counter")
     assert counter is None
 
@@ -47,11 +47,11 @@ async def test_lightdb_delete(board, device):
 
     # Verify lightdb delete (sync)
 
-    board.wait_for_regex_in_line(r'.*Counter deleted successfully', timeout_s=10.0)
+    await board.wait_for_regex_in_line(r'.*Counter deleted successfully', timeout_s=10.0)
     counter = await device.lightdb.get("counter")
     if counter is not None:
         # Try again, since previous counter value might get reassigned in counter_set_and_verify()
-        board.wait_for_regex_in_line(r'.*Counter deleted successfully', timeout_s=10.0)
+        await board.wait_for_regex_in_line(r'.*Counter deleted successfully', timeout_s=10.0)
         await trio.sleep(2)
         counter = await device.lightdb.get("counter")
 

--- a/examples/esp_idf/lightdb/get/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/get/pytest/test_sample.py
@@ -20,28 +20,28 @@ async def test_lightdb_get(board, device):
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Wait for device to connect
-    board.wait_for_regex_in_line(r'.*Golioth client connected', timeout_s=30.0)
+    await board.wait_for_regex_in_line(r'.*Golioth client connected', timeout_s=30.0)
 
     # Verify lightdb reads
 
-    board.wait_for_regex_in_line(r'.*Failed to get counter \(async\): 0', timeout_s=10.0)
+    await board.wait_for_regex_in_line(r'.*Failed to get counter \(async\): 0', timeout_s=10.0)
 
     await device.lightdb.set("counter", 13)
 
-    board.wait_for_regex_in_line(r'.*Counter \(sync\): 13', timeout_s=10.0)
+    await board.wait_for_regex_in_line(r'.*Counter \(sync\): 13', timeout_s=10.0)
 
     await device.lightdb.set("counter", 27)
 
-    board.wait_for_regex_in_line(r'.*7b 22 63 6f 75 6e 74 65  72 22 3a 32 37 7d       |{\"counte r\":27}',
+    await board.wait_for_regex_in_line(r'.*7b 22 63 6f 75 6e 74 65  72 22 3a 32 37 7d       |{\"counte r\":27}',
                                   timeout_s=10.0)
 
     await device.lightdb.set("counter", 99)
 
-    board.wait_for_regex_in_line(r'.*Counter \(CBOR async\): 99', timeout_s=10.0)
+    await board.wait_for_regex_in_line(r'.*Counter \(CBOR async\): 99', timeout_s=10.0)
 
     await device.lightdb.set("counter", 42)
 
-    board.wait_for_regex_in_line(r'.*Counter \(async\): 42', timeout_s=10.0)
+    await board.wait_for_regex_in_line(r'.*Counter \(async\): 42', timeout_s=10.0)

--- a/examples/esp_idf/lightdb/observe/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/observe/pytest/test_sample.py
@@ -21,15 +21,15 @@ async def test_lightdb_observe(board, device):
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Wait for device to connect
-    board.wait_for_regex_in_line('.*Golioth client connected', timeout_s=30.0)
+    await board.wait_for_regex_in_line('.*Golioth client connected', timeout_s=30.0)
 
     await trio.sleep(2)
 
     pattern = re.compile(r'.*6e 75 6c 6c\s+\|null')
-    success_pattern = board.wait_for_regex_in_line(pattern, timeout_s=10.0)
+    success_pattern = await board.wait_for_regex_in_line(pattern, timeout_s=10.0)
     if success_pattern:
         print("Success for pattern '6e 75 6c 6c |null'")
 
@@ -38,6 +38,6 @@ async def test_lightdb_observe(board, device):
     await trio.sleep(2)
 
     pattern = re.compile(r'.*38 37\s+\|87')
-    success_pattern = board.wait_for_regex_in_line(pattern, timeout_s=10.0)
+    success_pattern = await board.wait_for_regex_in_line(pattern, timeout_s=10.0)
     if success_pattern:
         print("Success for pattern '38 37 |87'")

--- a/examples/esp_idf/lightdb/set/pytest/test_sample.py
+++ b/examples/esp_idf/lightdb/set/pytest/test_sample.py
@@ -21,17 +21,17 @@ async def test_lightdb_set(board, device):
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Wait for device to connect
-    board.wait_for_regex_in_line('.*Golioth client connected', timeout_s=30.0)
+    await board.wait_for_regex_in_line('.*Golioth client connected', timeout_s=30.0)
 
     # Verify lightdb writes
 
     for i in range(0,4):
         pattern = re.compile(fr"Setting counter to {i}")
-        board.wait_for_regex_in_line(pattern, timeout_s=30.0)
-        board.wait_for_regex_in_line('Counter successfully set', timeout_s=5.0)
+        await board.wait_for_regex_in_line(pattern, timeout_s=30.0)
+        await board.wait_for_regex_in_line('Counter successfully set', timeout_s=5.0)
 
         for _ in range(3):
             counter = await device.lightdb.get("counter")

--- a/examples/esp_idf/rpc/pytest/test_sample.py
+++ b/examples/esp_idf/rpc/pytest/test_sample.py
@@ -13,10 +13,10 @@ pytestmark = pytest.mark.anyio
 async def test_rpc(board, device):
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Wait for device to reboot and connect
-    board.wait_for_regex_in_line('.*RPC observation established', timeout_s=90.0)
+    await board.wait_for_regex_in_line('.*RPC observation established', timeout_s=90.0)
 
     # Test successful RPC
     result = await device.rpc.call("multiply", [ 7, 6 ])

--- a/examples/esp_idf/settings/pytest/test_sample.py
+++ b/examples/esp_idf/settings/pytest/test_sample.py
@@ -27,16 +27,16 @@ async def test_settings(board, project, device):
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Reset board
-    board.reset()
+    await board.reset()
 
     # Wait for device to reboot and connect
-    board.wait_for_regex_in_line(r'.*Golioth client connected', timeout_s=30.0)
+    await board.wait_for_regex_in_line(r'.*Golioth client connected', timeout_s=30.0)
 
     # Set device-level setting
 
     await device.settings.set('LOOP_DELAY_S', 5)
 
-    board.wait_for_regex_in_line(r'.*Setting loop delay to 5 s', timeout_s=5.0)
+    await board.wait_for_regex_in_line(r'.*Setting loop delay to 5 s', timeout_s=5.0)

--- a/examples/esp_idf/stream/pytest/test_sample.py
+++ b/examples/esp_idf/stream/pytest/test_sample.py
@@ -17,10 +17,10 @@ async def test_stream(board, device):
 
     # Set Golioth credential
     golioth_cred = (await device.credentials.list())[0]
-    board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
+    await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Wait for device to connect
-    board.wait_for_regex_in_line('.*Golioth client connected', timeout_s=30.0)
+    await board.wait_for_regex_in_line('.*Golioth client connected', timeout_s=30.0)
 
     # Verify temp messages
 


### PR DESCRIPTION
This fixes commit 4aa8eb0ff883 ("tests: hil: use async to communicate with
HIL"), which converted some APIs to coroutines.

Fixes: 4aa8eb0ff883 ("tests: hil: use async to communicate with HIL")