### PR TITLE
coap: zephyr: add log level zephyr coap client

### DIFF
--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -24,7 +24,7 @@
 #include <golioth_ciphersuites.h>
 #include "golioth_openthread.h"
 
-LOG_MODULE_REGISTER(golioth_coap_client_zephyr);
+LOG_TAG_DEFINE(golioth_coap_client_zephyr);
 
 #define GOLIOTH_MAX_IDENTITY_LEN 32
 #define GOLIOTH_EMPTY_PACKET_LEN (16 + GOLIOTH_MAX_IDENTITY_LEN)


### PR DESCRIPTION
The coap_client_zephyr.c file registers for logging but it does not pass a log level. This meant that enabling debug logging for the Golioth Firmware SDK did not include enabling logs from the zephyr client. This commit adds GOLIOTH_DEBUG_DEFAULT_LOG_LEVEL as the default log level.

resolves https://github.com/golioth/firmware-issue-tracker/issues/598