### PR TITLE
examples: zephyr: fw_update: fix rak5010 board name in sample.yaml

### DIFF
--- a/examples/zephyr/fw_update/sample.yaml
+++ b/examples/zephyr/fw_update/sample.yaml
@@ -23,7 +23,7 @@ tests:
     build_only: true
     sysbuild: true
     platform_allow:
-      - rak5010_nrf52840
+      - rak5010/nrf52840
   sample.golioth.fw_update.native:
     build_only: true
     platform_allow:


### PR DESCRIPTION
Use `rak5010/nrf52840` instead.