### PR TITLE
examples: linux: fix error checks and update information to match current cert usage

### DIFF
--- a/examples/linux/certificate_auth/README.md
+++ b/examples/linux/certificate_auth/README.md
@@ -44,7 +44,7 @@ You should generate a new device certificate for every new device.
 
 ```
 cd certs
-../../../../scripts/certificates/generate_device_certificate.sh <project_id> <certificate_id>
+../../../../scripts/certificates/generate_device_certificate.sh <project_id> <certificate_id> pem
 ```
 
 * `project_id` must match the project ID in Golioth.
@@ -58,16 +58,16 @@ cd certs
 This will create three files in the `certs` directory:
 
 ```
-<project_id>-<certificate_id>.crt.der (public, cert presented to server)
-<project_id>-<certificate_id>.key.der (private, used for signing/decrypting)
+<project_id>-<certificate_id>.crt.pem (public, cert presented to server)
+<project_id>-<certificate_id>.key.pem (private, used for signing/decrypting)
 ```
 
 Copy the first two files to new files with standard names (required for project to run):
 
 ```
 cd certs
-cp <project_id>-<certificate_id>.crt.der client.crt.der
-cp <project_id>-<certificate_id>.key.der client.key.der
+cp <project_id>-<certificate_id>.crt.pem client.crt.pem
+cp <project_id>-<certificate_id>.key.pem client.key.pem
 ```
 
 ## A note about root_ca.pem

--- a/examples/linux/certificate_auth/README.md
+++ b/examples/linux/certificate_auth/README.md
@@ -70,18 +70,17 @@ cp <project_id>-<certificate_id>.crt.pem client.crt.pem
 cp <project_id>-<certificate_id>.key.pem client.key.pem
 ```
 
-## A note about root_ca.pem
+## Get server root CA certificate
 
-The file `root_ca.pem` is the public certificate of the root CA that was used
-to sign the server's certificate (which it presents to the device during DTLS
-handshake). This is required in order for the device to verify the authenticity
-of the Golioth server.
+In order to verify that you are communicating with Golioth servers, the
+CA certificate at the root of the trust chain that ends with the
+certificate presented by the server must be included. The CA certificate
+can be obtained from the SDK source and made accessible by copying it
+into this directory.
 
-It is not one of the generated files from the previous steps. This file should be left alone.
-
-The file was copied from the Let's Encrypt website (ISRG Root X1):
-
-https://letsencrypt.org/certificates/
+```
+cp ../../../src/isrgrootx1_goliothrootx1.pem .
+```
 
 ## Build and run
 

--- a/examples/linux/certificate_auth/main.c
+++ b/examples/linux/certificate_auth/main.c
@@ -35,12 +35,10 @@ int main(void)
     uint8_t client_cert_pem[MAX_PEM_FILE_SIZE];
     uint8_t root_ca_pem[MAX_PEM_FILE_SIZE];
 
-    size_t client_key_len =
-        read_file("certs/client.key.pem", client_key_pem, sizeof(client_key_pem));
-    size_t client_cert_len =
+    int client_key_len = read_file("certs/client.key.pem", client_key_pem, sizeof(client_key_pem));
+    int client_cert_len =
         read_file("certs/client.crt.pem", client_cert_pem, sizeof(client_cert_pem));
-    size_t root_ca_len =
-        read_file("isrgrootx1_goliothrootx1.pem", root_ca_pem, sizeof(root_ca_pem));
+    int root_ca_len = read_file("isrgrootx1_goliothrootx1.pem", root_ca_pem, sizeof(root_ca_pem));
     if ((client_key_len <= 0) || (client_cert_len <= 0) || (root_ca_len <= 0))
     {
         return 1;


### PR DESCRIPTION
Switches to using int as return type for read_file to properly detect
errors.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

Updates to generate PEM device certificates, which are expected by the
certificate_auth sample application.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

Updates the README.md to instruct the user to obtain the root CA
certificate from the SDK source.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>