### PR TITLE
Block download: add current_block_len

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes:
+
+- The parameters for `ota_component_block_write_cb()` have changed to
+  include `block_buffer_len` for the actual length of data and
+  `negotiated_block_size` to indicate the maximum block size (may be
+  used along with 'block_idx' to calculate a byte offset).
+
 ### Removed:
 
 - OTA compression was removed as the feature is currently unsupported on

--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -143,15 +143,17 @@ enum golioth_status golioth_ota_observe_manifest_async(struct golioth_client *cl
 /// @param component The @ref golioth_ota_component pointer from the original request
 /// @param block_idx The block number in sequence (starting with 0)
 /// @param block_buffer The component payload in the response packet.
-/// @param block_size The size of payload, in bytes
+/// @param block_buffer_len The length of the component payload, in bytes.
 /// @param is_last true if this is the final block of the request
+/// @param negotiated_block_size The maximum block size negotated with the server, in bytes
 /// @param arg User argument, copied from the original request. Can be NULL.
 typedef enum golioth_status (*ota_component_block_write_cb)(
     const struct golioth_ota_component *component,
     uint32_t block_idx,
     uint8_t *block_buffer,
-    size_t block_size,
+    size_t block_buffer_len,
     bool is_last,
+    size_t negotiated_block_size,
     void *arg);
 
 /// Download an OTA component synchronously.

--- a/src/coap_blockwise.c
+++ b/src/coap_blockwise.c
@@ -290,6 +290,7 @@ static void call_write_block_callback(struct blockwise_transfer *ctx, size_t rcv
                                ctx->block_buffer,
                                rcvd_bytes,
                                ctx->is_last,
+                               ctx->block_size,
                                ctx->callback_arg)
         != GOLIOTH_OK)
     {

--- a/src/coap_blockwise.h
+++ b/src/coap_blockwise.h
@@ -28,8 +28,9 @@ enum golioth_status golioth_blockwise_post(struct golioth_client *client,
 /* Blockwise Download */
 typedef enum golioth_status (*write_block_cb)(uint32_t block_idx,
                                               uint8_t *block_buffer,
-                                              size_t block_size,
+                                              size_t block_buffer_len,
                                               bool is_last,
+                                              size_t negotiated_block_size,
                                               void *callback_arg);
 
 enum golioth_status golioth_blockwise_get(struct golioth_client *client,

--- a/src/ota.c
+++ b/src/ota.c
@@ -336,13 +336,20 @@ struct ota_component_blockwise_ctx
 
 static enum golioth_status ota_component_write_cb_wrapper(uint32_t block_idx,
                                                           uint8_t *block_buffer,
-                                                          size_t block_size,
+                                                          size_t block_buffer_len,
                                                           bool is_last,
+                                                          size_t negotiated_block_size,
                                                           void *callback_arg)
 {
     struct ota_component_blockwise_ctx *ctx = callback_arg;
 
-    return ctx->cb(ctx->component, block_idx, block_buffer, block_size, is_last, ctx->arg);
+    return ctx->cb(ctx->component,
+                   block_idx,
+                   block_buffer,
+                   block_buffer_len,
+                   is_last,
+                   negotiated_block_size,
+                   ctx->arg);
 }
 
 enum golioth_status golioth_ota_download_component(struct golioth_client *client,


### PR DESCRIPTION
Block download callbacks now receive both block_size and current_block_len. These distinct values are needed to correctly calculate the offset when the final block is received and its data payload (current_data_len) is smaller than the coap blocksize (block_size).

Resolves https://github.com/golioth/firmware-issue-tracker/issues/656