### PR TITLE
zephyr: logging: fix off-by-one in log message length limit

### DIFF
--- a/port/zephyr/golioth_log_zephyr.c
+++ b/port/zephyr/golioth_log_zephyr.c
@@ -72,7 +72,7 @@ static const glth_log_fn log_to_log_func(struct log_msg *log)
 static int cbpprintf_out_func(int c, void *out_ctx)
 {
     struct cbpprintf_ctx *ctx = out_ctx;
-    if (ctx->ctr >= CONFIG_LOG_BACKEND_GOLIOTH_MAX_LOG_STRING_SIZE)
+    if (ctx->ctr >= CONFIG_LOG_BACKEND_GOLIOTH_MAX_LOG_STRING_SIZE - 1)
     {
         return -ENOMEM;
     }


### PR DESCRIPTION
Fix an off-by-one error when writing a null terminator to the end of a log message buffer before sending to Golioth.

When a log message is longer than the setting for the  maximum Golioth backend log buffer (CONFIG_LOG_BACKEND_GOLIOTH_MAX_LOG_STRING_SIZE), the message is truncated by writing a null terminator onto the end of the buffer. The index for this null terminator was using a counter that had already been incremented past the end of the buffer array. Instead, use a MIN() test to use either the counter value, or the final member of the buffer array.