### PR TITLE
ci: use `!cancelled()` instead of `always()`

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -126,7 +126,7 @@ jobs:
 
   test:
     name: zephyr-${{ inputs.hil_board }}-twister-run
-    if: ${{ inputs.run_tests && always() }}
+    if: ${{ inputs.run_tests && !cancelled() }}
     needs: build
     runs-on: [ is_active, "has_${{ inputs.hil_board }}" ]
     timeout-minutes: 30


### PR DESCRIPTION
Using `always()` prevented workflows from being cancelled.