### PR TITLE
examples: zephyr: use 32 as default PSK max length

### DIFF
--- a/examples/zephyr/common/Kconfig
+++ b/examples/zephyr/common/Kconfig
@@ -131,9 +131,10 @@ config GOLIOTH_SAMPLE_PSK_ID_MAX_LEN
 config GOLIOTH_SAMPLE_PSK_MAX_LEN
 	int "Max length of PSK"
 	default MBEDTLS_PSK_MAX_LEN if MBEDTLS_BUILTIN
-	default 64
+	default 32
 	help
-	  Maximum length of PSK, in bytes.
+      Maximum length of PSK, in bytes. Modification may require also updating
+      MBEDTLS_PSK_MAX_LEN.
 
 endif # GOLIOTH_SAMPLE_SETTINGS
 


### PR DESCRIPTION
Using a PSK that is longer than 32 bytes does not work because the default MBEDTLS_PSK_MAX_LEN is set to 32 bytes. In the event that MBEDTLS_BUILTIN is set, the default will be 32. However, if MBEDTLS_BUILTIN is not set, as is the case when NRF_SECURITY is set, the default will be 64, which is larger than the default of 32 in mbedtls (when not using TLS 1.3). If a PSK with length greater than 32 is used, we will not alert that the PSK is too large, but the connection will fail due to the mbedtls max length.

This updates to make the default match the 32 bytes used by mbedtls. This ensures that users will not encounter connection issues unless they have modified the max length, which now has a disclaimer that updating MBEDTLS_PSK_MAX_LEN may be required as well.

Ref: https://github.com/Mbed-TLS/mbedtls/blob/f27c10596ba20f8baab93530b365861b16e1ecf0/include/mbedtls/ssl.h#L650