### PR TITLE
Blockwise upload error handling

### DIFF
--- a/include/golioth/golioth_status.h
+++ b/include/golioth/golioth_status.h
@@ -12,23 +12,25 @@ extern "C"
 #pragma once
 
 /// Status code enum used throughout Golioth SDK
-#define FOREACH_GOLIOTH_STATUS(STATUS)      \
-    STATUS(GOLIOTH_OK) /* 0 */              \
-    STATUS(GOLIOTH_ERR_FAIL)                \
-    STATUS(GOLIOTH_ERR_DNS_LOOKUP)          \
-    STATUS(GOLIOTH_ERR_NOT_IMPLEMENTED)     \
-    STATUS(GOLIOTH_ERR_MEM_ALLOC)           \
-    STATUS(GOLIOTH_ERR_NULL) /* 5 */        \
-    STATUS(GOLIOTH_ERR_INVALID_FORMAT)      \
-    STATUS(GOLIOTH_ERR_SERIALIZE)           \
-    STATUS(GOLIOTH_ERR_IO)                  \
-    STATUS(GOLIOTH_ERR_TIMEOUT)             \
-    STATUS(GOLIOTH_ERR_QUEUE_FULL) /* 10 */ \
-    STATUS(GOLIOTH_ERR_NOT_ALLOWED)         \
-    STATUS(GOLIOTH_ERR_INVALID_STATE)       \
-    STATUS(GOLIOTH_ERR_NO_MORE_DATA)        \
-    STATUS(GOLIOTH_ERR_NACK)                \
-    STATUS(GOLIOTH_ERR_BAD_REQUEST)
+#define FOREACH_GOLIOTH_STATUS(STATUS)       \
+    STATUS(GOLIOTH_OK) /* 0 */               \
+    STATUS(GOLIOTH_ERR_FAIL)                 \
+    STATUS(GOLIOTH_ERR_DNS_LOOKUP)           \
+    STATUS(GOLIOTH_ERR_NOT_IMPLEMENTED)      \
+    STATUS(GOLIOTH_ERR_MEM_ALLOC)            \
+    STATUS(GOLIOTH_ERR_NULL) /* 5 */         \
+    STATUS(GOLIOTH_ERR_INVALID_FORMAT)       \
+    STATUS(GOLIOTH_ERR_SERIALIZE)            \
+    STATUS(GOLIOTH_ERR_IO)                   \
+    STATUS(GOLIOTH_ERR_TIMEOUT)              \
+    STATUS(GOLIOTH_ERR_QUEUE_FULL) /* 10 */  \
+    STATUS(GOLIOTH_ERR_NOT_ALLOWED)          \
+    STATUS(GOLIOTH_ERR_INVALID_STATE)        \
+    STATUS(GOLIOTH_ERR_NO_MORE_DATA)         \
+    STATUS(GOLIOTH_ERR_NACK)                 \
+    STATUS(GOLIOTH_ERR_BAD_REQUEST) /* 15 */ \
+    STATUS(GOLIOTH_ERR_INVALID_BLOCK_SIZE)
+
 
 #define GENERATE_GOLIOTH_STATUS_ENUM(code) code,
 enum golioth_status


### PR DESCRIPTION
Add error handling to the blockwise upload operation.

- Propagate any error returned by the application write block callback back to the initial call.
- Add an error condition for invalid block size and check the block size returned by the application callback for bounding.
- Check the status and response at the end of a block-write operation and only call the set_cb callback if there was no local error (it should still be called for successful block upload, and errors returned from the server during coap operations).

Resolves https://github.com/golioth/firmware-issue-tracker/issues/712

This implements the parts of an existing PR that are still relevant to the current state of the SDK so this PR also:
- Closes #489 