### PR TITLE
ci: remove unused arg from coverage upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -620,7 +620,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          secrets-json: ${{ toJson(secrets) }}
           name: coverage-native-sim
           path: coverage/*
 


### PR DESCRIPTION
The `secrets_json` argument is used with the `safe-upload-artifacts` action, and is not a valid argument to the standard `upload-artifacts` action. Coverage information does not contain sensitive information so we can continue using the standard upload action. Remove the unused argument to suppress warnings in the GitHub Actions UI.

This is the warning in question:
<img width="1279" alt="Screenshot 2024-11-20 at 5 23 09 PM" src="https://github.com/user-attachments/assets/144b69d9-d5a2-49e7-8a21-8008d6946393">
