### PR TITLE
ci: hil: prefer single-line pip invocations

### DIFF
--- a/.github/workflows/hil_sample_esp-idf.yml
+++ b/.github/workflows/hil_sample_esp-idf.yml
@@ -87,9 +87,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python dependencies
         run: |
-          pip install pytest pytest-timeout
-          pip install tests/hil/scripts/pytest-hil
-          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.3
+          pip install \
+            pytest \
+            pytest-timeout \
+            tests/hil/scripts/pytest-hil \
+            git+https://github.com/golioth/python-golioth-tools@v0.6.3
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -94,11 +94,20 @@ jobs:
           west patch
         fi
 
-        pip3 install -r zephyr/scripts/requirements-base.txt
-        pip3 install -r zephyr/scripts/requirements-build-test.txt
-        pip3 install -r zephyr/scripts/requirements-run-test.txt
+        pip3 install \
+          -r zephyr/scripts/requirements-base.txt \
+          -r zephyr/scripts/requirements-build-test.txt \
+          -r zephyr/scripts/requirements-run-test.txt
+
         # Needed for TF-M
-        pip3 install cryptography==41.0.7 pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.9.0 jinja2 click
+        pip3 install \
+          cryptography==41.0.7 \
+          pyasn1 \
+          pyyaml \
+          cbor>=1.0.0 \
+          imgtool>=1.9.0 \
+          jinja2 \
+          click
 
     - name: Download binary blobs
       if: ${{ inputs.binary_blob }}
@@ -161,12 +170,12 @@ jobs:
           git config --global user.name "Git User"
           west patch
 
-          pip3 install -r zephyr/scripts/requirements-base.txt
-          pip3 install -r zephyr/scripts/requirements-build-test.txt
-          pip3 install -r zephyr/scripts/requirements-run-test.txt
-
-          pip3 install tests/hil/scripts/pytest-zephyr-samples
-          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.6.3
+          pip3 install \
+            -r zephyr/scripts/requirements-base.txt \
+            -r zephyr/scripts/requirements-build-test.txt \
+            -r zephyr/scripts/requirements-run-test.txt \
+            tests/hil/scripts/pytest-zephyr-samples \
+            git+https://github.com/golioth/python-golioth-tools@v0.6.3
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -156,8 +156,6 @@ jobs:
           file = .ci-west-zephyr-twister.yml
           EOF
 
-          pip3 install west
-
           west update -o=--depth=1 -n
           git config --global user.email user@git-scm.com
           git config --global user.name "Git User"

--- a/.github/workflows/hil_test_esp-idf.yml
+++ b/.github/workflows/hil_test_esp-idf.yml
@@ -90,9 +90,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python dependencies
         run: |
-          pip install pytest pytest-timeout
-          pip install tests/hil/scripts/pytest-hil
-          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.4
+          pip install \
+            pytest \
+            pytest-timeout \
+            tests/hil/scripts/pytest-hil \
+            git+https://github.com/golioth/python-golioth-tools@v0.6.4
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build

--- a/.github/workflows/hil_test_linux.yml
+++ b/.github/workflows/hil_test_linux.yml
@@ -74,10 +74,12 @@ jobs:
         make -j$(nproc) -C build
     - name: Setup Python dependencies
       run: |
-        pip install --upgrade pip
-        pip install gcovr pytest pytest-timeout
-        pip install tests/hil/scripts/pytest-hil
-        pip install git+https://github.com/golioth/python-golioth-tools@v0.6.4
+        pip install \
+          gcovr \
+          pytest \
+          pytest-timeout \
+          tests/hil/scripts/pytest-hil \
+          git+https://github.com/golioth/python-golioth-tools@v0.6.4
     - name: Run test
       id: run_test
       shell: bash

--- a/.github/workflows/hil_test_zephyr.yml
+++ b/.github/workflows/hil_test_zephyr.yml
@@ -78,11 +78,20 @@ jobs:
 
         west update -o=--depth=1 -n
 
-        pip3 install -r zephyr/scripts/requirements-base.txt
-        pip3 install -r zephyr/scripts/requirements-build-test.txt
-        pip3 install -r zephyr/scripts/requirements-run-test.txt
+        pip3 install \
+          -r zephyr/scripts/requirements-base.txt \
+          -r zephyr/scripts/requirements-build-test.txt \
+          -r zephyr/scripts/requirements-run-test.txt
+
         # Needed for TF-M
-        pip3 install cryptography==41.0.7 pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.9.0 jinja2 click
+        pip3 install \
+          cryptography==41.0.7 \
+          pyasn1 \
+          pyyaml \
+          cbor>=1.0.0 \
+          imgtool>=1.9.0 \
+          jinja2 \
+          click
 
     - name: Download binary blobs
       if: ${{ inputs.binary_blob }}
@@ -126,9 +135,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python dependencies
         run: |
-          pip install pytest pytest-timeout
-          pip install tests/hil/scripts/pytest-hil
-          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.4
+          pip install \
+            pytest \
+            pytest-timeout \
+            tests/hil/scripts/pytest-hil \
+            git+https://github.com/golioth/python-golioth-tools@v0.6.4
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -195,13 +195,14 @@ jobs:
           git config --global user.name "Git User"
           west patch
 
-          pip install -r zephyr/scripts/requirements-base.txt
-          pip install -r zephyr/scripts/requirements-build-test.txt
-          pip install -r zephyr/scripts/requirements-run-test.txt
-
-          pip install pytest pytest-timeout
-          pip install modules/lib/golioth-firmware-sdk/tests/hil/scripts/pytest-hil
-          pip install git+https://github.com/golioth/python-golioth-tools@v0.6.4
+          pip install \
+            -r zephyr/scripts/requirements-base.txt \
+            -r zephyr/scripts/requirements-build-test.txt \
+            -r zephyr/scripts/requirements-run-test.txt \
+            pytest \
+            pytest-timeout \
+            modules/lib/golioth-firmware-sdk/tests/hil/scripts/pytest-hil \
+            git+https://github.com/golioth/python-golioth-tools@v0.6.4
 
       - name: Build test
         env:
@@ -369,12 +370,12 @@ jobs:
           git config --global user.name "Git User"
           west patch
 
-          pip3 install -r zephyr/scripts/requirements-base.txt
-          pip3 install -r zephyr/scripts/requirements-build-test.txt
-          pip3 install -r zephyr/scripts/requirements-run-test.txt
-
-          pip3 install modules/lib/golioth-firmware-sdk/tests/hil/scripts/pytest-zephyr-samples
-          pip3 install git+https://github.com/golioth/python-golioth-tools@v0.6.3
+          pip3 install \
+            -r zephyr/scripts/requirements-base.txt \
+            -r zephyr/scripts/requirements-build-test.txt \
+            -r zephyr/scripts/requirements-run-test.txt \
+            modules/lib/golioth-firmware-sdk/tests/hil/scripts/pytest-zephyr-samples \
+            git+https://github.com/golioth/python-golioth-tools@v0.6.3
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Install dependencies using single invocation to 'pip', so that:
 * Python interpreter is loaded once
 * dependencies resolution is calculated once

This saves about 15% of execution time (9.5s -> 8s on Ryzen 5950X).