### PR TITLE
pytest: plugins: use setup wrapper to set Allure values

### DIFF
--- a/tests/hil/scripts/pytest-hil/plugin.py
+++ b/tests/hil/scripts/pytest-hil/plugin.py
@@ -87,16 +87,11 @@ async def board(board_name, port, baud, wifi_ssid, wifi_psk, fw_image, serial_nu
     async with board.started():
         yield board
 
-@pytest.fixture(autouse=True, scope="session")
-def add_allure_report_parent_suite(board_name, platform_name):
-    # Set the full Allure suite name in case there is a failure during a fixture (before a test
-    # function runs).
-    allure.dynamic.parent_suite(f"hil.{platform_name}.{board_name}")
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_setup(item):
+    board_name = item.config.getoption("--board")
+    platform_name = item.config.getoption("--platform")
 
-@pytest.fixture(autouse=True, scope="function")
-def add_allure_report_device_and_platform(board_name, platform_name, runner_name):
-    # Set the Allure information for every test function.
-    # Especially important are the parameters which identify variants of the same test
     allure.dynamic.tag(board_name)
     allure.dynamic.tag(platform_name)
     allure.dynamic.parameter("board_name", board_name)
@@ -104,4 +99,6 @@ def add_allure_report_device_and_platform(board_name, platform_name, runner_name
     allure.dynamic.parent_suite(f"hil.{platform_name}.{board_name}")
 
     if runner_name is not None:
-        allure.dynamic.tag(runner_name)
+        allure.dynamic.tag(item.config.getoption("--runner-name"))
+
+    yield


### PR DESCRIPTION
Use a setup wrapper in both pytest-hil and pytest-zephyr-samples plugins to ensure that Allure values (suite, tag, params, etc) are in place before any other setup happens for each test.

This solves an issue where tests that failed during the board fixture would not be categorized with other tests from the same suite when using Allure reports.

Resolves https://github.com/golioth/firmware-issue-tracker/issues/677