### PR TITLE
examples: zephyr: wifi: make sure to get WiFi interface type

### DIFF
--- a/examples/zephyr/common/wifi.c
+++ b/examples/zephyr/common/wifi.c
@@ -564,7 +564,7 @@ static int wifi_manager_init(void)
     struct wifi_manager_data *wifi_mgmt = &wifi_manager_data;
     const struct wifi_manager_config *config = &wifi_manager_config;
 
-    wifi_mgmt->iface = net_if_get_default();
+    wifi_mgmt->iface = net_if_get_first_wifi();
     __ASSERT_NO_MSG(wifi_mgmt->iface);
 
     k_work_queue_start(&wifi_mgmt->workq,


### PR DESCRIPTION
So far `net_if_get_default()` was used. This is fine in case of all platforms
that have single network interface. However for platforms with multiple
network interfaces (e.g. WiFi and Ethernet) it would not work.

Make sure to always get WiFi network interface, in case there are multiple
available on used hardware platform.