### PR TITLE
fw_update: add resume download functionality

### DIFF
--- a/include/golioth/fw_update.h
+++ b/include/golioth/fw_update.h
@@ -103,13 +103,15 @@ void fw_update_cancel_rollback(void);
 /// Handle a single block of a new firmware image (e.g. write to flash
 /// in the secondary firmware slot).
 ///
+/// This function must return GOLIOTH_ERR_IO when there is an issue storing the block.
+///
 /// @param block The block data buffer
 /// @param block_size The block data size, in bytes
 /// @param offset The offset of this block in the overall firmware image
 /// @param total_size The total firmware image size
 ///
 /// @return GOLIOTH_OK - Block handled
-/// @return Otherwise - error handling block, abort firmware update
+/// @return GOLIOTH_ERR_IO - error handling block, abort firmware update
 enum golioth_status fw_update_handle_block(const uint8_t *block,
                                            size_t block_size,
                                            size_t offset,

--- a/port/esp_idf/fw_update_esp_idf.c
+++ b/port/esp_idf/fw_update_esp_idf.c
@@ -68,7 +68,7 @@ enum golioth_status fw_update_handle_block(const uint8_t *block,
         {
             GLTH_LOGE(TAG, "esp_ota_begin failed (%s)", esp_err_to_name(err));
             esp_ota_abort(_update_handle);
-            return GOLIOTH_ERR_FAIL;
+            return GOLIOTH_ERR_IO;
         }
     }
 
@@ -77,7 +77,7 @@ enum golioth_status fw_update_handle_block(const uint8_t *block,
     {
         GLTH_LOGE(TAG, "esp_ota_write failed (%s)", esp_err_to_name(err));
         esp_ota_abort(_update_handle);
-        return GOLIOTH_ERR_FAIL;
+        return GOLIOTH_ERR_IO;
     }
 
     return GOLIOTH_OK;

--- a/port/modus_toolbox/fw_update_mcuboot.c
+++ b/port/modus_toolbox/fw_update_mcuboot.c
@@ -51,7 +51,7 @@ enum golioth_status fw_update_handle_block(
         const struct image_header* header = (const struct image_header*)block;
         if (header->ih_magic != IMAGE_MAGIC) {
             GLTH_LOGE(TAG, "Image header invalid, IMAGE_MAGIC not found");
-            return GOLIOTH_ERR_FAIL;
+            return GOLIOTH_ERR_IO;
         }
 
         // Open secondary flash area
@@ -59,7 +59,7 @@ enum golioth_status fw_update_handle_block(
         status = flash_area_open(secondary_id, &_secondary_flash_area);
         if (status != 0) {
             GLTH_LOGE(TAG, "flash_area_open error: %d", status);
-            return GOLIOTH_ERR_FAIL;
+            return GOLIOTH_ERR_IO;
         }
 
         GLTH_LOGD(TAG, "Secondary flash area:");
@@ -75,7 +75,7 @@ enum golioth_status fw_update_handle_block(
         GLTH_LOGI(TAG, "Done erasing flash");
         if (status != 0) {
             GLTH_LOGE(TAG, "flash_area_erase error: %d", status);
-            return GOLIOTH_ERR_FAIL;
+            return GOLIOTH_ERR_IO;
         }
     }
 
@@ -83,7 +83,7 @@ enum golioth_status fw_update_handle_block(
     status = flash_area_write(_secondary_flash_area, offset, block, block_size);
     if (status != 0) {
         GLTH_LOGE(TAG, "flash_area_write error: %d", status);
-        return GOLIOTH_ERR_FAIL;
+        return GOLIOTH_ERR_IO;
     }
 
     return GOLIOTH_OK;

--- a/port/zephyr/golioth_fw_zephyr.c
+++ b/port/zephyr/golioth_fw_zephyr.c
@@ -207,7 +207,7 @@ enum golioth_status fw_update_handle_block(const uint8_t *block,
         err = flash_img_prepare(&_flash_img_context);
         if (err)
         {
-            return GOLIOTH_ERR_FAIL;
+            return GOLIOTH_ERR_IO;
         }
     }
 
@@ -215,7 +215,7 @@ enum golioth_status fw_update_handle_block(const uint8_t *block,
     if (err)
     {
         LOG_ERR("Failed to write to flash: %d", err);
-        return GOLIOTH_ERR_FAIL;
+        return GOLIOTH_ERR_IO;
     }
 
     return GOLIOTH_OK;


### PR DESCRIPTION
When an error occurs during a firmware block download, the download will now resume from that block instead of starting from the beginning.

Each block is included in a sha256 hash calculation during the download and compared to the server-supplied hash to verify a successful download. This comparison is made while the data is in RAM, before it is written to flash.

If a flash write error occurs during block download, the firmware download is considered a failure and will not try to resume from that block.

Resolves: https://github.com/golioth/firmware-issue-tracker/issues/688
Resolves: https://github.com/golioth/firmware-issue-tracker/issues/698