### PR TITLE
ci: add timeout for self-hosted runners

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -73,6 +73,7 @@ jobs:
     name: esp-idf-${{ inputs.hil_board }}-sample-test
     needs: build
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
+    timeout-minutes: 30
 
     container:
       image: golioth/golioth-hil-base:75dd802

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -127,6 +127,7 @@ jobs:
     if: ${{ inputs.run_tests }}
     needs: build
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
+    timeout-minutes: 30
 
     container:
       image: golioth/golioth-twister-base:75dd802

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -76,6 +76,7 @@ jobs:
     name: esp-idf-${{ inputs.hil_board }}-test
     needs: build
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
+    timeout-minutes: 30
 
     container:
       image: golioth/golioth-hil-base:75dd802

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -112,6 +112,7 @@ jobs:
     name: zephyr-${{ inputs.hil_board }}-test
     needs: build
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
+    timeout-minutes: 30
 
     container:
       image: golioth/golioth-hil-base:75dd802


### PR DESCRIPTION
A timeout will ensure that a hung test does prevent other tests that need to use self-hosted runners from running.