### PR TITLE
OTA: add function for resuming component download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes:
 
+- `golioth_ota_download_component()` has a new `uint32_t
+  *next_block_idx` parameter. Use this to resume block download. Set to
+  `NULL` to use previous functionality in existing code.
 - The parameters for `ota_component_block_write_cb()` have changed to
   include `block_buffer_len` for the actual length of data and
   `negotiated_block_size` to indicate the maximum block size (may be

--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -156,22 +156,35 @@ typedef enum golioth_status (*ota_component_block_write_cb)(
     size_t negotiated_block_size,
     void *arg);
 
-/// Download an OTA component synchronously.
+/// Begin or resume downloading an OTA component synchronously.
 ///
 /// This function will block until the final block of the component download is received from the
-/// server or an error is received on any block.
+/// server or an error is received on any block. The `next_block_idx` is used to pass in the first
+/// block index to be downloaded (components begin with the 0th index). After returning, the same
+/// parameter has been updated to indicate the next expected block in the download process.
+///
+/// Use this function to resume OTA component downloads. Pass the `next_block_idx` from a failed run
+/// to resume the download. The `ota_component_block_write_cb` function must be designed to handle
+/// storage when resuming a download. Upon successful completion, it is up to the application to
+/// verify the integrity of the component (eg: compare to the SHA256 in `struct
+/// golioth_ota_component`).
 ///
 /// @param client The client handle from @ref golioth_client_create
 /// @param component One @ref golioth_ota_component instance present in the @ref
 /// golioth_ota_manifest
+/// @param[in,out] block_idx Pointer to the next expected block index. The function will
+/// request the block index supplied as an input, when returning, this variable indicates the next
+/// block index expected. When an error status is returned, use this value as the input for the next
+/// resume operation. May be NULL to begin download with block_idx 0.
 /// @param cb Callback function to register
 /// @param arg Optional argument, forwarded directly to the callback when invoked. Can be NULL.
 ///
-/// @retval GOLIOTH_OK all blocks of package were received
+/// @retval GOLIOTH_OK the final block of package was received
 /// @retval GOLIOTH_ERR_FAIL invalid client handle, path, or callback
 /// @retval GOLIOTH_ERR_MEM_ALLOC unable to allocate necessary memory
 enum golioth_status golioth_ota_download_component(struct golioth_client *client,
                                                    const struct golioth_ota_component *component,
+                                                   uint32_t *block_idx,
                                                    ota_component_block_write_cb cb,
                                                    void *arg);
 

--- a/src/coap_blockwise.c
+++ b/src/coap_blockwise.c
@@ -397,6 +397,7 @@ enum golioth_status golioth_blockwise_get(struct golioth_client *client,
                                           const char *path_prefix,
                                           const char *path,
                                           enum golioth_content_type content_type,
+                                          uint32_t *block_idx,
                                           write_block_cb cb,
                                           void *callback_arg)
 {
@@ -422,6 +423,11 @@ enum golioth_status golioth_blockwise_get(struct golioth_client *client,
 
     blockwise_download_init(ctx, data_buff, path_prefix, path, content_type, cb, callback_arg);
 
+    if (block_idx)
+    {
+        ctx->block_idx = *block_idx;
+    }
+
     ctx->sem = golioth_sys_sem_create(1, 0);
     if (!ctx->sem)
     {
@@ -436,6 +442,11 @@ enum golioth_status golioth_blockwise_get(struct golioth_client *client,
         {
             break;
         }
+    }
+
+    if (block_idx)
+    {
+        *block_idx = ctx->block_idx;
     }
 
     /* Download complete. Clean up allocated resources. */

--- a/src/coap_blockwise.h
+++ b/src/coap_blockwise.h
@@ -34,9 +34,18 @@ typedef enum golioth_status (*write_block_cb)(uint32_t block_idx,
                                               size_t negotiated_block_size,
                                               void *callback_arg);
 
+/* Begin a blockwise download from a given block index
+ *
+ * This function will block until the download finishes or an error has occurred.
+ * - The block_idx parameter out will be set to the next expected block.
+ * - This value may be used as input to resume after a block download has failed.
+ * - block_idx may be NULL, in which case 0 will be used for first block_idx and no value will be
+ *   passed out.
+ */
 enum golioth_status golioth_blockwise_get(struct golioth_client *client,
                                           const char *path_prefix,
                                           const char *path,
                                           enum golioth_content_type content_type,
+                                          uint32_t *block_idx,
                                           write_block_cb cb,
                                           void *callback_arg);

--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -246,6 +246,7 @@ static void fw_update_thread(void *arg)
 
         int err = golioth_ota_download_component(_client,
                                                  _main_component,
+                                                 NULL,
                                                  fw_write_block_cb,
                                                  (void *) &bytes_downloaded);
         if (err != GOLIOTH_OK)

--- a/src/ota.c
+++ b/src/ota.c
@@ -367,6 +367,7 @@ enum golioth_status golioth_ota_download_component(struct golioth_client *client
                                  "",
                                  component->uri,
                                  GOLIOTH_CONTENT_TYPE_OCTET_STREAM,
+                                 NULL,
                                  ota_component_write_cb_wrapper,
                                  &ctx);
 }

--- a/src/ota.c
+++ b/src/ota.c
@@ -354,6 +354,7 @@ static enum golioth_status ota_component_write_cb_wrapper(uint32_t block_idx,
 
 enum golioth_status golioth_ota_download_component(struct golioth_client *client,
                                                    const struct golioth_ota_component *component,
+                                                   uint32_t *block_idx,
                                                    ota_component_block_write_cb cb,
                                                    void *arg)
 {
@@ -367,7 +368,7 @@ enum golioth_status golioth_ota_download_component(struct golioth_client *client
                                  "",
                                  component->uri,
                                  GOLIOTH_CONTENT_TYPE_OCTET_STREAM,
-                                 NULL,
+                                 block_idx,
                                  ota_component_write_cb_wrapper,
                                  &ctx);
 }


### PR DESCRIPTION
Add `golioth_ota_download_component_resumable()` that takes a block_idx to start the download and returns the next expected block_idx which may be used to resume when a block download fails before the final block.

Resolves https://github.com/golioth/firmware-issue-tracker/issues/684
Resolves https://github.com/golioth/firmware-issue-tracker/issues/686