### PR TITLE
tests: hil: make --hil-board and ${hil_board} optional

### DIFF
--- a/tests/hil/scripts/pytest-zephyr-samples/plugin.py
+++ b/tests/hil/scripts/pytest-zephyr-samples/plugin.py
@@ -37,8 +37,10 @@ def runner_name(request):
 def pytest_runtest_setup(item):
     if item.config.getoption("--hil-board") is not None:
         hil_board = item.config.getoption("--hil-board")
-    else:
+    elif 'hil_board' in os.environ:
         hil_board = os.environ['hil_board']
+    else:
+        hil_board = item.config.option.device_serial
 
     allure.dynamic.tag(hil_board)
     allure.dynamic.tag("zephyr")


### PR DESCRIPTION
Fallback to device serial when both `--hil-board` and `${hil_board}` are
missing. This allows to successfully run twister without providing those.
This also fixes parallel run of twister for many platforms, which requires
each to be unique in that scenario.