### PR TITLE
libcoap: block-upload: allow server-negotiated block size

### DIFF
--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -204,12 +204,19 @@ static coap_response_t coap_response_handler(coap_session_t *session,
             }
             else if (req->type == GOLIOTH_COAP_REQUEST_POST_BLOCK)
             {
+                coap_opt_iterator_t opt_iter;
+                coap_opt_t *block_opt = coap_check_option(received, COAP_OPTION_BLOCK1, &opt_iter);
+
+                /* Get block1 szx value from server; use stored value if block1 is not preset */
+                size_t server_requested_szx =
+                    block_opt ? COAP_OPT_BLOCK_SZX(block_opt) : req->post_block.block_szx;
+
                 if (req->post_block.callback)
                 {
                     req->post_block.callback(client,
                                              &response,
                                              req->path,
-                                             req->post_block.block_szx,
+                                             server_requested_szx,
                                              req->post_block.arg);
                 }
             }

--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -421,15 +421,14 @@ static void golioth_coap_add_accept(coap_pdu_t *request, enum golioth_content_ty
 
 static void golioth_coap_add_block1(coap_pdu_t *request,
                                     size_t block_index,
-                                    size_t block_size,
+                                    size_t block_szx,
                                     bool is_last)
 {
-    size_t szx = BLOCKSIZE_TO_SZX(block_size);
-    assert(szx != -1);
+    assert(block_szx <= COAP_MAX_BLOCK_SZX);
     coap_block_t block = {
         .num = block_index,
         .m = !is_last,
-        .szx = szx,
+        .szx = block_szx,
     };
 
     unsigned char buf[4];
@@ -571,7 +570,7 @@ static void golioth_coap_post_block(golioth_coap_request_msg_t *req,
     golioth_coap_add_content_type(req_pdu, req->post_block.content_type);
     golioth_coap_add_block1(req_pdu,
                             req->post_block.block_index,
-                            CONFIG_GOLIOTH_BLOCKWISE_UPLOAD_MAX_BLOCK_SIZE,
+                            req->post_block.block_szx,
                             req->post_block.is_last);
     coap_add_data(req_pdu, req->post_block.payload_size, (unsigned char *) req->post_block.payload);
     coap_send(session, req_pdu);


### PR DESCRIPTION
When performing a block upload, honor requests from the server for  a smaller block size.

Resolves: https://github.com/golioth/firmware-issue-tracker/issues/670