### PR TITLE
workflows: allure-report: silence line-length error

### DIFF
--- a/.github/workflows/reports-allure-publish.yml
+++ b/.github/workflows/reports-allure-publish.yml
@@ -80,9 +80,11 @@ jobs:
           publish_dir: ${{ env.GHPAGES_LABEL }}
 
       - name: Add Allure link to summary
+        # yamllint disable rule:line-length
         run: |
           echo "### Allure Report" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- [Workflow ${{ github.run_number }}]\
           (https://golioth.github.io/allure-reports/${{ steps.vars.outputs.allure_subdir}}/${{ github.run_number }}/)" \
           >> $GITHUB_STEP_SUMMARY
+        # yamllint enable


### PR DESCRIPTION
yamllint workflow is failing on this file because of a long line. This line includes a URL formatting string that is longer than a full line. Turn off linting for this command to silence the error.