### PR TITLE
ci: unit_tests: merge coverage with HIL tests

### DIFF
--- a/.github/workflows/hil_tests.yml
+++ b/.github/workflows/hil_tests.yml
@@ -53,6 +53,43 @@ on:
         default: 'all'
 
 jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install gcovr and ninja
+        run: |
+          pip install gcovr ninja
+
+      - name: Run unit tests
+        run: |
+          ctest --build-and-test tests/unit_tests build \
+            --build-generator Ninja                     \
+            --test-command                              \
+              ctest                                     \
+                --output-on-failure                     \
+                --timeout 2
+
+      - name: Coverage
+        run: |
+          gcovr                                                         \
+            --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
+            --merge-mode-functions=separate                             \
+            --json coverage.json                                        \
+            build
+
+      - name: Upload test coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-coverage
+          path: coverage.json
+
   hil_test_zephyr:
     if: ${{ inputs.workflow == 'all' || inputs.workflow == 'zephyr_integration' }}
     strategy:
@@ -425,6 +462,7 @@ jobs:
       - hil_sample_zephyr_nsim
       - hil_test_linux
       - hil_test_zephyr_nsim
+      - unit_tests
     name: coverage
     steps:
       - name: Checkout repository
@@ -444,6 +482,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: twister-run-artifacts-native*
+
+      - name: Download Unit Tests coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-test-coverage
+          path: unit-test-coverage
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -472,13 +516,16 @@ jobs:
             printf -- " $d/twister-out/coverage.json"
           done)
 
+          tracefiles_unit_tests=" unit-test-coverage/coverage.json"
+
           shopt -s expand_aliases
 
           echo -e "HIL Linux tracefiles:${tracefiles_hil_linux// /\\n - }"
           echo -e "HIL Zephyr tracefiles:${tracefiles_hil_zephyr// /\\n - }"
           echo -e "Twister tracefiles:${tracefiles_twister// /\\n - }"
+          echo -e "Unit Tests tracefiles:${tracefiles_unit_tests// /\\n - }"
 
-          tracefiles="${tracefiles_hil_linux}${tracefiles_hil_zephyr}${tracefiles_twister}"
+          tracefiles="${tracefiles_hil_linux}${tracefiles_hil_zephyr}${tracefiles_twister}${tracefiles_unit_tests}"
 
           alias gcovr="gcovr \
             ${tracefiles// / --add-tracefile } \

--- a/.github/workflows/lint_build.yml
+++ b/.github/workflows/lint_build.yml
@@ -37,43 +37,6 @@ jobs:
           fi
           git clang-format-17 --verbose --extensions c,h --diff --diffstat $BASE
 
-  unit_tests:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository and submodules
-        uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
-
-      - name: Install gcovr and ninja
-        run: |
-          pip install gcovr ninja
-
-      - name: Run unit tests
-        run: |
-          ctest --build-and-test tests/unit_tests build \
-            --build-generator Ninja                     \
-            --test-command                              \
-              ctest                                     \
-                --output-on-failure                     \
-                --timeout 2
-
-      - name: Coverage
-        run: |
-          gcovr                                                         \
-            --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
-            --merge-mode-functions=separate                             \
-            --json coverage.json                                        \
-            build
-
-      - name: Upload test coverage artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-coverage
-          path: coverage.json
-
   linux_build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -46,9 +46,9 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Install ninja
+      - name: Install gcovr and ninja
         run: |
-          sudo apt install -y ninja-build
+          pip install gcovr ninja
 
       - name: Run unit tests
         run: |
@@ -58,6 +58,21 @@ jobs:
               ctest                                     \
                 --output-on-failure                     \
                 --timeout 2
+
+      - name: Coverage
+        run: |
+          gcovr                                                         \
+            --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
+            --merge-mode-functions=separate                             \
+            --json coverage.json                                        \
+            build
+
+      - name: Upload test coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-coverage
+          path: coverage.json
 
   linux_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_build_unit_test.yml
+++ b/.github/workflows/lint_build_unit_test.yml
@@ -46,11 +46,18 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Run unit tests
-        shell: bash
+      - name: Install ninja
         run: |
-          cd tests/unit_tests
-          ./test.sh
+          sudo apt install -y ninja-build
+
+      - name: Run unit tests
+        run: |
+          ctest --build-and-test tests/unit_tests build \
+            --build-generator Ninja                     \
+            --test-command                              \
+              ctest                                     \
+                --output-on-failure                     \
+                --timeout 2
 
   linux_build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`tests/unit_tests/test.sh` is very verbose, while it is possible to do most
of it with single `ctest` command.

Use *Ninja* generator to build using multiple threads automatically.

Install both `gcovr` and `ninja` from pypi, so a single tool (pip) is used.

Move `unit_tests` job from `lint_build_unit_test.yml` to `hil_tests.yml`,
so that coverage data can be easily combined as part of single workflow.

Also rename `lint_build_unit_test.yml` to `lint_build.yml`, as there are no
more unit tests as part of this workflow.