### PR TITLE
workflows: zephyr: remove extra comma from runs-on entry

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -138,7 +138,7 @@ jobs:
     if: ${{ inputs.run_tests && !cancelled() }}
     needs: build
     runs-on:
-      - is_active,
+      - is_active
       - has_${{ inputs.hil_board }}
     timeout-minutes: 30
 


### PR DESCRIPTION
Comma after board label is causing tests to not be able to find runners.