### PR TITLE
coap_client_zephyr: ensure keepalive timer reset on observation

### DIFF
--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -306,8 +306,9 @@ static int golioth_coap_cb(struct golioth_req_rsp *rsp)
                 req->observe
                     .callback(client, &response, req->path, rsp->data, rsp->len, req->observe.arg);
             }
-            /* There is no synchronous version of observe request */
-            return 0;
+            /* There is no synchronous version of observe request, req->request_complete_event will
+               always be NULL. */
+            break;
     }
 
     if (CONFIG_GOLIOTH_COAP_KEEPALIVE_INTERVAL_S > 0)


### PR DESCRIPTION
Ensure that we reset the keepalive timer when we receive an observation response.