### PR TITLE
ci: linux: switch from lcov to gcovr

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         rm -rf test_binaries
         mkdir test_binaries
-        echo sample_list=`find examples/esp_idf -type d -name pytest -exec dirname "{}" \;` >> "$GITHUB_OUTPUT"
+        echo sample_list=$(find examples/esp_idf -type d -name pytest -exec dirname "{}" \;) >> "$GITHUB_OUTPUT"
     - name: Build Samples
       uses: espressif/esp-idf-ci-action@v1
       with:
@@ -105,7 +105,7 @@ jobs:
           rm -rf allure-reports
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
-          for sample in `find examples/esp_idf -type d -name pytest -exec dirname "{}" \;`
+          for sample in $(find examples/esp_idf -type d -name pytest -exec dirname "{}" \;)
           do
             pytest --rootdir . $sample                                          \
               --board ${{ inputs.hil_board }}_espidf                                                   \

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -52,7 +52,7 @@ jobs:
 
         rm -rf test_binaries
         mkdir test_binaries
-        echo test_list=`ls tests/hil/tests` >> "$GITHUB_OUTPUT"
+        echo test_list=$(ls tests/hil/tests) >> "$GITHUB_OUTPUT"
     - name: Build Test Firmware
       uses: espressif/esp-idf-ci-action@v1
       with:
@@ -110,7 +110,7 @@ jobs:
           rm -rf allure-reports
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
-          for test in `ls tests/hil/tests`
+          for test in $(ls tests/hil/tests)
           do
             pytest --rootdir . tests/hil/tests/$test                            \
               --board ${{ inputs.hil_board }}_espidf                            \

--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -47,22 +47,13 @@ jobs:
     - name: Setup Python dependencies
       run: |
         pip install --upgrade pip
-        pip install pytest pytest-timeout
+        pip install gcovr pytest pytest-timeout
         pip install tests/hil/scripts/pytest-hil
         pip install git+https://github.com/golioth/python-golioth-tools@v0.6.4
-    - name: Install Linux dependencies
-      run: |
-        sudo apt-get install lcov
     - name: Run test
       id: run_test
       shell: bash
       run: |
-        # Get coverage baseline
-        lcov -i -o baseline.info -c   \
-             -d build/connection      \
-             --include "*/golioth-firmware-sdk/src/*"
-        LCOV_FILES="-a baseline.info"
-
         rm -rf summary
         mkdir summary
         rm -rf allure-reports
@@ -81,36 +72,53 @@ jobs:
             --alluredir=allure-reports                  \
             --platform linux                            \
             || EXITCODE=$?
-          lcov -c                                       \
-               --directory build/${test}                \
-               --include "*/golioth-firmware-sdk/src/*" \
-               -o ${test}.info
-          LCOV_FILES="$LCOV_FILES -a ${test}.info"
+
+          gcovr                                                         \
+            --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
+            --merge-mode-functions=separate                             \
+            --json summary/hil-linux-${test}-coverage.json              \
+            build/${test}
         done
 
-        lcov $LCOV_FILES -o all_tests.info
+        tracefiles=$(for f in summary/hil-linux-*-coverage.json; do
+          printf -- " $f"
+        done)
 
-        genhtml -o coverage_html          \
-                --rc genhtml_med_limit=50 \
-                --rc genhtml_hi_limit=80  \
-                all_tests.info
+        alias gcovr="gcovr \
+          ${tracefiles// / --add-tracefile } \
+          -e examples -e external -e tests"
 
-        # Generate coverage summary and format into markdown table
+        rm -rf coverage_html
+        mkdir -p coverage_html
+        gcovr --txt-summary --xml coverage.xml --html-details coverage_html/index.html
 
-        coverage_summary=$(lcov --summary all_tests.info)
-        coverage_summary=${coverage_summary#*$'\n'*$'\n'}
-        coverage_summary=${coverage_summary%%  branches*}
-        coverage_summary="$(echo "$coverage_summary" | sed 's/\.*:/ |/g' | sed 's/^  /|/g' | sed 's/)/)|/g')"
-
-        # Echo coverage summary into GitHub Output, with title
-
-        echo "coverage_summary<<EOF" >> $GITHUB_OUTPUT
-        echo "# Code Coverage (Linux)" >> $GITHUB_OUTPUT
-        echo "| Type | Coverage |" >> $GITHUB_OUTPUT
-        echo "| --- | --- |" >> $GITHUB_OUTPUT
-        echo "$coverage_summary" >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
         exit $EXITCODE
+
+    - name: Coverage report
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: coverage.xml
+        format: markdown
+        badge: true
+        output: file
+        hide_complexity: true
+
+    - name: Coverage summary
+      shell: bash
+      run: |
+        cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+
+    - name: Append Coverage PR Comment title
+      shell: bash
+      run: |
+        echo "# Code Coverage (Linux)" > code-coverage-comment.md
+        cat code-coverage-results.md >> code-coverage-comment.md
+
+    - name: Add Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: github.event_name == 'pull_request'
+      with:
+        path: code-coverage-comment.md
 
     - name: Prepare summary
       if: always()
@@ -140,23 +148,6 @@ jobs:
         secrets-json: ${{ toJson(secrets) }}
         name: allure-reports-hil-linux
         path: allure-reports
-
-    - name: Find Comment
-      uses: peter-evans/find-comment@v3
-      if: github.event_name == 'pull_request'
-      id: fc
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: Code Coverage (Linux)
-    - name: Code coverage comment
-      uses: peter-evans/create-or-update-comment@v4
-      if: github.event_name == 'pull_request'
-      with:
-        comment-id: ${{ steps.fc.outputs.comment-id }}
-        issue-number: ${{ github.event.pull_request.number }}
-        body: ${{ steps.run_test.outputs.coverage_summary }}
-        edit-mode: replace
 
     - name: Upload test coverage artifacts
       uses: ./.github/actions/safe-upload-artifacts

--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -42,7 +42,7 @@ jobs:
         for test in $(ls tests/hil/tests)
         do
           cmake -B build/$test -S tests/hil/platform/linux $EXTRA_BUILD_ARGS -DGOLIOTH_HIL_TEST=$test
-          make -j8 -C build/$test
+          make -j$(nproc) -C build/$test
         done
     - name: Setup Python dependencies
       run: |

--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         export EXTRA_BUILD_ARGS=-DCONFIG_GOLIOTH_COAP_HOST_URI=${{ inputs.coap_gateway_url }}
 
-        for test in `ls tests/hil/tests`
+        for test in $(ls tests/hil/tests)
         do
           cmake -B build/$test -S tests/hil/platform/linux $EXTRA_BUILD_ARGS -DGOLIOTH_HIL_TEST=$test
           make -j8 -C build/$test
@@ -67,7 +67,7 @@ jobs:
         mkdir summary
         rm -rf allure-reports
 
-        for test in `ls tests/hil/tests`
+        for test in $(ls tests/hil/tests)
         do
           pytest --rootdir . tests/hil/tests/$test      \
             --board linux                               \
@@ -97,7 +97,7 @@ jobs:
 
         # Generate coverage summary and format into markdown table
 
-        coverage_summary=`lcov --summary all_tests.info`
+        coverage_summary=$(lcov --summary all_tests.info)
         coverage_summary=${coverage_summary#*$'\n'*$'\n'}
         coverage_summary=${coverage_summary%%  branches*}
         coverage_summary="$(echo "$coverage_summary" | sed 's/\.*:/ |/g' | sed 's/^  /|/g' | sed 's/)/)|/g')"

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -97,7 +97,7 @@ jobs:
 
         export EXTRA_BUILD_ARGS=-DCONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"
 
-        for test in `ls modules/lib/golioth-firmware-sdk/tests/hil/tests`
+        for test in $(ls modules/lib/golioth-firmware-sdk/tests/hil/tests)
         do
           west build -p -b ${{ inputs.west_board }} modules/lib/golioth-firmware-sdk/tests/hil/platform/zephyr -- $EXTRA_BUILD_ARGS -DGOLIOTH_HIL_TEST=$test
           mv build/zephyr/${{ inputs.binary_name }} test_binaries/${test}-${{ inputs.binary_name }}
@@ -147,7 +147,7 @@ jobs:
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
           SNR_VAR=CI_${hil_board^^}_SNR
-          for test in `ls tests/hil/tests`
+          for test in $(ls tests/hil/tests)
           do
             pytest --rootdir . tests/hil/tests/$test                            \
               --board ${hil_board}                                              \

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -146,7 +146,7 @@ jobs:
           rm -rf hil-out
           mkdir -p hil-out
 
-          for test in `ls modules/lib/golioth-firmware-sdk/tests/hil/tests`
+          for test in $(ls modules/lib/golioth-firmware-sdk/tests/hil/tests)
           do
             echo "Testing $test"
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
           CODE=0 # run pre-commit
-          for CID in `git rev-list --reverse origin/$GITHUB_BASE_REF..`; do
+          for CID in $(git rev-list --reverse origin/$GITHUB_BASE_REF..); do
               git show $CID -s --format='    pre-commit %h ("%s")'
               git checkout -f -q $CID
               pre-commit run --color always --show-diff-on-failure --from-ref $CID^ --to-ref $CID || CODE=$?


### PR DESCRIPTION
Zephyr tests and samples coverage is handled using gcovr. Switch to that
tool for Linux tests as well for improved consistency. This also allows to
combine coverage results for Linux and Zephyr in the future.

Use gcovr tool to generate:
 * HTML report (instead of lcov -> genhtml)
 * PR comment from XML output (so a single format of PR comment is used)
 * GH Actions step summary (which was not generated before)