### PR TITLE
tests: unit: enforce ENABLE_DOCS=OFF by defining option()

### DIFF
--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -38,7 +38,7 @@ target_compile_options(zcbor PRIVATE "-Wno-strict-aliasing" "-Wno-uninitialized"
 
 # Build libcoap
 
-set(ENABLE_DOCS OFF)
+option(ENABLE_DOCS "" OFF)
 add_subdirectory("${repo_root}/external/libcoap" build)
 
 # Function for declaring unit tests


### PR DESCRIPTION
Seems that:

``` cmake
set(ENABLE_DOCS OFF)
```

is not respected. Convert that to:

``` cmake
option(ENABLE_DOCS "" OFF)
```