### PR TITLE
coap: zephyr: honor CONFIG_GOLIOTH_USE_CONNECTION_ID

### DIFF
--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -874,6 +874,16 @@ static int golioth_setsockopt_dtls(struct golioth_client *client, int sock, cons
         }
     }
 
+    if (IS_ENABLED(CONFIG_GOLIOTH_USE_CONNECTION_ID))
+    {
+        int supported = TLS_DTLS_CID_SUPPORTED;
+        ret = zsock_setsockopt(sock, SOL_TLS, TLS_DTLS_CID, &supported, sizeof(supported));
+        if (ret < 0)
+        {
+            return -errno;
+        }
+    }
+
     if (sizeof(golioth_ciphersuites) > 0)
     {
         ret = zsock_setsockopt(sock,


### PR DESCRIPTION
Support for setting DTLS 1.2 Connection IDs was inadvertently removed in the transition from using libcoap with Zephyr to using the Zephyr CoAP client. This re-enables Connection ID support when CONFIG_GOLIOTH_USE_CONNECTION_ID is set. It is off by default.

See previous support added in https://github.com/golioth/golioth-firmware-sdk/pull/163