### PR TITLE
test: fw_update: use first platform specified

### DIFF
--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -206,6 +206,7 @@ jobs:
                 --device-serial ${!PORT_VAR}                                                      \
                 --test-only                                                                       \
                 ${{ inputs.extra_twister_args }}                                                  \
+                --pytest-args="-s"                                   \
                 --pytest-args="--api-url=${{ inputs.api-url }}"                                   \
                 --pytest-args="--api-key=${{ secrets[inputs.api-key-id] }}"                       \
                 --pytest-args="--wifi-ssid=${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}"  \

--- a/examples/zephyr/fw_update/pytest/conftest.py
+++ b/examples/zephyr/fw_update/pytest/conftest.py
@@ -2,13 +2,14 @@ import golioth
 import os
 import pytest
 
-UPDATE_VERSION = '255.8.9'
-UPDATE_PACKAGE = 'main'
+UPDATE_VERSION = "255.8.9"
+UPDATE_PACKAGE = "main"
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def anyio_backend():
-    return 'trio'
+    return "trio"
+
 
 @pytest.fixture(scope="session")
 async def fw_info():
@@ -17,13 +18,15 @@ async def fw_info():
 
 @pytest.fixture(scope="module")
 async def blueprint_id(project, request):
-    bp_name = request.config.option.platform[0].replace('/','_')
+    bp_name = request.config.option.platform[0].replace("/", "_")
+    print(request.config.option.platform.replace("/", "_"))
+    print(request.config.option.platform[0].replace("/", "_"))
     yield await project.blueprints.get_id(bp_name)
 
 
 @pytest.fixture(scope="module")
 async def tag(project, device, blueprint_id):
-    tag_name = device.name.lower().replace('-','_')
+    tag_name = device.name.lower().replace("-", "_")
     tag = await project.tags.create(tag_name)
 
     await device.add_blueprint(blueprint_id)
@@ -46,9 +49,11 @@ async def artifact(project, blueprint_id):
     artifact = None
     all_artifacts = await project.artifacts.get_all()
     for a in all_artifacts:
-        if (a.blueprint == blueprint_id and
-            a.version == UPDATE_VERSION and
-            a.package == UPDATE_PACKAGE):
+        if (
+            a.blueprint == blueprint_id
+            and a.version == UPDATE_VERSION
+            and a.package == UPDATE_PACKAGE
+        ):
             artifact = a
 
     assert artifact != None

--- a/examples/zephyr/fw_update/pytest/conftest.py
+++ b/examples/zephyr/fw_update/pytest/conftest.py
@@ -17,7 +17,7 @@ async def fw_info():
 
 @pytest.fixture(scope="module")
 async def blueprint_id(project, request):
-    bp_name = request.config.option.platform.replace('/','_')
+    bp_name = request.config.option.platform[0].replace('/','_')
     yield await project.blueprints.get_id(bp_name)
 
 


### PR DESCRIPTION
Platform is a list argument and can be specified multiple times. We currently only ever invoke pytest with a single platform and it should be used to fetch the blueprint ID for the fw_update sample test.