### PR TITLE
coap: tokens: store as uint64_t instead of as array

### DIFF
--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -639,8 +639,7 @@ enum golioth_status golioth_coap_client_observe_release(struct golioth_client *c
                                                         const char *path_prefix,
                                                         const char *path,
                                                         enum golioth_content_type content_type,
-                                                        uint8_t *token,
-                                                        size_t token_len,
+                                                        uint64_t token,
                                                         void *arg)
 {
     if (!client || !path)
@@ -675,9 +674,7 @@ enum golioth_status golioth_coap_client_observe_release(struct golioth_client *c
     }
     strncpy(request_msg.path, path, sizeof(request_msg.path) - 1);
 
-    size_t t_len = min(token_len, sizeof(request_msg.token));
-    memcpy(request_msg.token, token, t_len);
-    request_msg.token_len = t_len;
+    request_msg.token = token;
 
     bool sent = golioth_mbox_try_send(client->request_queue, &request_msg);
     if (!sent)

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -117,8 +117,7 @@ typedef struct
     // Assumption: path_prefix is a string literal (i.e. we don't need to strcpy).
     const char *path_prefix;
     char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
-    uint8_t token[8];
-    size_t token_len;
+    uint64_t token;
     golioth_coap_request_type_t type;
     union
     {
@@ -229,8 +228,7 @@ enum golioth_status golioth_coap_client_observe_release(struct golioth_client *c
                                                         const char *path_prefix,
                                                         const char *path,
                                                         enum golioth_content_type content_type,
-                                                        uint8_t *token,
-                                                        size_t token_len,
+                                                        uint64_t token,
                                                         void *arg);
 
 void golioth_coap_client_cancel_all_observations(struct golioth_client *client);

--- a/src/coap_client_libcoap.h
+++ b/src/coap_client_libcoap.h
@@ -16,8 +16,7 @@ struct golioth_client
     golioth_coap_request_msg_t *pending_req;
     golioth_coap_observe_info_t observations[CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS];
     // token to use for block GETs (must use same token for all blocks)
-    uint8_t block_token[8];
-    size_t block_token_len;
+    uint64_t block_token;
     golioth_client_event_cb_fn event_callback;
     void *event_callback_arg;
 };

--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -366,12 +366,14 @@ static int golioth_coap_get_block(golioth_coap_request_msg_t *req)
     if (first)
     {
         /* Save token for subsequent block requests */
-        client->block_token_len = coap_header_get_token(&coap_req->request, client->block_token);
+        coap_header_get_token(&coap_req->request, (uint8_t *) &client->block_token);
     }
     else
     {
         /* Override tokeń with the one geenrated in first block request */
-        memcpy(&coap_req->request.data[4], client->block_token, client->block_token_len);
+        memcpy(&coap_req->request.data[4],
+               (uint8_t *) &client->block_token,
+               sizeof(client->block_token));
     }
 
     err = coap_packet_append_uri_path_from_pathv(&coap_req->request, pathv);
@@ -431,12 +433,14 @@ static int golioth_coap_post_block(golioth_coap_request_msg_t *req)
     if (first)
     {
         /* Save token for subsequent block requests */
-        client->block_token_len = coap_header_get_token(&coap_req->request, client->block_token);
+        coap_header_get_token(&coap_req->request, (uint8_t *) &client->block_token);
     }
     else
     {
         /* Override token with the one geenrated in first block request */
-        memcpy(&coap_req->request.data[4], client->block_token, client->block_token_len);
+        memcpy(&coap_req->request.data[4],
+               (uint8_t *) &client->block_token,
+               sizeof(client->block_token));
     }
 
     err = coap_packet_append_uri_path_from_pathv(&coap_req->request, pathv);
@@ -595,8 +599,8 @@ static int golioth_deregister_observation(golioth_coap_request_msg_t *req,
                            sizeof(buffer),
                            COAP_VERSION_1,
                            COAP_TYPE_CON,
-                           req->token_len,
-                           req->token,
+                           sizeof(req->token),
+                           (uint8_t *) &req->token,
                            COAP_METHOD_GET,
                            coap_next_id());
     if (err)

--- a/src/coap_client_zephyr.h
+++ b/src/coap_client_zephyr.h
@@ -77,8 +77,7 @@ struct golioth_client
     struct golioth_client_config config;
     golioth_coap_observe_info_t observations[CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS];
     // token to use for block GETs (must use same token for all blocks)
-    uint8_t block_token[8];
-    size_t block_token_len;
+    uint64_t block_token;
 
     struct golioth_tls tls;
     uint8_t *rx_buffer;

--- a/src/zephyr_coap_req.c
+++ b/src/zephyr_coap_req.c
@@ -762,8 +762,8 @@ static int __golioth_coap_req_find_and_cancel_observation(
         if ((req->user_data == cancel_req_msg) && (req->is_observe))
         {
             int err;
-            uint8_t coap_token[COAP_TOKEN_MAX_LEN];
-            size_t coap_token_len = coap_header_get_token(&req->request, coap_token);
+            uint64_t coap_token;
+            size_t coap_token_len = coap_header_get_token(&req->request, (uint8_t *) &coap_token);
             int coap_content_format = coap_get_option_int(&req->request, COAP_OPTION_ACCEPT);
 
             if (coap_token_len == 0)
@@ -788,7 +788,6 @@ static int __golioth_coap_req_find_and_cancel_observation(
                                                       req_msg->path,
                                                       coap_content_format,
                                                       coap_token,
-                                                      coap_token_len,
                                                       NULL);
             if (err)
             {


### PR DESCRIPTION
Store CoAP tokens as uint64_t values instead of as 8-byte arrays.