### PR TITLE
examples: zephyr: rpc: fix typo in test name

### DIFF
--- a/examples/zephyr/rpc/pytest/test_sample.py
+++ b/examples/zephyr/rpc/pytest/test_sample.py
@@ -9,7 +9,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
-async def test_logging(shell, device, wifi_ssid, wifi_psk):
+async def test_rpc(shell, device, wifi_ssid, wifi_psk):
     await trio.sleep(2)
 
     # Set Golioth credential


### PR DESCRIPTION
The RPC sample test function was `test_logging` which made disambiguating the results for the RPC test from the results for the logging test difficult.