### PR TITLE
example: zephyr: drop check for CONFIG_GOLIOTH_SAMPLE_COMMON

### DIFF
--- a/examples/zephyr/lightdb/delete/src/main.c
+++ b/examples/zephyr/lightdb/delete/src/main.c
@@ -77,7 +77,7 @@ int main(void)
 {
     LOG_DBG("Start LightDB delete sample");
 
-    IF_ENABLED(CONFIG_GOLIOTH_SAMPLE_COMMON, (net_connect();))
+    net_connect();
 
     /* Note: In production, you would provision unique credentials onto each
      * device. For simplicity, we provide a utility to hardcode credentials as

--- a/examples/zephyr/lightdb/get/src/main.c
+++ b/examples/zephyr/lightdb/get/src/main.c
@@ -148,7 +148,7 @@ int main(void)
 {
     LOG_DBG("Start LightDB get sample");
 
-    IF_ENABLED(CONFIG_GOLIOTH_SAMPLE_COMMON, (net_connect();))
+    net_connect();
 
     /* Note: In production, you would provision unique credentials onto each
      * device. For simplicity, we provide a utility to hardcode credentials as

--- a/examples/zephyr/lightdb/observe/src/main.c
+++ b/examples/zephyr/lightdb/observe/src/main.c
@@ -53,7 +53,7 @@ int main(void)
 {
     LOG_DBG("Start LightDB observe sample");
 
-    IF_ENABLED(CONFIG_GOLIOTH_SAMPLE_COMMON, (net_connect();))
+    net_connect();
 
     /* Note: In production, you would provision unique credentials onto each
      * device. For simplicity, we provide a utility to hardcode credentials as

--- a/examples/zephyr/lightdb/set/src/main.c
+++ b/examples/zephyr/lightdb/set/src/main.c
@@ -154,7 +154,7 @@ int main(void)
 
     LOG_DBG("Start LightDB set sample");
 
-    IF_ENABLED(CONFIG_GOLIOTH_SAMPLE_COMMON, (net_connect();))
+    net_connect();
 
     /* Note: In production, you would provision unique credentials onto each
      * device. For simplicity, we provide a utility to hardcode credentials as

--- a/examples/zephyr/stream/src/main.c
+++ b/examples/zephyr/stream/src/main.c
@@ -189,7 +189,7 @@ int main(void)
 
     LOG_DBG("Start Golioth stream sample");
 
-    IF_ENABLED(CONFIG_GOLIOTH_SAMPLE_COMMON, (net_connect();))
+    net_connect();
 
     /* Note: In production, you would provision unique credentials onto each
      * device. For simplicity, we provide a utility to hardcode credentials as


### PR DESCRIPTION
This option is always selected for each sample, so there is no need to
check if it is enabled in C code.