### PR TITLE
Replace typedefs

### DIFF
--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -117,7 +117,7 @@ static enum golioth_status golioth_coap_client_set_internal(struct golioth_clien
                                                             const char *path,
                                                             const uint8_t *payload,
                                                             size_t payload_size,
-                                                            golioth_coap_request_type_t type,
+                                                            enum golioth_coap_request_type type,
                                                             void *request_params,
                                                             bool is_synchronous,
                                                             int32_t timeout_s)
@@ -431,7 +431,7 @@ enum golioth_status golioth_coap_client_delete(struct golioth_client *client,
 static enum golioth_status golioth_coap_client_get_internal(struct golioth_client *client,
                                                             const char *path_prefix,
                                                             const char *path,
-                                                            golioth_coap_request_type_t type,
+                                                            enum golioth_coap_request_type type,
                                                             void *request_params,
                                                             bool is_synchronous,
                                                             int32_t timeout_s)

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -203,14 +203,14 @@ static enum golioth_status golioth_coap_client_set_internal(struct golioth_clien
 
     if (type == GOLIOTH_COAP_REQUEST_POST_BLOCK)
     {
-        request_msg.post_block = *(golioth_coap_post_block_params_t *) request_params;
+        request_msg.post_block = *(struct golioth_coap_post_block_params *) request_params;
         request_msg.post_block.payload = request_payload;
         request_msg.post_block.payload_size = payload_size;
     }
     else
     {
         assert(type == GOLIOTH_COAP_REQUEST_POST);
-        request_msg.post = *(golioth_coap_post_params_t *) request_params;
+        request_msg.post = *(struct golioth_coap_post_params *) request_params;
         request_msg.post.payload = request_payload;
         request_msg.post.payload_size = payload_size;
     }
@@ -272,7 +272,7 @@ enum golioth_status golioth_coap_client_set(struct golioth_client *client,
                                             bool is_synchronous,
                                             int32_t timeout_s)
 {
-    golioth_coap_post_params_t params = {
+    struct golioth_coap_post_params params = {
         .content_type = content_type,
         .callback = callback,
         .arg = callback_arg,
@@ -302,7 +302,7 @@ enum golioth_status golioth_coap_client_set_block(struct golioth_client *client,
                                                   bool is_synchronous,
                                                   int32_t timeout_s)
 {
-    golioth_coap_post_block_params_t params = {
+    struct golioth_coap_post_block_params params = {
         .is_last = is_last,
         .content_type = content_type,
         .block_index = block_index,
@@ -489,12 +489,12 @@ static enum golioth_status golioth_coap_client_get_internal(struct golioth_clien
     request_msg.ageout_ms = ageout_ms;
     if (type == GOLIOTH_COAP_REQUEST_GET_BLOCK)
     {
-        request_msg.get_block = *(golioth_coap_get_block_params_t *) request_params;
+        request_msg.get_block = *(struct golioth_coap_get_block_params *) request_params;
     }
     else
     {
         assert(type == GOLIOTH_COAP_REQUEST_GET);
-        request_msg.get = *(golioth_coap_get_params_t *) request_params;
+        request_msg.get = *(struct golioth_coap_get_params *) request_params;
     }
 
     bool sent = golioth_mbox_try_send(client->request_queue, &request_msg);
@@ -544,7 +544,7 @@ enum golioth_status golioth_coap_client_get(struct golioth_client *client,
                                             bool is_synchronous,
                                             int32_t timeout_s)
 {
-    golioth_coap_get_params_t params = {
+    struct golioth_coap_get_params params = {
         .content_type = content_type,
         .callback = callback,
         .arg = arg,
@@ -569,7 +569,7 @@ enum golioth_status golioth_coap_client_get_block(struct golioth_client *client,
                                                   bool is_synchronous,
                                                   int32_t timeout_s)
 {
-    golioth_coap_get_block_params_t params = {
+    struct golioth_coap_get_block_params params = {
         .content_type = content_type,
         .block_index = block_index,
         .block_size = block_size,

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -47,7 +47,7 @@ enum golioth_status golioth_coap_client_empty(struct golioth_client *client,
         ageout_ms = golioth_sys_now_ms() + (1000 * timeout_s);
     }
 
-    golioth_coap_request_msg_t request_msg = {
+    struct golioth_coap_request_msg request_msg = {
         .type = GOLIOTH_COAP_REQUEST_EMPTY,
         .ageout_ms = ageout_ms,
     };
@@ -127,7 +127,7 @@ static enum golioth_status golioth_coap_client_set_internal(struct golioth_clien
         return GOLIOTH_ERR_NULL;
     }
 
-    golioth_coap_request_msg_t request_msg = {};
+    struct golioth_coap_request_msg request_msg = {};
     enum golioth_status status = GOLIOTH_OK;
     uint8_t *request_payload = NULL;
 
@@ -349,7 +349,7 @@ enum golioth_status golioth_coap_client_delete(struct golioth_client *client,
         ageout_ms = golioth_sys_now_ms() + (1000 * timeout_s);
     }
 
-    golioth_coap_request_msg_t request_msg = {
+    struct golioth_coap_request_msg request_msg = {
         .type = GOLIOTH_COAP_REQUEST_DELETE,
         .path_prefix = path_prefix,
         .delete =
@@ -453,7 +453,7 @@ static enum golioth_status golioth_coap_client_get_internal(struct golioth_clien
         ageout_ms = golioth_sys_now_ms() + (1000 * timeout_s);
     }
 
-    golioth_coap_request_msg_t request_msg = {};
+    struct golioth_coap_request_msg request_msg = {};
     enum golioth_status status = GOLIOTH_OK;
     request_msg.type = type;
     request_msg.path_prefix = path_prefix;
@@ -606,7 +606,7 @@ enum golioth_status golioth_coap_client_observe(struct golioth_client *client,
         return GOLIOTH_ERR_INVALID_STATE;
     }
 
-    golioth_coap_request_msg_t request_msg = {
+    struct golioth_coap_request_msg request_msg = {
         .type = GOLIOTH_COAP_REQUEST_OBSERVE,
         .path_prefix = path_prefix,
         .ageout_ms = GOLIOTH_SYS_WAIT_FOREVER,
@@ -657,7 +657,7 @@ enum golioth_status golioth_coap_client_observe_release(struct golioth_client *c
         return GOLIOTH_ERR_INVALID_STATE;
     }
 
-    golioth_coap_request_msg_t request_msg = {
+    struct golioth_coap_request_msg request_msg = {
         .type = GOLIOTH_COAP_REQUEST_OBSERVE_RELEASE,
         .path_prefix = path_prefix,
         .ageout_ms = GOLIOTH_SYS_WAIT_FOREVER,

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -97,7 +97,7 @@ struct golioth_coap_observe_params
     void *arg;
 };
 
-typedef enum
+enum golioth_coap_request_type
 {
     GOLIOTH_COAP_REQUEST_EMPTY,
     GOLIOTH_COAP_REQUEST_GET,
@@ -107,7 +107,7 @@ typedef enum
     GOLIOTH_COAP_REQUEST_DELETE,
     GOLIOTH_COAP_REQUEST_OBSERVE,
     GOLIOTH_COAP_REQUEST_OBSERVE_RELEASE,
-} golioth_coap_request_type_t;
+};
 
 struct golioth_coap_request_msg
 {
@@ -119,7 +119,7 @@ struct golioth_coap_request_msg
     char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
     uint8_t token[8];
     size_t token_len;
-    golioth_coap_request_type_t type;
+    enum golioth_coap_request_type type;
     union
     {
         struct golioth_coap_get_params get;

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -155,11 +155,11 @@ struct golioth_coap_request_msg
     golioth_sys_sem_t request_complete_ack_sem;
 };
 
-typedef struct
+struct golioth_coap_observe_info
 {
     bool in_use;
     struct golioth_coap_request_msg req;
-} golioth_coap_observe_info_t;
+};
 
 enum golioth_status golioth_coap_client_empty(struct golioth_client *client,
                                               bool is_synchronous,

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -41,7 +41,7 @@ typedef void (*golioth_set_block_cb_fn)(struct golioth_client *client,
                                         size_t block_szx,
                                         void *arg);
 
-typedef struct
+struct golioth_coap_post_params
 {
     enum golioth_content_type content_type;
     // CoAP payload assumed to be dynamically allocated before enqueue
@@ -51,9 +51,9 @@ typedef struct
     size_t payload_size;
     golioth_set_cb_fn callback;
     void *arg;
-} golioth_coap_post_params_t;
+};
 
-typedef struct
+struct golioth_coap_post_block_params
 {
     bool is_last;
     enum golioth_content_type content_type;
@@ -66,36 +66,36 @@ typedef struct
     size_t payload_size;
     golioth_set_block_cb_fn callback;
     void *arg;
-} golioth_coap_post_block_params_t;
+};
 
-typedef struct
+struct golioth_coap_get_params
 {
     enum golioth_content_type content_type;
     golioth_get_cb_fn callback;
     void *arg;
-} golioth_coap_get_params_t;
+};
 
-typedef struct
+struct golioth_coap_get_block_params
 {
     enum golioth_content_type content_type;
     size_t block_index;
     size_t block_size;
     golioth_get_block_cb_fn callback;
     void *arg;
-} golioth_coap_get_block_params_t;
+};
 
-typedef struct
+struct golioth_coap_delete_params
 {
     golioth_set_cb_fn callback;
     void *arg;
-} golioth_coap_delete_params_t;
+};
 
-typedef struct
+struct golioth_coap_observe_params
 {
     enum golioth_content_type content_type;
     golioth_get_cb_fn callback;
     void *arg;
-} golioth_coap_observe_params_t;
+};
 
 typedef enum
 {
@@ -122,12 +122,12 @@ struct golioth_coap_request_msg
     golioth_coap_request_type_t type;
     union
     {
-        golioth_coap_get_params_t get;
-        golioth_coap_get_block_params_t get_block;
-        golioth_coap_post_params_t post;
-        golioth_coap_post_block_params_t post_block;
-        golioth_coap_delete_params_t delete;
-        golioth_coap_observe_params_t observe;
+        struct golioth_coap_get_params get;
+        struct golioth_coap_get_block_params get_block;
+        struct golioth_coap_post_params post;
+        struct golioth_coap_post_block_params post_block;
+        struct golioth_coap_delete_params delete;
+        struct golioth_coap_observe_params observe;
     };
     /// Time (since boot) in milliseconds when request is no longer valid.
     /// This is checked when reqeusts are pulled out of the queue and when responses are received.

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -109,7 +109,7 @@ typedef enum
     GOLIOTH_COAP_REQUEST_OBSERVE_RELEASE,
 } golioth_coap_request_type_t;
 
-typedef struct
+struct golioth_coap_request_msg
 {
     struct golioth_client *client;
 
@@ -153,12 +153,12 @@ typedef struct
     /// Used by the coap thread to know when it's safe
     /// to delete request_complete_event and this semaphore.
     golioth_sys_sem_t request_complete_ack_sem;
-} golioth_coap_request_msg_t;
+};
 
 typedef struct
 {
     bool in_use;
-    golioth_coap_request_msg_t req;
+    struct golioth_coap_request_msg req;
 } golioth_coap_observe_info_t;
 
 enum golioth_status golioth_coap_client_empty(struct golioth_client *client,

--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -38,7 +38,7 @@ static void notify_observers(const coap_pdu_t *received,
     // scan observations, check for token match
     for (int i = 0; i < CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS; i++)
     {
-        const golioth_coap_observe_info_t *obs_info = &client->observations[i];
+        const struct golioth_coap_observe_info *obs_info = &client->observations[i];
         golioth_get_cb_fn callback = obs_info->req.observe.callback;
 
         if (!obs_info->in_use || !callback)
@@ -668,7 +668,7 @@ static enum golioth_status add_observation(struct golioth_coap_request_msg *req,
                                            coap_session_t *session)
 {
     // scan for available (not used) observation slot
-    golioth_coap_observe_info_t *obs_info = NULL;
+    struct golioth_coap_observe_info *obs_info = NULL;
     bool found_slot = false;
     for (int i = 0; i < CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS; i++)
     {
@@ -701,7 +701,7 @@ static enum golioth_status add_observation(struct golioth_coap_request_msg *req,
 
 void golioth_cancel_all_observations_by_prefix(struct golioth_client *client, const char *prefix)
 {
-    golioth_coap_observe_info_t *obs_info = NULL;
+    struct golioth_coap_observe_info *obs_info = NULL;
     for (int i = 0; i < CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS; i++)
     {
         obs_info = &client->observations[i];
@@ -731,7 +731,7 @@ void golioth_cancel_all_observations(struct golioth_client *client)
 
 static void reestablish_observations(struct golioth_client *client, coap_session_t *session)
 {
-    golioth_coap_observe_info_t *obs_info = NULL;
+    struct golioth_coap_observe_info *obs_info = NULL;
     for (int i = 0; i < CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS; i++)
     {
         obs_info = &client->observations[i];

--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -21,7 +21,7 @@ LOG_TAG_DEFINE(golioth_coap_client_libcoap);
 
 static bool _initialized;
 
-static bool token_matches_request(const golioth_coap_request_msg_t *req, const coap_pdu_t *pdu)
+static bool token_matches_request(const struct golioth_coap_request_msg *req, const coap_pdu_t *pdu)
 {
     coap_bin_const_t rcvd_token = coap_pdu_get_token(pdu);
     bool len_matches = (rcvd_token.length == req->token_len);
@@ -95,7 +95,7 @@ static coap_response_t coap_response_handler(coap_session_t *session,
     coap_get_data(received, &data_len, &data);
 
     // Get the original/pending request info
-    golioth_coap_request_msg_t *req = client->pending_req;
+    struct golioth_coap_request_msg *req = client->pending_req;
 
     if (req)
     {
@@ -277,7 +277,7 @@ static void nack_handler(coap_session_t *session,
 {
     coap_context_t *context = coap_session_get_context(session);
     struct golioth_client *client = coap_get_app_data(context);
-    golioth_coap_request_msg_t *req = client->pending_req;
+    struct golioth_coap_request_msg *req = client->pending_req;
 
     switch (reason)
     {
@@ -369,7 +369,7 @@ static enum golioth_status get_coap_dst_address(const coap_uri_t *host_uri,
 }
 
 static void golioth_coap_add_token(coap_pdu_t *req_pdu,
-                                   golioth_coap_request_msg_t *req,
+                                   struct golioth_coap_request_msg *req,
                                    coap_session_t *session)
 {
     coap_session_new_token(session, &req->token_len, req->token);
@@ -475,7 +475,7 @@ static void golioth_coap_add_block2(coap_pdu_t *request, size_t block_index, siz
     coap_add_option(request, COAP_OPTION_BLOCK2, opt_length, buf);
 }
 
-static void golioth_coap_empty(golioth_coap_request_msg_t *req, coap_session_t *session)
+static void golioth_coap_empty(struct golioth_coap_request_msg *req, coap_session_t *session)
 {
     // Note: libcoap has keepalive functionality built in, but we're not using because
     // it doesn't seem to work correctly. The server responds to the keepalive message,
@@ -495,7 +495,7 @@ static void golioth_coap_empty(golioth_coap_request_msg_t *req, coap_session_t *
     coap_send(session, req_pdu);
 }
 
-static void golioth_coap_get(golioth_coap_request_msg_t *req, coap_session_t *session)
+static void golioth_coap_get(struct golioth_coap_request_msg *req, coap_session_t *session)
 {
     coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_CODE_GET, session);
     if (!req_pdu)
@@ -510,7 +510,7 @@ static void golioth_coap_get(golioth_coap_request_msg_t *req, coap_session_t *se
     coap_send(session, req_pdu);
 }
 
-static void golioth_coap_get_block(golioth_coap_request_msg_t *req,
+static void golioth_coap_get_block(struct golioth_coap_request_msg *req,
                                    struct golioth_client *client,
                                    coap_session_t *session)
 {
@@ -544,7 +544,7 @@ static void golioth_coap_get_block(golioth_coap_request_msg_t *req,
     coap_send(session, req_pdu);
 }
 
-static void golioth_coap_post(golioth_coap_request_msg_t *req, coap_session_t *session)
+static void golioth_coap_post(struct golioth_coap_request_msg *req, coap_session_t *session)
 {
     coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_CODE_POST, session);
     if (!req_pdu)
@@ -560,7 +560,7 @@ static void golioth_coap_post(golioth_coap_request_msg_t *req, coap_session_t *s
     coap_send(session, req_pdu);
 }
 
-static void golioth_coap_post_block(golioth_coap_request_msg_t *req,
+static void golioth_coap_post_block(struct golioth_coap_request_msg *req,
                                     struct golioth_client *client,
                                     coap_session_t *session)
 {
@@ -598,7 +598,7 @@ static void golioth_coap_post_block(golioth_coap_request_msg_t *req,
     coap_send(session, req_pdu);
 }
 
-static void golioth_coap_delete(golioth_coap_request_msg_t *req, coap_session_t *session)
+static void golioth_coap_delete(struct golioth_coap_request_msg *req, coap_session_t *session)
 {
     coap_pdu_t *req_pdu = coap_new_pdu(COAP_MESSAGE_CON, COAP_REQUEST_CODE_DELETE, session);
     if (!req_pdu)
@@ -612,7 +612,7 @@ static void golioth_coap_delete(golioth_coap_request_msg_t *req, coap_session_t 
     coap_send(session, req_pdu);
 }
 
-static enum golioth_status golioth_coap_observe(golioth_coap_request_msg_t *req,
+static enum golioth_status golioth_coap_observe(struct golioth_coap_request_msg *req,
                                                 struct golioth_client *client,
                                                 coap_session_t *session,
                                                 bool eager_release)
@@ -663,7 +663,7 @@ static enum golioth_status golioth_coap_observe(golioth_coap_request_msg_t *req,
     }
 }
 
-static enum golioth_status add_observation(golioth_coap_request_msg_t *req,
+static enum golioth_status add_observation(struct golioth_coap_request_msg *req,
                                            struct golioth_client *client,
                                            coap_session_t *session)
 {
@@ -878,7 +878,7 @@ static enum golioth_status coap_io_loop_once(struct golioth_client *client,
                                              coap_context_t *context,
                                              coap_session_t *session)
 {
-    golioth_coap_request_msg_t request_msg = {};
+    struct golioth_coap_request_msg request_msg = {};
     int mbox_fd = golioth_sys_sem_get_fd(client->request_queue->fill_count_sem);
 
     if (mbox_fd >= 0)
@@ -1329,7 +1329,7 @@ struct golioth_client *golioth_client_create(const struct golioth_client_config 
     golioth_sys_sem_give(new_client->run_sem);
 
     new_client->request_queue = golioth_mbox_create(CONFIG_GOLIOTH_COAP_REQUEST_QUEUE_MAX_ITEMS,
-                                                    sizeof(golioth_coap_request_msg_t));
+                                                    sizeof(struct golioth_coap_request_msg));
     if (!new_client->request_queue)
     {
         GLTH_LOGE(TAG, "Failed to create request queue");
@@ -1386,7 +1386,7 @@ error:
 
 static void purge_request_mbox(golioth_mbox_t request_mbox)
 {
-    golioth_coap_request_msg_t request_msg = {};
+    struct golioth_coap_request_msg request_msg = {};
     size_t num_messages = golioth_mbox_num_messages(request_mbox);
 
     for (size_t i = 0; i < num_messages; i++)

--- a/src/coap_client_libcoap.h
+++ b/src/coap_client_libcoap.h
@@ -13,7 +13,7 @@ struct golioth_client
     bool end_session;
     bool session_connected;
     struct golioth_client_config config;
-    golioth_coap_request_msg_t *pending_req;
+    struct golioth_coap_request_msg *pending_req;
     golioth_coap_observe_info_t observations[CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS];
     // token to use for block GETs (must use same token for all blocks)
     uint8_t block_token[8];

--- a/src/coap_client_libcoap.h
+++ b/src/coap_client_libcoap.h
@@ -14,7 +14,7 @@ struct golioth_client
     bool session_connected;
     struct golioth_client_config config;
     struct golioth_coap_request_msg *pending_req;
-    golioth_coap_observe_info_t observations[CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS];
+    struct golioth_coap_observe_info observations[CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS];
     // token to use for block GETs (must use same token for all blocks)
     uint8_t block_token[8];
     size_t block_token_len;

--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -518,7 +518,7 @@ static int golioth_coap_observe(struct golioth_coap_request_msg *req, struct gol
 static int add_observation(struct golioth_coap_request_msg *req, struct golioth_client *client)
 {
     // scan for available (not used) observation slot
-    golioth_coap_observe_info_t *obs_info = NULL;
+    struct golioth_coap_observe_info *obs_info = NULL;
     bool found_slot = false;
     for (int i = 0; i < CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS; i++)
     {
@@ -557,7 +557,7 @@ void golioth_cancel_all_observations_by_prefix(struct golioth_client *client, co
 {
     for (int i = 0; i < CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS; i++)
     {
-        golioth_coap_observe_info_t *obs_info = &client->observations[i];
+        struct golioth_coap_observe_info *obs_info = &client->observations[i];
         if (obs_info->in_use)
         {
             if ((prefix != NULL) && (strcmp(prefix, obs_info->req.path_prefix) != 0))
@@ -638,7 +638,7 @@ static int golioth_deregister_observation(struct golioth_coap_request_msg *req,
 
 static void reestablish_observations(struct golioth_client *client)
 {
-    golioth_coap_observe_info_t *obs_info = NULL;
+    struct golioth_coap_observe_info *obs_info = NULL;
     for (int i = 0; i < CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS; i++)
     {
         obs_info = &client->observations[i];

--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -101,7 +101,7 @@ static enum coap_content_format golioth_content_type_to_coap_format(
     }
 }
 
-static int golioth_coap_req_append_block1_option(golioth_coap_request_msg_t *req_msg,
+static int golioth_coap_req_append_block1_option(struct golioth_coap_request_msg *req_msg,
                                                  struct golioth_coap_req *req)
 {
     unsigned int val = 0;
@@ -223,7 +223,7 @@ static enum golioth_status golioth_err_to_status(int err)
 
 static int golioth_coap_cb(struct golioth_req_rsp *rsp)
 {
-    golioth_coap_request_msg_t *req = rsp->user_data;
+    struct golioth_coap_request_msg *req = rsp->user_data;
     struct golioth_client *client = req->client;
 
     switch (req->type)
@@ -342,7 +342,7 @@ static int golioth_coap_cb(struct golioth_req_rsp *rsp)
     return rsp->status;
 }
 
-static int golioth_coap_get_block(golioth_coap_request_msg_t *req)
+static int golioth_coap_get_block(struct golioth_coap_request_msg *req)
 {
     const uint8_t **pathv = PATHV(req->path_prefix, req->path);
     size_t path_len = coap_pathv_estimate_alloc_len(pathv);
@@ -406,7 +406,7 @@ free_req:
     return err;
 }
 
-static int golioth_coap_post_block(golioth_coap_request_msg_t *req)
+static int golioth_coap_post_block(struct golioth_coap_request_msg *req)
 {
     const uint8_t **pathv = PATHV(req->path_prefix, req->path);
     size_t path_len = coap_pathv_estimate_alloc_len(pathv);
@@ -495,7 +495,7 @@ free_req:
     return err;
 }
 
-static int golioth_coap_observe(golioth_coap_request_msg_t *req, struct golioth_client *client)
+static int golioth_coap_observe(struct golioth_coap_request_msg *req, struct golioth_client *client)
 {
     int err = golioth_coap_req_cb(req->client,
                                   COAP_METHOD_GET,
@@ -515,7 +515,7 @@ static int golioth_coap_observe(golioth_coap_request_msg_t *req, struct golioth_
     return err;
 }
 
-static int add_observation(golioth_coap_request_msg_t *req, struct golioth_client *client)
+static int add_observation(struct golioth_coap_request_msg *req, struct golioth_client *client)
 {
     // scan for available (not used) observation slot
     golioth_coap_observe_info_t *obs_info = NULL;
@@ -580,7 +580,7 @@ void golioth_cancel_all_observations(struct golioth_client *client)
     golioth_cancel_all_observations_by_prefix(client, NULL);
 }
 
-static int golioth_deregister_observation(golioth_coap_request_msg_t *req,
+static int golioth_deregister_observation(struct golioth_coap_request_msg *req,
                                           struct golioth_client *client)
 {
     struct coap_packet packet;
@@ -651,7 +651,7 @@ static void reestablish_observations(struct golioth_client *client)
 
 static enum golioth_status coap_io_loop_once(struct golioth_client *client)
 {
-    golioth_coap_request_msg_t *req;
+    struct golioth_coap_request_msg *req;
     int err = 0;
 
     req = calloc(1, sizeof(*req));
@@ -1512,7 +1512,7 @@ struct golioth_client *golioth_client_create(const struct golioth_client_config 
                       &new_client->run_sem);
 
     new_client->request_queue = golioth_mbox_create(CONFIG_GOLIOTH_COAP_REQUEST_QUEUE_MAX_ITEMS,
-                                                    sizeof(golioth_coap_request_msg_t));
+                                                    sizeof(struct golioth_coap_request_msg));
     if (!new_client->request_queue)
     {
         LOG_ERR("Failed to create request queue");
@@ -1569,7 +1569,7 @@ error:
 
 static void purge_request_mbox(golioth_mbox_t request_mbox)
 {
-    golioth_coap_request_msg_t request_msg = {};
+    struct golioth_coap_request_msg request_msg = {};
     size_t num_messages = golioth_mbox_num_messages(request_mbox);
 
     for (size_t i = 0; i < num_messages; i++)

--- a/src/coap_client_zephyr.h
+++ b/src/coap_client_zephyr.h
@@ -75,7 +75,7 @@ struct golioth_client
     bool is_running;
     bool session_connected;
     struct golioth_client_config config;
-    golioth_coap_observe_info_t observations[CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS];
+    struct golioth_coap_observe_info observations[CONFIG_GOLIOTH_MAX_NUM_OBSERVATIONS];
     // token to use for block GETs (must use same token for all blocks)
     uint8_t block_token[8];
     size_t block_token_len;

--- a/src/zephyr_coap_req.c
+++ b/src/zephyr_coap_req.c
@@ -229,7 +229,7 @@ static int golioth_coap_req_reply_handler(struct golioth_coap_req *req,
             /* This response has block1 */
             if (coap_update_from_block(response, &req->block_ctx) == 0)
             {
-                golioth_coap_request_msg_t *rmsg = req->user_data;
+                struct golioth_coap_request_msg *rmsg = req->user_data;
 
                 if (req->block_ctx.block_size < rmsg->post_block.block_szx)
                 {
@@ -753,7 +753,7 @@ static void golioth_coap_reqs_cancel_all_with_reason(struct golioth_client *clie
 
 static int __golioth_coap_req_find_and_cancel_observation(
     struct golioth_client *client,
-    golioth_coap_request_msg_t *cancel_req_msg)
+    struct golioth_coap_request_msg *cancel_req_msg)
 {
     struct golioth_coap_req *req, *next;
 
@@ -780,7 +780,7 @@ static int __golioth_coap_req_find_and_cancel_observation(
                 goto remove_from_coap_reqs_and_free;
             }
 
-            golioth_coap_request_msg_t *req_msg = req->user_data;
+            struct golioth_coap_request_msg *req_msg = req->user_data;
 
             /* Enqueue an "eager release" request for this observation */
             err = golioth_coap_client_observe_release(client,
@@ -805,7 +805,7 @@ static int __golioth_coap_req_find_and_cancel_observation(
 }
 
 int golioth_coap_req_find_and_cancel_observation(struct golioth_client *client,
-                                                 golioth_coap_request_msg_t *cancel_req_msg)
+                                                 struct golioth_coap_request_msg *cancel_req_msg)
 {
     k_mutex_lock(&client->coap_reqs_lock, K_FOREVER);
     int err = __golioth_coap_req_find_and_cancel_observation(client, cancel_req_msg);

--- a/src/zephyr_coap_req.h
+++ b/src/zephyr_coap_req.h
@@ -137,7 +137,7 @@ int golioth_coap_req_schedule(struct golioth_coap_req *req);
  * @retval <0 On failure
  */
 int golioth_coap_req_find_and_cancel_observation(struct golioth_client *client,
-                                                 golioth_coap_request_msg_t *cancel_req_msg);
+                                                 struct golioth_coap_request_msg *cancel_req_msg);
 
 /**
  * @brief Create and schedule CoAP request for sending


### PR DESCRIPTION
Remove typedefs defined in `src/coap_client.h` to align with our coding standard