### PR TITLE
ci: linux: switch from lcov to gcovr

### DIFF
--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -47,25 +47,20 @@ jobs:
     - name: Setup Python dependencies
       run: |
         pip install --upgrade pip
-        pip install pytest pytest-timeout
+        pip install gcovr pytest pytest-timeout
         pip install tests/hil/scripts/pytest-hil
         pip install git+https://github.com/golioth/python-golioth-tools@v0.6.4
-    - name: Install Linux dependencies
-      run: |
-        sudo apt-get install lcov
     - name: Run test
       id: run_test
       shell: bash
       run: |
-        # Get coverage baseline
-        lcov -i -o baseline.info -c   \
-             -d build/connection      \
-             --include "*/golioth-firmware-sdk/src/*"
-        LCOV_FILES="-a baseline.info"
-
         rm -rf summary
         mkdir summary
+
         rm -rf allure-reports
+
+        rm -rf coverage
+        mkdir -p coverage
 
         for test in $(ls tests/hil/tests)
         do
@@ -81,35 +76,14 @@ jobs:
             --alluredir=allure-reports                  \
             --platform linux                            \
             || EXITCODE=$?
-          lcov -c                                       \
-               --directory build/${test}                \
-               --include "*/golioth-firmware-sdk/src/*" \
-               -o ${test}.info
-          LCOV_FILES="$LCOV_FILES -a ${test}.info"
+
+          gcovr                                                         \
+            --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
+            --merge-mode-functions=separate                             \
+            --json coverage/${test}-coverage.json                       \
+            build/${test}
         done
 
-        lcov $LCOV_FILES -o all_tests.info
-
-        genhtml -o coverage_html          \
-                --rc genhtml_med_limit=50 \
-                --rc genhtml_hi_limit=80  \
-                all_tests.info
-
-        # Generate coverage summary and format into markdown table
-
-        coverage_summary=$(lcov --summary all_tests.info)
-        coverage_summary=${coverage_summary#*$'\n'*$'\n'}
-        coverage_summary=${coverage_summary%%  branches*}
-        coverage_summary="$(echo "$coverage_summary" | sed 's/\.*:/ |/g' | sed 's/^  /|/g' | sed 's/)/)|/g')"
-
-        # Echo coverage summary into GitHub Output, with title
-
-        echo "coverage_summary<<EOF" >> $GITHUB_OUTPUT
-        echo "# Code Coverage (Linux)" >> $GITHUB_OUTPUT
-        echo "| Type | Coverage |" >> $GITHUB_OUTPUT
-        echo "| --- | --- |" >> $GITHUB_OUTPUT
-        echo "$coverage_summary" >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
         exit $EXITCODE
 
     - name: Prepare summary
@@ -141,27 +115,9 @@ jobs:
         name: allure-reports-hil-linux
         path: allure-reports
 
-    - name: Find Comment
-      uses: peter-evans/find-comment@v3
-      if: github.event_name == 'pull_request'
-      id: fc
+    - name: Upload coverage
+      uses: actions/upload-artifact@v4
       with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: Code Coverage (Linux)
-    - name: Code coverage comment
-      uses: peter-evans/create-or-update-comment@v4
-      if: github.event_name == 'pull_request'
-      with:
-        comment-id: ${{ steps.fc.outputs.comment-id }}
-        issue-number: ${{ github.event.pull_request.number }}
-        body: ${{ steps.run_test.outputs.coverage_summary }}
-        edit-mode: replace
-
-    - name: Upload test coverage artifacts
-      uses: ./.github/actions/safe-upload-artifacts
-      with:
-        secrets-json: ${{ toJson(secrets) }}
         name: linux-hil-test-coverage
         path: |
-          coverage_html/*
+          coverage/*

--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -364,17 +364,24 @@ jobs:
           name: allure-reports-samples-zephyr-${{ matrix.artifact_suffix }}
           path: allure-reports
 
-  hil_sample_zephyr_nsim_coverage:
+  coverage:
     runs-on: ubuntu-latest
     needs:
       - hil_sample_zephyr_nsim
+      - hil_test_linux
       - hil_test_zephyr_nsim
-    name: zephyr-coverage
+    name: coverage
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download HIL coverage artifacts
+      - name: Download HIL Linux coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-hil-test-coverage
+          path: linux-hil-test-coverage
+
+      - name: Download HIL Zephyr coverage artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: native-sim-hil-test-coverage-*
@@ -397,22 +404,27 @@ jobs:
       - name: Merge coverage
         shell: bash
         run: |
-          hil_tracefiles=$(for t in native-sim-hil-test-coverage-*; do
+          tracefiles_hil_linux=$(for f in linux-hil-test-coverage/*-coverage.json; do
+            printf -- " $f"
+          done)
+
+          tracefiles_hil_zephyr=$(for t in native-sim-hil-test-coverage-*; do
             for d in $t/*; do
               printf -- " $d/coverage.json"
             done
           done)
 
-          twister_tracefiles=$(for d in twister-run-artifacts-*; do
+          tracefiles_twister=$(for d in twister-run-artifacts-*; do
             printf -- " $d/twister-out/coverage.json"
           done)
 
           shopt -s expand_aliases
 
-          echo -e "HIL tracefiles:${hil_tracefiles// /\\n - }"
-          echo -e "Twister tracefiles:${twister_tracefiles// /\\n - }"
+          echo -e "HIL Linux tracefiles:${tracefiles_hil_linux// /\\n - }"
+          echo -e "HIL Zephyr tracefiles:${tracefiles_hil_zephyr// /\\n - }"
+          echo -e "Twister tracefiles:${tracefiles_twister// /\\n - }"
 
-          tracefiles="${hil_tracefiles}${twister_tracefiles}"
+          tracefiles="${tracefiles_hil_linux}${tracefiles_hil_zephyr}${tracefiles_twister}"
 
           alias gcovr="gcovr \
             ${tracefiles// / --add-tracefile } \
@@ -447,7 +459,7 @@ jobs:
       - name: Append Coverage PR Comment title
         shell: bash
         run: |
-          echo "# Code Coverage (Zephyr)" > code-coverage-comment.md
+          echo "# Code Coverage" > code-coverage-comment.md
           cat code-coverage-results.md >> code-coverage-comment.md
 
       - name: Add Coverage PR Comment


### PR DESCRIPTION
Zephyr tests and samples coverage is handled using gcovr. Switch to that
tool for Linux tests as well for improved consistency. This also allows to
combine coverage results for Linux and Zephyr.

Use gcovr tool to generate JSON output for each test and put most of the
coverage report generation inside 'coverage' job:
 * HTML report (instead of lcov -> genhtml in case of Linux)
 * single PR comment from XML output (instead of having two comments, each
   with slightly different format)
 * GH Actions step summary that includes Linux platform coverage (which was
   not generated before for Linux)