### PR TITLE
coap_blockwise: support passing set_cb to golioth_blockwise_post()

### DIFF
--- a/src/coap_blockwise.h
+++ b/src/coap_blockwise.h
@@ -23,6 +23,7 @@ enum golioth_status golioth_blockwise_post(struct golioth_client *client,
                                            const char *path,
                                            enum golioth_content_type content_type,
                                            read_block_cb cb,
+                                           golioth_set_cb_fn callback,
                                            void *callback_arg);
 
 /* Blockwise Download */

--- a/src/stream.c
+++ b/src/stream.c
@@ -56,7 +56,13 @@ enum golioth_status golioth_stream_set_blockwise_sync(struct golioth_client *cli
                                                       stream_read_block_cb cb,
                                                       void *arg)
 {
-    return golioth_blockwise_post(client, GOLIOTH_STREAM_PATH_PREFIX, path, content_type, cb, arg);
+    return golioth_blockwise_post(client,
+                                  GOLIOTH_STREAM_PATH_PREFIX,
+                                  path,
+                                  content_type,
+                                  cb,
+                                  NULL,
+                                  arg);
 }
 
 


### PR DESCRIPTION
`golioth_blockwise_post()` was just returning `enum golioth_status`. Add
support for `set_cb`, which will be called in case of response to blockwise
POST request.