### PR TITLE
workflows: show outcome report on summary page

### DIFF
--- a/.github/workflows/reports-summary-publish.yml
+++ b/.github/workflows/reports-summary-publish.yml
@@ -24,3 +24,4 @@ jobs:
         name: Firmware Test Summary
         path: summary/*.xml
         reporter: java-junit
+        output-to: step-summary


### PR DESCRIPTION
Show the test-reporting summary information on the workflow summary page. This resolves the issue where the report appeared under random jobs when displaying on the checks page.

Resolves https://github.com/golioth/firmware-issue-tracker/issues/678