### PR TITLE
Revert "zephyr: zcbor: parse version and expose ZCBOR_VERSION_{MAJOR,MINOR}"

### DIFF
--- a/port/zephyr/CMakeLists.txt
+++ b/port/zephyr/CMakeLists.txt
@@ -83,14 +83,3 @@ endif()
 file(WRITE
   ${ZEPHYR_BINARY_DIR}/include/generated/golioth_ciphersuites.h
   "${ciphersuites_generated}")
-
-if(CONFIG_ZCBOR)
-  file(READ ${ZEPHYR_ZCBOR_MODULE_DIR}/zcbor/VERSION zcbor_version)
-  string(STRIP ${zcbor_version} zcbor_version)
-  set(zcbor_version_regex "^([0-9]+)\.([0-9]+)\.([0-9]+)$")
-  string(REGEX REPLACE ${zcbor_version_regex} "\\1" zcbor_version_major "${zcbor_version}")
-  string(REGEX REPLACE ${zcbor_version_regex} "\\2" zcbor_version_minor "${zcbor_version}")
-  zephyr_compile_definitions(ZCBOR_VERSION_MAJOR=${zcbor_version_major})
-  zephyr_compile_definitions(ZCBOR_VERSION_MINOR=${zcbor_version_minor})
-  zephyr_compile_definitions(ZCBOR_VARIANCE)
-endif()


### PR DESCRIPTION
Information about ZCBOR version at buildsystem and C level is no longer
needed, so drop that from cmake file.

This reverts commit 82203e723e4edfbcc4fc83ec11e8f1628ba2d7cd.