### PR TITLE
ci: convert backtick `...` to braces $(...) for command substitution

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         rm -rf test_binaries
         mkdir test_binaries
-        echo sample_list=`find examples/esp_idf -type d -name pytest -exec dirname "{}" \;` >> "$GITHUB_OUTPUT"
+        echo sample_list=$(find examples/esp_idf -type d -name pytest -exec dirname "{}" \;) >> "$GITHUB_OUTPUT"
     - name: Build Samples
       uses: espressif/esp-idf-ci-action@v1
       with:
@@ -105,7 +105,7 @@ jobs:
           rm -rf allure-reports
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
-          for sample in `find examples/esp_idf -type d -name pytest -exec dirname "{}" \;`
+          for sample in $(find examples/esp_idf -type d -name pytest -exec dirname "{}" \;)
           do
             pytest --rootdir . $sample                                          \
               --board ${{ inputs.hil_board }}_espidf                                                   \

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -52,7 +52,7 @@ jobs:
 
         rm -rf test_binaries
         mkdir test_binaries
-        echo test_list=`ls tests/hil/tests` >> "$GITHUB_OUTPUT"
+        echo test_list=$(ls tests/hil/tests) >> "$GITHUB_OUTPUT"
     - name: Build Test Firmware
       uses: espressif/esp-idf-ci-action@v1
       with:
@@ -110,7 +110,7 @@ jobs:
           rm -rf allure-reports
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
-          for test in `ls tests/hil/tests`
+          for test in $(ls tests/hil/tests)
           do
             pytest --rootdir . tests/hil/tests/$test                            \
               --board ${{ inputs.hil_board }}_espidf                            \

--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         export EXTRA_BUILD_ARGS=-DCONFIG_GOLIOTH_COAP_HOST_URI=${{ inputs.coap_gateway_url }}
 
-        for test in `ls tests/hil/tests`
+        for test in $(ls tests/hil/tests)
         do
           cmake -B build/$test -S tests/hil/platform/linux $EXTRA_BUILD_ARGS -DGOLIOTH_HIL_TEST=$test
           make -j8 -C build/$test
@@ -67,7 +67,7 @@ jobs:
         mkdir summary
         rm -rf allure-reports
 
-        for test in `ls tests/hil/tests`
+        for test in $(ls tests/hil/tests)
         do
           pytest --rootdir . tests/hil/tests/$test      \
             --board linux                               \
@@ -97,7 +97,7 @@ jobs:
 
         # Generate coverage summary and format into markdown table
 
-        coverage_summary=`lcov --summary all_tests.info`
+        coverage_summary=$(lcov --summary all_tests.info)
         coverage_summary=${coverage_summary#*$'\n'*$'\n'}
         coverage_summary=${coverage_summary%%  branches*}
         coverage_summary="$(echo "$coverage_summary" | sed 's/\.*:/ |/g' | sed 's/^  /|/g' | sed 's/)/)|/g')"

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -97,7 +97,7 @@ jobs:
 
         export EXTRA_BUILD_ARGS=-DCONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"
 
-        for test in `ls modules/lib/golioth-firmware-sdk/tests/hil/tests`
+        for test in $(ls modules/lib/golioth-firmware-sdk/tests/hil/tests)
         do
           west build -p -b ${{ inputs.west_board }} modules/lib/golioth-firmware-sdk/tests/hil/platform/zephyr -- $EXTRA_BUILD_ARGS -DGOLIOTH_HIL_TEST=$test
           mv build/zephyr/${{ inputs.binary_name }} test_binaries/${test}-${{ inputs.binary_name }}
@@ -147,7 +147,7 @@ jobs:
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
           SNR_VAR=CI_${hil_board^^}_SNR
-          for test in `ls tests/hil/tests`
+          for test in $(ls tests/hil/tests)
           do
             pytest --rootdir . tests/hil/tests/$test                            \
               --board ${hil_board}                                              \

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -146,7 +146,7 @@ jobs:
           rm -rf hil-out
           mkdir -p hil-out
 
-          for test in `ls modules/lib/golioth-firmware-sdk/tests/hil/tests`
+          for test in $(ls modules/lib/golioth-firmware-sdk/tests/hil/tests)
           do
             echo "Testing $test"
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
           CODE=0 # run pre-commit
-          for CID in `git rev-list --reverse origin/$GITHUB_BASE_REF..`; do
+          for CID in $(git rev-list --reverse origin/$GITHUB_BASE_REF..); do
               git show $CID -s --format='    pre-commit %h ("%s")'
               git checkout -f -q $CID
               pre-commit run --color always --show-diff-on-failure --from-ref $CID^ --to-ref $CID || CODE=$?


### PR DESCRIPTION
Use $(...) syntax, as it is more visually clear, simplifies nested quoting
and command substitution. See [1].

[1] https://mywiki.wooledge.org/BashFAQ/082