### PR TITLE
coap: zephyr: replace workaround with coap_header_get_code()

### DIFF
--- a/src/zephyr_coap_req.c
+++ b/src/zephyr_coap_req.c
@@ -149,9 +149,7 @@ static int golioth_coap_req_reply_handler(struct golioth_coap_req *req,
     int block2;
     int err;
 
-    // TODO: Replace with coap_header_get_code(response) after
-    // NCS update includes fix for TOO_MANY_REQUESTS
-    code = response->data[1];
+    code = coap_header_get_code(response);
 
     LOG_DBG("CoAP response code: 0x%x (class %u detail %u)",
             (unsigned int) code,


### PR DESCRIPTION
A workaround for the TOO_MANY_REQUESTS coap error code was put in place with 503456d because the upsteam fix was not yet included in NCS. Now that we have moved to NCS v2.7.0 this fix is in place and the workaround has been removed in favor of the coap_header_get_code() function.

Resolves https://github.com/golioth/firmware-issue-tracker/issues/646