### PR TITLE
examples: zephyr: rename certificate provisioning test func

### DIFF
--- a/examples/zephyr/certificate_provisioning/pytest/test_sample.py
+++ b/examples/zephyr/certificate_provisioning/pytest/test_sample.py
@@ -24,10 +24,10 @@ def subprocess_logger(result, log_msg):
     if result.stderr:
         LOGGER.error(f'{log_msg} stderr: {result.stderr}')
 
-async def test_credentials(request, shell,
-                           project, device_name,
-                           mcumgr_conn_args, certificate_cred,
-                           wifi_ssid, wifi_psk):
+async def test_cert_provisioning(request, shell,
+                                 project, device_name,
+                                 mcumgr_conn_args, certificate_cred,
+                                 wifi_ssid, wifi_psk):
     # Check cloud to verify device does not exist
 
     with pytest.raises(Exception):


### PR DESCRIPTION
Rename the pytest function used to test the certificate provisioning sample from `test_credentials()` to `test_cert_provisioning()`. This will make it easier to identify the test in Allure reports.