### PR TITLE
ota: add reason codes related to fw_update

### DIFF
--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -68,6 +68,10 @@ enum golioth_ota_reason
     GOLIOTH_OTA_REASON_FIRMWARE_UPDATE_FAILED,
     /// Protocol not supported
     GOLIOTH_OTA_REASON_UNSUPPORTED_PROTOCOL,
+    /// IO error while trying to store component
+    GOLIOTH_OTA_REASON_IO,
+    /// Awaiting retry
+    GOLIOTH_OTA_REASON_AWAIT_RETRY,
 };
 
 /// A component/artifact within an OTA manifest


### PR DESCRIPTION
We need more reason codes to better indicate behavior added to the SDK. This PR seeks alignment from the firmware and cloud teams as the codes will need to be added to both the SDK and the Console.

Please view the comments for each new code in the commit. I think these should align with what is shown in the console so adding your thoughts on those lines is appreciated!

## Here is a rundown of how I think these codes will be used

1. Firmware download begins, current behavior remains the same:
    ```
    GOLIOTH_OTA_STATE_DOWNLOADING : GOLIOTH_OTA_REASON_READY
    ```

2. Failure while downloading a block (client restart or request timeout):
    ```
    GOLIOTH_OTA_STATE_DOWNLOADING : GOLIOTH_OTA_REASON_BLOCK_FAILED
    ```

3. Previous failure does not cause the download to fail... we will immediately try to resume. This combined with step two means that repeated block failures followed by resumes will not be hidden by deduplication on the cloud.
    ```
    GOLIOTH_OTA_STATE_DOWNLOADING : GOLIOTH_OTA_REASON_RESUMING
    ```

4. Block is downloaded but cannot be written storage (e.g. flash memory)
    ```
    GOLIOTH_OTA_STATE_DOWNLOADING : GOLIOTH_OTA_REASON_IO
    ```

5. Previous error is not resumable, block download fails immediately but will enter a state of retry from the beginning with backoff delay. This is not yet implemented but the plan is that in this state a new manifest can still be received, cancelling the retry.
    ```
    GOLIOTH_OTA_STATE_IDLE : GOLIOTH_OTA_REASON_AWAIT_RETRY
    ```