### PR TITLE
ci: run twister tests using with NCS when using nrf9160dk

### DIFF
--- a/.ci-west-ncs-twister.yml
+++ b/.ci-west-ncs-twister.yml
@@ -1,0 +1,11 @@
+manifest:
+  self:
+    path: modules/lib/golioth-firmware-sdk
+    import:
+      file: west-ncs.yml
+      name-allowlist:
+        - nrf
+        - zephyr
+    userdata:
+      patches_dirs:
+        - patches/west-ncs

--- a/.ci-west-ncs.yml
+++ b/.ci-west-ncs.yml
@@ -19,3 +19,6 @@ manifest:
         - trusted-firmware-m
         - zcbor
         - zephyr
+    userdata:
+      patches_dirs:
+        - patches/west-ncs

--- a/.github/workflows/hil_sample_zephyr.yml
+++ b/.github/workflows/hil_sample_zephyr.yml
@@ -160,11 +160,14 @@ jobs:
         run: |
           rm -rf zephyr
 
+          MANIFEST=${{ inputs.manifest }}
+          MANIFEST_TWISTER=${MANIFEST%.yml}-twister.yml
+
           mkdir -p .west
           cat <<EOF > .west/config
           [manifest]
           path = modules/lib/golioth-firmware-sdk
-          file = .ci-west-zephyr-twister.yml
+          file = ${MANIFEST_TWISTER}
           EOF
 
           west update -o=--depth=1 -n

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -7,3 +7,7 @@ manifest:
 
   self:
     path: modules/lib/golioth-firmware-sdk
+    west-commands: scripts/west-commands.yml
+    userdata:
+      patches_dirs:
+        - patches/west-ncs


### PR DESCRIPTION
So far twister build stage was run either with Zephyr or NCS fork of
Zephyr. Twister test stage was run always with Zephyr.

This approach is not compatible anymore (since there are obviously two
different twister implementations) after switching to Zephyr 4.0.0 and NCS
2.8.0.

Introduce `.ci-west-ncs-twister.yml` and allow `nrf` and `zephyr` repositories
to make tests work with twister. Use it to initialize SDK with NCS and NCS' fork
of Zephyr as dependencies, so that the same twister implementation is used for
build and testing.

Fixes: 7aa069cdc22f ("bump NCS to 2.8.0")