### PR TITLE
workflows: use forked allure-report-action

### DIFF
--- a/.github/workflows/reports-allure-publish.yml
+++ b/.github/workflows/reports-allure-publish.yml
@@ -34,7 +34,7 @@ jobs:
           path: reports/allure-results
 
       - name: Build Allure report
-        uses: simple-elf/allure-report-action@v1.9
+        uses: szczys/allure-report-action@fix-workflow-url-when-hosted-remotely
         if: always()
         with:
           gh_pages: gh-pages


### PR DESCRIPTION
Use forked version of allure-report-action that fixes the GitHub run URL when hosted on a different repo from the tests.

I opened a PR with these changes on the upstream repo: https://github.com/simple-elf/allure-report-action/pull/57

Once merged I will update to the new release.

Resolves https://github.com/golioth/firmware-issue-tracker/issues/675