### PR TITLE
workflows: use safe-upload-artifacts throughout

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -123,13 +123,15 @@ jobs:
               || EXITCODE=$?
           done
           exit $EXITCODE
-      - name: Upload reports
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+
+      - name: Safe upload Allure reports
+        if: always()
+        uses: ./.github/actions/safe-upload-artifacts
         with:
+          secrets-json: ${{ toJson(secrets) }}
           name: allure-reports-samples-espidf-${{ inputs.hil_board }}
           path: allure-reports
-          retention-days: 1
+
       - name: Erase flash
         if: always()
         shell: bash

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -209,7 +209,6 @@ jobs:
                 -v
 
       - name: Safe upload twister artifacts
-        id: safe-upload-artifacts
         if: always()
         uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
@@ -236,13 +235,13 @@ jobs:
           name: ci-summary-samples-zephyr-${{ inputs.hil_board }}
           path: summary/*
 
-      - name: Upload Allure reports
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+      - name: Safe upload Allure reports
+        if: always()
+        uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
+          secrets-json: ${{ toJson(secrets) }}
           name: allure-reports-samples-zephyr-${{ inputs.hil_board }}
           path: allure-reports
-          retention-days: 1
 
       - name: Erase flash
         if: always()

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -126,13 +126,15 @@ jobs:
               || EXITCODE=$?
           done
           exit $EXITCODE
-      - name: Upload reports
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+
+      - name: Safe upload Allure reports
+        if: always()
+        uses: ./.github/actions/safe-upload-artifacts
         with:
+          secrets-json: ${{ toJson(secrets) }}
           name: allure-reports-hil-espidf-${{ inputs.hil_board }}
           path: allure-reports
-          retention-days: 1
+
       - name: Erase flash
         if: always()
         shell: bash

--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -108,13 +108,15 @@ jobs:
         echo "$coverage_summary" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
         exit $EXITCODE
-    - name: Upload reports
-      uses: actions/upload-artifact@v4
-      if: ${{ always() }}
+
+    - name: Safe upload Allure reports
+      if: always()
+      uses: ./.github/actions/safe-upload-artifacts
       with:
+        secrets-json: ${{ toJson(secrets) }}
         name: allure-reports-hil-linux
         path: allure-reports
-        retention-days: 1
+
     - name: Find Comment
       uses: peter-evans/find-comment@v3
       if: github.event_name == 'pull_request'
@@ -131,9 +133,11 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         body: ${{ steps.run_test.outputs.coverage_summary }}
         edit-mode: replace
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+
+    - name: Upload test coverage artifacts
+      uses: ./.github/actions/safe-upload-artifacts
       with:
+        secrets-json: ${{ toJson(secrets) }}
         name: linux-hil-test-coverage
         path: |
           coverage_html/*

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -164,13 +164,15 @@ jobs:
               || EXITCODE=$?
           done
           exit $EXITCODE
-      - name: Upload reports
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+
+      - name: Safe upload Allure reports
+        if: always()
+        uses: ./.github/actions/safe-upload-artifacts
         with:
+          secrets-json: ${{ toJson(secrets) }}
           name: allure-reports-hil-zephyr-${{ inputs.hil_board }}
           path: allure-reports
-          retention-days: 1
+
       - name: Erase flash
         if: always()
         shell: bash

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -171,10 +171,11 @@ jobs:
 
           exit $EXITCODE
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+      - name: Upload test coverage artifacts
+        if: always()
+        uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
+          secrets-json: ${{ toJson(secrets) }}
           name: native-sim-hil-test-coverage-${{ matrix.artifact_suffix }}
           path: |
             hil-out/*/coverage.json
@@ -324,7 +325,6 @@ jobs:
               --pytest-args="--hil-board=${{ matrix.artifact_suffix }}"
 
       - name: Safe upload twister artifacts
-        id: safe-upload-artifacts
         if: always()
         uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
@@ -353,13 +353,13 @@ jobs:
           name: ci-summary-samples-zephyr-${{ matrix.artifact_suffix }}
           path: summary/*
 
-      - name: Upload Allure reports
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+      - name: Safe upload Allure reports
+        if: always()
+        uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
+          secrets-json: ${{ toJson(secrets) }}
           name: allure-reports-samples-zephyr-${{ matrix.artifact_suffix }}
           path: allure-reports
-          retention-days: 1
 
   hil_sample_zephyr_nsim_coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update all workflows to use safe-upload-artifacts whenever upload artifacts that may contain secrets.

- Binary artifact uploads from build steps do not contain secrets and still use upload-artifact directly
- The merge reports workflows combine artifacts that have already been uploaded (and therefor have already run through the safe upload)
- Remove a few erroneous ids and retention settings

resolves https://github.com/golioth/firmware-issue-tracker/issues/672