### PR TITLE
workflows: update to latest images and Zephyr 0.16.8

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:75dd802
+      image: golioth/golioth-hil-base:3407412
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -66,9 +66,9 @@ on:
 jobs:
   build:
     name: zephyr-${{ inputs.hil_board }}-twister-build
-    container: golioth/golioth-zephyr-base:0.16.3-SDK-v0
+    container: golioth/golioth-zephyr-base:0.16.8-SDK-v0
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.8
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
@@ -143,9 +143,9 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-twister-base:75dd802
+      image: golioth/golioth-twister-base:3407412
       env:
-        ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
+        ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.8
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:75dd802
+      image: golioth/golioth-hil-base:3407412
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -57,9 +57,9 @@ on:
 jobs:
   build:
     name: zephyr-${{ inputs.hil_board }}-build
-    container: golioth/golioth-zephyr-base:0.16.3-SDK-v0
+    container: golioth/golioth-zephyr-base:0.16.8-SDK-v0
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.8
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
@@ -129,7 +129,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:75dd802
+      image: golioth/golioth-hil-base:3407412
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,9 +162,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: hil_test_zephyr_nsim_matrix
     container:
-      image: golioth/golioth-zephyr-base:0.16.3-SDK-v0
+      image: golioth/golioth-zephyr-base:0.16.8-SDK-v0
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.8
     name: zephyr-${{ matrix.platform }}-${{ matrix.test }}-test-nsim
     strategy:
       fail-fast: false
@@ -349,9 +349,9 @@ jobs:
     if: ${{ inputs.workflow == 'all' || inputs.workflow == 'zephyr_sample_native_sim' }}
     runs-on: ubuntu-latest
     container:
-      image: golioth/golioth-zephyr-base:0.16.3-SDK-v0
+      image: golioth/golioth-zephyr-base:0.16.8-SDK-v0
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.8
     name: zephyr-${{ matrix.west_board }}-twister
     strategy:
       fail-fast: false


### PR DESCRIPTION
- Update all workflows to use the latest images
- Update all instances of the Zephyr toolchain to 0.16.8 to match the latest images

Resolves https://github.com/golioth/firmware-issue-tracker/issues/667