### PR TITLE
Publish Allure reports to GitHub pages

### DIFF
--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -456,8 +456,7 @@ jobs:
       coap_gateway_url: ${{ inputs.coap_gateway_url }}
     secrets: inherit
 
-  merge_reports:
-    runs-on: ubuntu-latest
+  process_allure_reports:
     needs:
       - hil_sample_esp-idf
       - hil_sample_zephyr
@@ -465,21 +464,9 @@ jobs:
       - hil_test_esp-idf
       - hil_test_linux
       - hil_test_zephyr
-
-    if: ${{ always() }}
-    steps:
-    - name: Gather reports
-      uses: actions/download-artifact@v4
-      with:
-        path: allure-reports
-        pattern: allure-reports-*
-        merge-multiple: true
-
-    - name: Upload reports
-      uses: actions/upload-artifact@v4
-      with:
-        name: allure-reports-alltest
-        path: allure-reports
+    if: ${{ !cancelled() }}
+    uses: ./.github/workflows/reports-allure-publish.yml
+    secrets: inherit
 
   publish_summary:
     runs-on: ubuntu-latest

--- a/.github/workflows/reports-allure-publish.yml
+++ b/.github/workflows/reports-allure-publish.yml
@@ -1,0 +1,49 @@
+name: Publish Allure Reports to GitHub Pages
+
+on:
+  workflow_call:
+
+jobs:
+  allure-collect-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load Allure report history
+        uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          repository: golioth/allure-reports
+          ref: gh-pages
+          path: gh-pages
+          ssh-key: ${{ secrets.ALLURE_REPORTS_DEPLOY_KEY }}
+
+      - name: Collect individual reports
+        uses: actions/download-artifact@v4
+        with:
+          path: reports/allure-results
+          pattern: allure-reports-*
+          merge-multiple: true
+
+      - name: Upload collected reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-reports-alltest
+          path: reports/allure-results
+
+      - name: Build Allure report
+        uses: simple-elf/allure-report-action@v1.9
+        if: always()
+        with:
+          gh_pages: gh-pages
+          allure_history: reports/allure-history
+          allure_results: reports/allure-results
+          github_repo: golioth/allure-reports
+          github_repo_owner: golioth
+
+      - name: Publish test report
+        uses: peaceiris/actions-gh-pages@v4
+        if: always()
+        with:
+          deploy_key: ${{ secrets.ALLURE_REPORTS_DEPLOY_KEY }}
+          external_repository: golioth/allure-reports
+          publish_branch: gh-pages
+          publish_dir: reports/allure-history

--- a/.github/workflows/reports-allure-publish.yml
+++ b/.github/workflows/reports-allure-publish.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   allure-collect-and-publish:
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish_allure_to_gh_pages
+      cancel-in-progress: false
+
     steps:
       - name: Load Allure report history
         uses: actions/checkout@v4

--- a/tests/hil/scripts/pytest-zephyr-samples/plugin.py
+++ b/tests/hil/scripts/pytest-zephyr-samples/plugin.py
@@ -37,7 +37,7 @@ def runner_name(request):
 def add_allure_report_parent_suite(hil_board):
     # Set the full Allure suite name in case there is a failure during a fixture (before a test
     # function runs).
-    allure.dynamic.parent_suite(f"hil.zephyr.{hil_board}")
+    allure.dynamic.parent_suite(f"sample.zephyr.{hil_board}")
 
 @pytest.fixture(autouse=True, scope="function")
 def add_allure_report_device_and_platform(hil_board, runner_name):
@@ -47,7 +47,7 @@ def add_allure_report_device_and_platform(hil_board, runner_name):
     allure.dynamic.tag("zephyr")
     allure.dynamic.parameter("board_name", hil_board)
     allure.dynamic.parameter("platform_name", "zephyr")
-    allure.dynamic.parent_suite(f"hil.zephyr.{hil_board}")
+    allure.dynamic.parent_suite(f"sample.zephyr.{hil_board}")
 
     if runner_name is not None:
         allure.dynamic.tag(runner_name)


### PR DESCRIPTION
add a workflow to gather all individual reports, publish them as an artifact, generate the Allure webpage, and save it to the `gh-pages` branch for automatic publishing to GitHub pages.

- [ ] Set up automatic deploy of `gh-pages` branch to GitHub Pages

resolves https://github.com/golioth/firmware-issue-tracker/issues/663