### PR TITLE
ci: coverage: generate HTML coverage

### DIFF
--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -314,7 +314,7 @@ jobs:
               --platform ${{ matrix.west_board }}                                   \
               -T modules/lib/golioth-firmware-sdk/examples/zephyr                   \
               -C --coverage-basedir modules/lib/golioth-firmware-sdk                \
-              --coverage-formats txt,html                                           \
+              --coverage-formats txt                                                \
               -x=CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"    \
               --pytest-args="--api-url=${{ inputs.api-url }}"                       \
               --pytest-args="--api-key=${{ secrets[inputs.api-key-id] }}"           \
@@ -333,7 +333,6 @@ jobs:
           path: |
             reports/*
             twister-out/coverage.json
-            twister-out/coverage/*
             twister-out/**/*.log
             twister-out/**/report.xml
             twister-out/*.xml

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -396,18 +396,23 @@ jobs:
         run: |
           hil_tracefiles=$(for t in native-sim-hil-test-coverage-*; do
             for d in $t/*; do
-              printf -- "--add-tracefile $d/coverage.json "
+              printf -- " $d/coverage.json"
             done
           done)
 
           twister_tracefiles=$(for d in twister-run-artifacts-*; do
-            printf -- "--add-tracefile $d/twister-out/coverage.json "
+            printf -- " $d/twister-out/coverage.json"
           done)
 
           shopt -s expand_aliases
 
+          echo -e "HIL tracefiles:${hil_tracefiles// /\\n - }"
+          echo -e "Twister tracefiles:${twister_tracefiles// /\\n - }"
+
+          tracefiles="${hil_tracefiles}${twister_tracefiles}"
+
           alias gcovr="gcovr \
-            $hil_tracefiles $twister_tracefiles \
+            ${tracefiles// / --add-tracefile } \
             -e examples -e external -e tests"
 
           rm -rf coverage

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -368,6 +368,9 @@ jobs:
       - hil_test_zephyr_nsim
     name: zephyr-coverage
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download HIL coverage artifacts
         uses: actions/download-artifact@v4
         with:
@@ -407,7 +410,17 @@ jobs:
             $hil_tracefiles $twister_tracefiles \
             -e examples -e external -e tests"
 
-          gcovr --txt-summary --xml coverage.xml
+          rm -rf coverage
+          mkdir -p coverage
+          gcovr --txt-summary --xml coverage.xml --html-details coverage/index.html
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          secrets-json: ${{ toJson(secrets) }}
+          name: coverage-native-sim
+          path: coverage/*
 
       - name: Coverage report
         uses: irongut/CodeCoverageSummary@v1.3.0


### PR DESCRIPTION
This generates HTML coverage from all native_sim runs:
 * both 32-bit and 64-bit
 * samples and tests
 
Echo HIL and Twister gcovr tracefiles, which helps with visibility of what is actually combined to single gcovr output.

Drop HTML coverage generation from specific native_sim jobs, as that just shows partial result.