### PR TITLE
ports: move golioth_sys_sha256_* APIs out of FreeRTOS and into platforms

### DIFF
--- a/port/esp_idf/components/golioth_sdk/CMakeLists.txt
+++ b/port/esp_idf/components/golioth_sdk/CMakeLists.txt
@@ -26,6 +26,7 @@ idf_component_register(
     SRCS
         "${sdk_port}/freertos/golioth_sys_freertos.c"
         "${sdk_port}/esp_idf/fw_update_esp_idf.c"
+        "${sdk_port}/esp_idf/golioth_sys_espidf.c"
         "${sdk_port}/utils/hex.c"
         "${sdk_src}/golioth_status.c"
         "${sdk_src}/coap_client.c"

--- a/port/esp_idf/golioth_sys_espidf.c
+++ b/port/esp_idf/golioth_sys_espidf.c
@@ -1,0 +1,74 @@
+#include <golioth/golioth_sys.h>
+#include <golioth/golioth_status.h>
+#include "mbedtls/sha256.h"
+#include "../utils/hex.h"
+
+/*-------------------------------------------------
+ * Hash
+ *------------------------------------------------*/
+
+golioth_sys_sha256_t golioth_sys_sha256_create(void)
+{
+    mbedtls_sha256_context *hash = golioth_sys_malloc(sizeof(mbedtls_sha256_context));
+    if (!hash)
+    {
+        return NULL;
+    }
+
+    mbedtls_sha256_init(hash);
+    mbedtls_sha256_starts(hash, 0);
+
+    return (golioth_sys_sha256_t) hash;
+}
+
+void golioth_sys_sha256_destroy(golioth_sys_sha256_t sha_ctx)
+{
+    if (!sha_ctx)
+    {
+        return;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    mbedtls_sha256_free(hash);
+}
+
+enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,
+                                              const uint8_t *input,
+                                              size_t len)
+{
+    if (!sha_ctx || !input)
+    {
+        return GOLIOTH_ERR_NULL;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    int err = mbedtls_sha256_update(hash, input, len);
+    if (err)
+    {
+        return GOLIOTH_ERR_FAIL;
+    }
+
+    return GOLIOTH_OK;
+}
+
+enum golioth_status golioth_sys_sha256_finish(golioth_sys_sha256_t sha_ctx, uint8_t *output)
+{
+    if (!sha_ctx || !output)
+    {
+        return GOLIOTH_ERR_NULL;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    int err = mbedtls_sha256_finish(hash, output);
+    if (err)
+    {
+        return GOLIOTH_ERR_FAIL;
+    }
+
+    return GOLIOTH_OK;
+}
+
+size_t golioth_sys_hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen)
+{
+    return hex2bin(hex, hexlen, buf, buflen);
+}

--- a/port/freertos/golioth_sys_freertos.c
+++ b/port/freertos/golioth_sys_freertos.c
@@ -10,8 +10,6 @@
 #include <semphr.h>
 #include <timers.h>
 #include <string.h>  // memset
-#include "../utils/hex.h"
-#include "mbedtls/sha256.h"
 
 /*--------------------------------------------------
  * Time
@@ -193,76 +191,6 @@ golioth_sys_thread_t golioth_sys_thread_create(const struct golioth_thread_confi
 void golioth_sys_thread_destroy(golioth_sys_thread_t thread)
 {
     vTaskDelete((TaskHandle_t) thread);
-}
-
-/*-------------------------------------------------
- * Hash
- *------------------------------------------------*/
-
-golioth_sys_sha256_t golioth_sys_sha256_create(void)
-{
-    mbedtls_sha256_context *hash = golioth_sys_malloc(sizeof(mbedtls_sha256_context));
-    if (!hash)
-    {
-        return NULL;
-    }
-
-    mbedtls_sha256_init(hash);
-    mbedtls_sha256_starts(hash, 0);
-
-    return (golioth_sys_sha256_t) hash;
-}
-
-void golioth_sys_sha256_destroy(golioth_sys_sha256_t sha_ctx)
-{
-    if (!sha_ctx)
-    {
-        return;
-    }
-
-    mbedtls_sha256_context *hash = sha_ctx;
-    mbedtls_sha256_free(hash);
-}
-
-enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,
-                                              const uint8_t *input,
-                                              size_t len)
-{
-    if (!sha_ctx || !input)
-    {
-        return GOLIOTH_ERR_NULL;
-    }
-
-    mbedtls_sha256_context *hash = sha_ctx;
-    int err = mbedtls_sha256_update(hash, input, len);
-    if (err)
-    {
-        return GOLIOTH_ERR_FAIL;
-    }
-
-    return GOLIOTH_OK;
-}
-
-enum golioth_status golioth_sys_sha256_finish(golioth_sys_sha256_t sha_ctx, uint8_t *output)
-{
-    if (!sha_ctx || !output)
-    {
-        return GOLIOTH_ERR_NULL;
-    }
-
-    mbedtls_sha256_context *hash = sha_ctx;
-    int err = mbedtls_sha256_finish(hash, output);
-    if (err)
-    {
-        return GOLIOTH_ERR_FAIL;
-    }
-
-    return GOLIOTH_OK;
-}
-
-size_t golioth_sys_hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen)
-{
-    return hex2bin(hex, hexlen, buf, buflen);
 }
 
 /*--------------------------------------------------

--- a/port/modus_toolbox/golioth_port_config.h
+++ b/port/modus_toolbox/golioth_port_config.h
@@ -5,14 +5,6 @@
  */
 #pragma once
 
-/* ModusToolbox uses an older 2.25 version of mbedtls
- * These function names changed in version 3.0:
- * https://github.com/Mbed-TLS/mbedtls/commit/26371e47939d02d5f1a5ad9012f49aff0c7f5bc4
- */
-#define mbedtls_sha256_starts mbedtls_sha256_starts_ret
-#define mbedtls_sha256_update mbedtls_sha256_update_ret
-#define mbedtls_sha256_finish mbedtls_sha256_finish_ret
-
 // Same as GLTH_LOGX, but with 32-bit timestamp (PRIu32),
 // since MTB built-in C lib doesn't support 64-bit formatters.
 #define GLTH_LOGX(COLOR, LEVEL, LEVEL_STR, TAG, ...) \

--- a/port/modus_toolbox/golioth_sys_modus_toolbox.c
+++ b/port/modus_toolbox/golioth_sys_modus_toolbox.c
@@ -1,0 +1,74 @@
+#include <golioth/golioth_sys.h>
+#include <golioth/golioth_status.h>
+#include "mbedtls/sha256.h"
+#include "../utils/hex.h"
+
+/*-------------------------------------------------
+ * Hash
+ *------------------------------------------------*/
+
+golioth_sys_sha256_t golioth_sys_sha256_create(void)
+{
+    mbedtls_sha256_context *hash = golioth_sys_malloc(sizeof(mbedtls_sha256_context));
+    if (!hash)
+    {
+        return NULL;
+    }
+
+    mbedtls_sha256_init(hash);
+    mbedtls_sha256_starts_ret(hash, 0);
+
+    return (golioth_sys_sha256_t) hash;
+}
+
+void golioth_sys_sha256_destroy(golioth_sys_sha256_t sha_ctx)
+{
+    if (!sha_ctx)
+    {
+        return;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    mbedtls_sha256_free(hash);
+}
+
+enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,
+                                              const uint8_t *input,
+                                              size_t len)
+{
+    if (!sha_ctx || !input)
+    {
+        return GOLIOTH_ERR_NULL;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    int err = mbedtls_sha256_update_ret(hash, input, len);
+    if (err)
+    {
+        return GOLIOTH_ERR_FAIL;
+    }
+
+    return GOLIOTH_OK;
+}
+
+enum golioth_status golioth_sys_sha256_finish(golioth_sys_sha256_t sha_ctx, uint8_t *output)
+{
+    if (!sha_ctx || !output)
+    {
+        return GOLIOTH_ERR_NULL;
+    }
+
+    mbedtls_sha256_context *hash = sha_ctx;
+    int err = mbedtls_sha256_finish_ret(hash, output);
+    if (err)
+    {
+        return GOLIOTH_ERR_FAIL;
+    }
+
+    return GOLIOTH_OK;
+}
+
+size_t golioth_sys_hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen)
+{
+    return hex2bin(hex, hexlen, buf, buflen);
+}


### PR DESCRIPTION
The sha256 API was implemented in the FreeRTOS port layer. It used mbedtls to calculate the hash, but different versions of mbedtls can be used with FreeRTOS.

This PR moves the golioth_sys_sha256_* APIs out of FreeRTOS and into ESP-IDF and ModusToolbox ports. This solves a function name issue with the older version of mbedtls in ModusToolbox. It also makes it easier for custom ports to implement their own hashing.