### PR TITLE
Use _ret variants of mbedtls functions introduced in 2.7.0

### DIFF
--- a/port/freertos/golioth_sys_freertos.c
+++ b/port/freertos/golioth_sys_freertos.c
@@ -234,7 +234,7 @@ enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,
     }
 
     mbedtls_sha256_context *hash = sha_ctx;
-    int err = mbedtls_sha256_update(hash, input, len);
+    int err = mbedtls_sha256_update_ret(hash, input, len);
     if (err)
     {
         return GOLIOTH_ERR_FAIL;
@@ -251,7 +251,7 @@ enum golioth_status golioth_sys_sha256_finish(golioth_sys_sha256_t sha_ctx, uint
     }
 
     mbedtls_sha256_context *hash = sha_ctx;
-    int err = mbedtls_sha256_finish(hash, output);
+    int err = mbedtls_sha256_finish_ret(hash, output);
     if (err)
     {
         return GOLIOTH_ERR_FAIL;


### PR DESCRIPTION
Change `mbedtls_sha256_update` and `mbedtls_sha256_finish` to `mbedtls_sha256_update_ret` and `mbedtls_sha256_finish_ret`, respectively. the non-`_ret` versions were depreciated in 2.7.0 according to the [documentation](https://mbed-ce.github.io/mbed-os/group__mbedtls__sha256__module.html).

I get a `error: void value not ignored as it ought to be` when trying to compile with the deprecated functions. Switching to the _ret versions fixed this for me.