### PR TITLE
examples: zephyr: certificate_provisioning: pytest improvements

### DIFF
--- a/examples/zephyr/certificate_provisioning/pytest/conftest.py
+++ b/examples/zephyr/certificate_provisioning/pytest/conftest.py
@@ -40,12 +40,13 @@ def anyio_backend():
     return 'trio'
 
 @pytest.fixture(scope="module")
-async def certificate_cred(project):
-    subprocess.run([WEST_TOPDIR / "modules/lib/golioth-firmware-sdk/scripts/certificates/generate_root_certificate.sh"])
+async def certificate_cred(request, project):
+    subprocess.run([WEST_TOPDIR / "modules/lib/golioth-firmware-sdk/scripts/certificates/generate_root_certificate.sh"],
+                   cwd=request.config.option.build_dir)
 
     # Pass root public key to Golioth server
 
-    with open('golioth.crt.pem', 'rb') as f:
+    with open(Path(request.config.option.build_dir) / 'golioth.crt.pem', 'rb') as f:
         cert_pem = f.read()
     root_cert = await project.certificates.add(cert_pem, 'root')
     yield root_cert['data']['id']

--- a/examples/zephyr/certificate_provisioning/pytest/conftest.py
+++ b/examples/zephyr/certificate_provisioning/pytest/conftest.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 import os
 from pathlib import Path
 import random
@@ -18,9 +19,12 @@ def pytest_addoption(parser):
 def get_device_port(request):
     if request.config.getoption("--device-port") is not None:
         return request.config.getoption("--device-port")
-    else:
+
+    with suppress(KeyError):
         port_key = f"CI_{os.environ['hil_board'].upper()}_PORT"
         return os.environ[port_key]
+
+    return request.config.option.device_serial
 
 @pytest.fixture
 def mcumgr_conn_args(request, dut):

--- a/examples/zephyr/certificate_provisioning/pytest/test_sample.py
+++ b/examples/zephyr/certificate_provisioning/pytest/test_sample.py
@@ -24,7 +24,10 @@ def subprocess_logger(result, log_msg):
     if result.stderr:
         LOGGER.error(f'{log_msg} stderr: {result.stderr}')
 
-async def test_credentials(shell, project, device_name, mcumgr_conn_args, certificate_cred, wifi_ssid, wifi_psk):
+async def test_credentials(request, shell,
+                           project, device_name,
+                           mcumgr_conn_args, certificate_cred,
+                           wifi_ssid, wifi_psk):
     # Check cloud to verify device does not exist
 
     with pytest.raises(Exception):
@@ -33,7 +36,8 @@ async def test_credentials(shell, project, device_name, mcumgr_conn_args, certif
     # Generate device certificates
 
     subprocess.run([WEST_TOPDIR / "modules/lib/golioth-firmware-sdk/scripts/certificates/generate_device_certificate.sh",
-                    project.info['id'], device_name])
+                    project.info['id'], device_name],
+                   cwd=request.config.option.build_dir)
 
     # Set WiFi credential
 
@@ -54,7 +58,8 @@ async def test_credentials(shell, project, device_name, mcumgr_conn_args, certif
                             ["--tries=3", "--timeout=2",
                              "fs", "upload",
                              f"{project.info['id']}-{device_name}.crt.der", FS_CRT_PATH],
-                            capture_output=True, text=True)
+                            capture_output=True, text=True,
+                            cwd=request.config.option.build_dir)
     subprocess_logger(result, 'mcumgr crt')
     assert result.returncode == 0
 
@@ -62,7 +67,8 @@ async def test_credentials(shell, project, device_name, mcumgr_conn_args, certif
                             ["--tries=3", "--timeout=2",
                              "fs", "upload",
                              f"{project.info['id']}-{device_name}.key.der", FS_KEY_PATH],
-                            capture_output=True, text=True)
+                            capture_output=True, text=True,
+                            cwd=request.config.option.build_dir)
     subprocess_logger(result, 'mcumgr key')
     assert result.returncode == 0
 

--- a/examples/zephyr/certificate_provisioning/pytest/test_sample.py
+++ b/examples/zephyr/certificate_provisioning/pytest/test_sample.py
@@ -54,7 +54,7 @@ async def test_credentials(shell, project, device_name, mcumgr_conn_args, certif
                             ["--tries=3", "--timeout=2",
                              "fs", "upload",
                              f"{project.info['id']}-{device_name}.crt.der", FS_CRT_PATH],
-                            capture_output = True, text = True)
+                            capture_output=True, text=True)
     subprocess_logger(result, 'mcumgr crt')
     assert result.returncode == 0
 
@@ -62,7 +62,7 @@ async def test_credentials(shell, project, device_name, mcumgr_conn_args, certif
                             ["--tries=3", "--timeout=2",
                              "fs", "upload",
                              f"{project.info['id']}-{device_name}.key.der", FS_KEY_PATH],
-                            capture_output = True, text = True)
+                            capture_output=True, text=True)
     subprocess_logger(result, 'mcumgr key')
     assert result.returncode == 0
 


### PR DESCRIPTION
- drop spaces around `=` to suppress flake8's "unexpected spaces around keyword / parameter equals"
  warning
- use build directory as CWD, so that certs/keys are stored in per-application directory (instead of
  current directory from which twister is invoked)
- use twister serial for mcumgr, so `--device-port` CLI argument (or `CI_DEVNAME_PORT` environment
  variable) is not required