### PR TITLE
port: add sha256 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   include `block_buffer_len` for the actual length of data and
   `negotiated_block_size` to indicate the maximum block size (may be
   used along with 'block_idx' to calculate a byte offset).
+- `golioth_ota_component->hash` is now stored as an array of bytes
+  instead of as a hex string.
 
 ### Removed:
 

--- a/examples/modus_toolbox/golioth_basics/golioth_app/Makefile
+++ b/examples/modus_toolbox/golioth_basics/golioth_app/Makefile
@@ -187,6 +187,7 @@ SOURCES+=\
     $(wildcard $(GOLIOTHSDK_PATH)/port/freertos/*.c)\
     $(wildcard $(GOLIOTHSDK_PATH)/port/modus_toolbox/*.c)\
     $(wildcard $(GOLIOTHSDK_PATH)/port/modus_toolbox/libcoap/*.c)\
+    $(wildcard $(GOLIOTHSDK_PATH)/port/utils/hex.c)\
     $(wildcard $(GOLIOTHSDK_PATH)/examples/common/*.c)\
     $(GOLIOTHSDK_PATH)/external/zcbor/src/zcbor_common.c\
     $(GOLIOTHSDK_PATH)/external/zcbor/src/zcbor_decode.c\

--- a/include/golioth/golioth_sys.h
+++ b/include/golioth/golioth_sys.h
@@ -122,6 +122,68 @@ void golioth_sys_thread_destroy(golioth_sys_thread_t thread);
 #endif
 
 /*--------------------------------------------------
+ * Hash
+ *------------------------------------------------*/
+
+/* Hash functions are only needed when the OTA component is enabled. */
+
+/// Opaque handle for sha256 context
+typedef void *golioth_sys_sha256_t;
+
+/// Create a context for generating a sha256 hash.
+///
+/// Dynamically creates and initializes a context, then returns an opaque handle to the context.
+/// The handle is a required parameter for all other Golioth sha256 functions.
+///
+/// @return Non-NULL The sha256 context handle (success)
+/// @return NULL There was an error creating the context
+golioth_sys_sha256_t golioth_sys_sha256_create(void);
+
+/// Destroys a Golioth sha256 context
+///
+/// Frees memory dynamically allocated for golioth_sys_sha256_t context handle by @ref
+/// golioth_sys_sha256_create.
+///
+/// @param sha_ctx A sha256 context handle
+void golioth_sys_sha256_destroy(golioth_sys_sha256_t sha_ctx);
+
+/// Adds an input buffer into a sha256 hash calculation.
+///
+/// Call on an existing context to add data to the sha256 calculation. May be called repeatedly (eg:
+/// each block in a block download) or once for a large data set (eg: calculate the hash after
+/// writing all bytes to memory).
+///
+/// @param sha_ctx A sha256 context handle
+/// @param input   Input buffer to be added to the sha256 calculation
+/// @param len     Length of the input buffer, in bytes.
+///
+/// @return GOLIOTH_OK On success
+/// @return GOLIOTH_ERR_FAIL On failure
+enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,
+                                              const uint8_t *input,
+                                              size_t len);
+
+/// Finalizes a sha256 hash calculation and outputs to a binary buffer.
+///
+/// @param sha_ctx A sha256 context handle.
+/// @param output  A buffer of exactly 32 bytes where the sha256 value is written.
+///
+/// @return GOLIOTH_OK On success
+/// @return GOLIOTH_ERR_FAIL On failure
+enum golioth_status golioth_sys_sha256_finish(golioth_sys_sha256_t sha_ctx, uint8_t *output);
+
+/// Convert a string of hexadecimal values to an array of bytes
+///
+/// @param hex    Pointer at a hexadecimal string.
+/// @param hexlen Length of the hex string.
+/// @param buf    A buffer where binary values will be written.
+/// @param buflen Length of the binary buffer.
+///
+/// @return GOLIOTH_OK On success
+/// @return GOLIOTH_ERR_FAIL On failure
+size_t golioth_sys_hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen);
+
+/*--------------------------------------------------
  * Misc
  *------------------------------------------------*/
 

--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -22,8 +22,10 @@ extern "C"
 /// https://docs.golioth.io/reference/protocols/coap/ota
 /// @{
 
-/// Size of a SHA256 of Artifact Binary in bytes
-#define GOLIOTH_OTA_COMPONENT_HASH_LEN 64
+/// Size of a SHA256 of Artifact hex string in bytes
+#define GOLIOTH_OTA_COMPONENT_HEX_HASH_LEN 64
+/// Size of a SHA256 of Artifact bin array in bytes
+#define GOLIOTH_OTA_COMPONENT_BIN_HASH_LEN 32
 /// Maximum size of Binary Detected Type in bytes
 #define GOLIOTH_OTA_MAX_COMPONENT_BOOTLOADER_NAME_LEN 7
 /// Maximum size of Relative URI to download binary (+ 7 bytes for Path)
@@ -78,7 +80,7 @@ struct golioth_ota_component
     /// Size of the artifact, in bytes
     int32_t size;
     /// Artifact Hash
-    char hash[GOLIOTH_OTA_COMPONENT_HASH_LEN + 1];
+    uint8_t hash[GOLIOTH_OTA_COMPONENT_BIN_HASH_LEN];
     /// Artifact uri (e.g. "/.u/c/main@1.2.3")
     char uri[GOLIOTH_OTA_MAX_COMPONENT_URI_LEN + 1];
     /// Artifact bootloader ("mcuboot" or "default"")

--- a/port/esp_idf/components/golioth_sdk/CMakeLists.txt
+++ b/port/esp_idf/components/golioth_sdk/CMakeLists.txt
@@ -26,6 +26,7 @@ idf_component_register(
     SRCS
         "${sdk_port}/freertos/golioth_sys_freertos.c"
         "${sdk_port}/esp_idf/fw_update_esp_idf.c"
+        "${sdk_port}/utils/hex.c"
         "${sdk_src}/golioth_status.c"
         "${sdk_src}/coap_client.c"
         "${sdk_src}/coap_client_libcoap.c"

--- a/port/freertos/golioth_sys_freertos.c
+++ b/port/freertos/golioth_sys_freertos.c
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <golioth/golioth_sys.h>
+#include <golioth/golioth_status.h>
 #include <FreeRTOS.h>
 #include <task.h>
 #include <semphr.h>
 #include <timers.h>
 #include <string.h>  // memset
+#include "../utils/hex.h"
+#include "mbedtls/sha256.h"
 
 /*--------------------------------------------------
  * Time
@@ -190,6 +193,76 @@ golioth_sys_thread_t golioth_sys_thread_create(const struct golioth_thread_confi
 void golioth_sys_thread_destroy(golioth_sys_thread_t thread)
 {
     vTaskDelete((TaskHandle_t) thread);
+}
+
+/*-------------------------------------------------
+ * Hash
+ *------------------------------------------------*/
+
+golioth_sys_sha256_t golioth_sys_sha256_create(void)
+{
+    mbedtls_sha256_context *hash = golioth_sys_malloc(sizeof(mbedtls_sha256_context));
+    if (!hash)
+    {
+        return NULL;
+    }
+
+    mbedtls_sha256_init(hash);
+    mbedtls_sha256_starts(hash, 0);
+
+    return (golioth_sys_sha256_t) hash;
+}
+
+void golioth_sys_sha256_destroy(golioth_sys_sha256_t sha_ctx)
+{
+    if (!sha_ctx)
+    {
+        return;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    mbedtls_sha256_free(hash);
+}
+
+enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,
+                                              const uint8_t *input,
+                                              size_t len)
+{
+    if (!sha_ctx || !input)
+    {
+        return GOLIOTH_ERR_NULL;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    int err = mbedtls_sha256_update(hash, input, len);
+    if (err)
+    {
+        return GOLIOTH_ERR_FAIL;
+    }
+
+    return GOLIOTH_OK;
+}
+
+enum golioth_status golioth_sys_sha256_finish(golioth_sys_sha256_t sha_ctx, uint8_t *output)
+{
+    if (!sha_ctx || !output)
+    {
+        return GOLIOTH_ERR_NULL;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    int err = mbedtls_sha256_finish(hash, output);
+    if (err)
+    {
+        return GOLIOTH_ERR_FAIL;
+    }
+
+    return GOLIOTH_OK;
+}
+
+size_t golioth_sys_hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen)
+{
+    return hex2bin(hex, hexlen, buf, buflen);
 }
 
 /*--------------------------------------------------

--- a/port/linux/golioth_sdk/CMakeLists.txt
+++ b/port/linux/golioth_sdk/CMakeLists.txt
@@ -54,5 +54,5 @@ target_include_directories(golioth_sdk
         ${zcbor_dir}
 )
 target_link_libraries(golioth_sdk
-    PRIVATE coap-3 pthread rt)
+    PRIVATE coap-3 pthread rt crypto)
 target_compile_definitions(golioth_sdk PRIVATE -DHEATSHRINK_DYNAMIC_ALLOC=0)

--- a/port/linux/golioth_sdk/CMakeLists.txt
+++ b/port/linux/golioth_sdk/CMakeLists.txt
@@ -20,6 +20,7 @@ set(zcbor_srcs
 set(sdk_srcs
     "${sdk_port}/linux//golioth_sys_linux.c"
     "${sdk_port}/linux/fw_update_linux.c"
+    "${sdk_port}/utils/hex.c"
     "${sdk_src}/golioth_status.c"
     "${sdk_src}/coap_client.c"
     "${sdk_src}/coap_client_libcoap.c"

--- a/port/utils/hex.c
+++ b/port/utils/hex.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * These utilities already included in Zephyr tree but needed for other platforms for OTA service.
+ */
+
+#include <errno.h>
+#include "hex.h"
+
+static int char2hex(char c, uint8_t *x)
+{
+    if ((c >= '0') && (c <= '9'))
+    {
+        *x = c - '0';
+    }
+    else if ((c >= 'a') && (c <= 'f'))
+    {
+        *x = c - 'a' + 10;
+    }
+    else if ((c >= 'A') && (c <= 'F'))
+    {
+        *x = c - 'A' + 10;
+    }
+    else
+    {
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+size_t hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen)
+{
+    uint8_t dec;
+
+    if (buflen < (hexlen / 2U + hexlen % 2U))
+    {
+        return 0;
+    }
+
+    /* if hexlen is uneven, insert leading zero nibble */
+    if ((hexlen % 2U) != 0)
+    {
+        if (char2hex(hex[0], &dec) < 0)
+        {
+            return 0;
+        }
+        buf[0] = dec;
+        hex++;
+        buf++;
+    }
+
+    /* regular hex conversion */
+    for (size_t i = 0; i < (hexlen / 2U); i++)
+    {
+        if (char2hex(hex[2U * i], &dec) < 0)
+        {
+            return 0;
+        }
+        buf[i] = dec << 4;
+
+        if (char2hex(hex[2U * i + 1U], &dec) < 0)
+        {
+            return 0;
+        }
+        buf[i] += dec;
+    }
+
+    return hexlen / 2U + hexlen % 2U;
+}

--- a/port/utils/hex.h
+++ b/port/utils/hex.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2011-2014, Wind River Systems, Inc.
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * These utilities already included in Zephyr tree but needed for other platforms for OTA service.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @brief      Convert a hexadecimal string into a binary array.
+ *
+ * @param hex     The hexadecimal string to convert
+ * @param hexlen  The length of the hexadecimal string to convert.
+ * @param buf     Address of where to store the binary data
+ * @param buflen  Size of the storage area for binary data
+ *
+ * @return     The length of the binary array, or 0 if an error occurred.
+ */
+size_t hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen);

--- a/port/zephyr/golioth_sys_zephyr.c
+++ b/port/zephyr/golioth_sys_zephyr.c
@@ -7,7 +7,10 @@
 #include <zephyr/net/socket.h>
 #include <zephyr/posix/sys/eventfd.h>
 
+#include <mbedtls/sha256.h>
+
 #include <golioth/golioth_sys.h>
+#include <golioth/golioth_status.h>
 #include "golioth_log_zephyr.h"
 
 LOG_TAG_DEFINE(golioth_sys_zephyr);
@@ -282,6 +285,76 @@ void golioth_sys_thread_destroy(golioth_sys_thread_t gthread)
 
     k_thread_abort(thread->tid);
     golioth_sys_free(thread);
+}
+
+/*--------------------------------------------------
+ * Hash
+ *------------------------------------------------*/
+
+golioth_sys_sha256_t golioth_sys_sha256_create(void)
+{
+    mbedtls_sha256_context *hash = golioth_sys_malloc(sizeof(mbedtls_sha256_context));
+    if (!hash)
+    {
+        return NULL;
+    }
+
+    mbedtls_sha256_init(hash);
+    mbedtls_sha256_starts(hash, 0);
+
+    return (golioth_sys_sha256_t) hash;
+}
+
+void golioth_sys_sha256_destroy(golioth_sys_sha256_t sha_ctx)
+{
+    if (!sha_ctx)
+    {
+        return;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    mbedtls_sha256_free(hash);
+}
+
+enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,
+                                              const uint8_t *input,
+                                              size_t len)
+{
+    if (!sha_ctx || !input)
+    {
+        return GOLIOTH_ERR_NULL;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    int err = mbedtls_sha256_update(hash, input, len);
+    if (err)
+    {
+        return GOLIOTH_ERR_FAIL;
+    }
+
+    return GOLIOTH_OK;
+}
+
+enum golioth_status golioth_sys_sha256_finish(golioth_sys_sha256_t sha_ctx, uint8_t *output)
+{
+    if (!sha_ctx || !output)
+    {
+        return GOLIOTH_ERR_NULL;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    int err = mbedtls_sha256_finish(hash, output);
+    if (err)
+    {
+        return GOLIOTH_ERR_FAIL;
+    }
+
+    return GOLIOTH_OK;
+}
+
+size_t golioth_sys_hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen)
+{
+    return hex2bin(hex, hexlen, buf, buflen);
 }
 
 /*--------------------------------------------------

--- a/src/ota.c
+++ b/src/ota.c
@@ -12,6 +12,7 @@
 #include "coap_blockwise.h"
 #include "coap_client.h"
 #include <golioth/golioth_debug.h>
+#include <golioth/golioth_sys.h>
 #include "golioth_util.h"
 #include <golioth/zcbor_utils.h>
 
@@ -216,9 +217,10 @@ static int components_decode(zcbor_state_t *zsd, void *value)
             component->version,
             sizeof(component->version) - 1,
         };
+        char hash_string[GOLIOTH_OTA_COMPONENT_HEX_HASH_LEN + 1];
         struct component_tstr_value hash = {
-            component->hash,
-            sizeof(component->hash) - 1,
+            hash_string,
+            sizeof(hash_string) - 1,
         };
         struct component_tstr_value uri = {
             component->uri,
@@ -248,6 +250,10 @@ static int components_decode(zcbor_state_t *zsd, void *value)
             return err;
         }
 
+        golioth_sys_hex2bin(hash_string,
+                            strlen(hash_string),
+                            component->hash,
+                            sizeof(component->hash));
         component->size = component_size;
 
         manifest->num_components++;

--- a/tests/hil/tests/ota/test.c
+++ b/tests/hil/tests/ota/test.c
@@ -32,10 +32,23 @@ struct golioth_client *client;
 
 static void log_component_members(const struct golioth_ota_component *component)
 {
+    char hash_string[GOLIOTH_OTA_COMPONENT_HEX_HASH_LEN + 1];
+    for (int i = 0; i < sizeof(component->hash); i++)
+    {
+        int write_idx = i * 2;
+        if (write_idx > (GOLIOTH_OTA_COMPONENT_HEX_HASH_LEN - 2))
+        {
+            GLTH_LOGE(TAG, "Error converting component hash to string");
+            return;
+        }
+
+        sprintf(hash_string + write_idx, "%02x", component->hash[i]);
+    }
+
     GLTH_LOGI(TAG, "component.package: %s", component->package);
     GLTH_LOGI(TAG, "component.version: %s", component->version);
     GLTH_LOGI(TAG, "component.size: %u", (unsigned int) component->size);
-    GLTH_LOGI(TAG, "component.hash: %s", component->hash);
+    GLTH_LOGI(TAG, "component.hash: %s", hash_string);
     GLTH_LOGI(TAG, "component.uri: %s", component->uri);
     GLTH_LOGI(TAG, "component.bootloader: %s", component->bootloader);
 }


### PR DESCRIPTION
Add an API for generating a sha256 hash that can be used to validate an OTA component.

Resolves https://github.com/golioth/firmware-issue-tracker/issues/717