### PR TITLE
hil: tests: use success/failure instead of cancelled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -261,14 +261,14 @@ jobs:
             hil-out/*/coverage.json
 
       - name: Safe upload CI report summary
-        if: ${{ !cancelled() }}
+        if: success() || failure()
         uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
           name: ci-individual-hil-zephyr-${{ matrix.platform }}-${{ matrix.test }}
           path: summary/*
 
       - name: Safe upload Allure reports
-        if: ${{ !cancelled() }}
+        if: success() || failure()
         uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}
@@ -279,7 +279,7 @@ jobs:
     name: zephyr-summary-hil-nsim
     runs-on: ubuntu-latest
     needs: hil_test_zephyr_nsim
-    if: ${{ !cancelled() }}
+    if: success() || failure()
 
     strategy:
       fail-fast: false
@@ -501,7 +501,7 @@ jobs:
     name: zephyr-summary-twister
     runs-on: ubuntu-latest
     needs: hil_sample_zephyr_nsim
-    if: ${{ !cancelled() }}
+    if: success() || failure()
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Jobs set to !cancelled() were still running when steps they depend on where skipped. In the case of Zephyr sample summaries for nsim, integration tests were failing because these summary steps still ran even though the summary tests were skipped.

Use success() || failure() to only run when the job either failed or succeeded.

## Examples of failure before fix

Zephyr Sample summary steps running during unrelated integration jobs
![image](https://github.com/user-attachments/assets/7c3c0f35-51f6-4cda-84e0-fc67f1fe9431)
![image](https://github.com/user-attachments/assets/f501c434-22b0-459a-a8a4-3784155c67e3)
