### PR TITLE
hil: zephyr: increase log buffer to prevent dropped logs

### DIFF
--- a/tests/hil/platform/zephyr/prj.conf
+++ b/tests/hil/platform/zephyr/prj.conf
@@ -36,3 +36,6 @@ CONFIG_GOLIOTH_OTA_MAX_NUM_COMPONENTS=2
 
 # Allow for larger error message buffer for Settings service
 CONFIG_GOLIOTH_SETTINGS_MAX_RESPONSE_LEN=512
+
+# Double log memory to prevent dropped logs on settings test
+CONFIG_LOG_BUFFER_SIZE=2048


### PR DESCRIPTION
When running the settings HIL test for Zephyr, logs are often dropped because of the number of settings being reported on first connect. This often results in the "Connected" message being dropped which causes the test to fail.

Double the size of the Zephyr log buffer to 2048 to prevent logs from being dropped.