### PR TITLE
ci: use nproc to determine number of CPU cores for make

### DIFF
--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -42,7 +42,7 @@ jobs:
         for test in `ls tests/hil/tests`
         do
           cmake -B build/$test -S tests/hil/platform/linux $EXTRA_BUILD_ARGS -DGOLIOTH_HIL_TEST=$test
-          make -j8 -C build/$test
+          make -j$(nproc) -C build/$test
         done
     - name: Setup Python dependencies
       run: |

--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -141,4 +141,4 @@ jobs:
         cd examples/modus_toolbox/golioth_basics/golioth_app
         cp source/credentials.inc.template source/credentials.inc
         make getlibs
-        make build -j8
+        make build -j$(nproc)


### PR DESCRIPTION
Use number of detected system cores instead of always using 8 threads for
build using make.