### PR TITLE
examples: linux: increase max size of CA cert PEM file

### DIFF
--- a/examples/linux/certificate_auth/main.c
+++ b/examples/linux/certificate_auth/main.c
@@ -11,7 +11,7 @@
 
 #define TAG "main"
 
-#define MAX_PEM_FILE_SIZE 2048
+#define MAX_PEM_FILE_SIZE 4096
 
 static int read_file(const char *filepath, uint8_t *buffer, size_t buffer_size)
 {


### PR DESCRIPTION
If multiple CA certificates are included in the PEM file it could easily overflow the 2048 limit. This doubles the max to provide plenty of space for 2 certificates, which is the common case.