### PR TITLE
workflows: use upstream action for reports-allure-publish

### DIFF
--- a/.github/workflows/reports-allure-publish.yml
+++ b/.github/workflows/reports-allure-publish.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Build Allure report
-        uses: szczys/allure-report-action@fix-workflow-url-when-hosted-remotely
+        uses: simple-elf/allure-report-action@v1
         if: always()
         with:
           gh_pages: ${{ env.GHPAGES_LABEL }}


### PR DESCRIPTION
Change back to upstream GH action for Allure Reports publishing now that changes we needed are merged.