### PR TITLE
hil: ota: use 1 Hz polling for reason and state test

### DIFF
--- a/tests/hil/tests/ota/test.c
+++ b/tests/hil/tests/ota/test.c
@@ -98,7 +98,7 @@ static void test_reason_and_state(void)
         {
             GLTH_LOGI(TAG, "OTA status reported successfully");
         }
-        golioth_sys_msleep(7000);
+        golioth_sys_msleep(4000);
     }
 
     GLTH_LOGI(TAG, "golioth_ota_get_state: %d", golioth_ota_get_state());


### PR DESCRIPTION
Use 1 Hz polling in pytest to catch reason and state changes more efficiently.

This removes an arbitrary delay, instead trying multiple times to get the device's reported reason and state codes. On the final timeout, the asserts will always be run so we retain helpful logging messages. This PR also reduces the device delay by 3 seconds, which equates to 30 seconds saved across all reason codes.