### PR TITLE
fw_update: do not drop manifests based on state; store target components

### DIFF
--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -223,9 +223,8 @@ static void fw_download_failed(enum golioth_ota_reason reason)
 
     fw_update_end();
 
-    GLTH_LOGI(TAG, "State = Idle");
     golioth_fw_update_report_state_sync(_client,
-                                        GOLIOTH_OTA_STATE_IDLE,
+                                        GOLIOTH_OTA_STATE_DOWNLOADING,
                                         reason,
                                         _component_ctx.config.fw_package_name,
                                         _component_ctx.config.current_version,


### PR DESCRIPTION
Allow a new manifest to be received regardless of the state of the fw_update thread. This removes the need to drop a new manifest during the downloading step. To make this possible, a new version of the target component is copied from the manifest for the fw_update thread to use during the download process.

Resolves: https://github.com/golioth/firmware-issue-tracker/issues/748