### PR TITLE
workflows: standardize titles and filenames

### DIFF
--- a/.github/workflows/ci-clean-project.yml
+++ b/.github/workflows/ci-clean-project.yml
@@ -1,4 +1,4 @@
-name: Clean CI Project
+name: "CI: Clean Project"
 
 on:
   schedule:

--- a/.github/workflows/ci-gitlint.yml
+++ b/.github/workflows/ci-gitlint.yml
@@ -1,4 +1,4 @@
-name: gitlint
+name: "CI: gitlint"
 
 on:
   pull_request:

--- a/.github/workflows/ci-lint-build.yml
+++ b/.github/workflows/ci-lint-build.yml
@@ -1,4 +1,4 @@
-name: Firmware Build
+name: "CI: Firmware Build"
 
 on:
   push:

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -1,4 +1,4 @@
-name: pre-commit
+name: "CI: pre-commit"
 
 on:
   pull_request:

--- a/.github/workflows/ci-yamllint.yml
+++ b/.github/workflows/ci-yamllint.yml
@@ -1,4 +1,4 @@
-name: yamllint
+name: "CI: yamllint"
 
 on:
   pull_request:

--- a/.github/workflows/doc-firebase-doxygen-main.yml
+++ b/.github/workflows/doc-firebase-doxygen-main.yml
@@ -1,4 +1,4 @@
-name: Deploy Doxygen to Firebase Hosting on Main
+name: "Doc: Doxygen to Firebase (Main)"
 'on':
   push:
     branches:

--- a/.github/workflows/doc-firebase-doxygen-pr.yml
+++ b/.github/workflows/doc-firebase-doxygen-pr.yml
@@ -1,4 +1,4 @@
-name: Deploy Doxygen to Firebase Hosting on PR
+name: "Doc: Doxygen to Firebase (PR)"
 on: pull_request
 jobs:
   deploy_doxygen_dev:

--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -1,4 +1,4 @@
-name: ESP-IDF Hardware-in-the-Loop Sample Tests
+name: "HIL: ESP-IDF Integration"
 
 on:
   workflow_dispatch:
@@ -38,7 +38,7 @@ on:
 
 jobs:
   build:
-    name: esp-idf-${{ inputs.hil_board }}-sample-build
+    name: esp-idf-${{ inputs.hil_board }}-build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository and Submodules
@@ -48,31 +48,33 @@ jobs:
       - name: Prep for build
         id: build_prep
         run: |
+          echo CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\" \
+            >> tests/hil/platform/esp-idf/sdkconfig.defaults
+
           rm -rf test_binaries
           mkdir test_binaries
-          echo sample_list=$(find examples/esp_idf -type d -name pytest -exec dirname "{}" \;) \
-            >> "$GITHUB_OUTPUT"
-      - name: Build Samples
+          echo test_list=$(ls tests/hil/tests) >> "$GITHUB_OUTPUT"
+      - name: Build Test Firmware
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: v5.3
           target: ${{ inputs.idf_target }}
+          path: 'tests/hil/platform/esp-idf'
           command: |
-            for sample in ${{ steps.build_prep.outputs.sample_list }};
-            do
-              echo CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\" \
-                >> ${sample}/sdkconfig.defaults && \
-              idf.py -C $sample build && \
-              mv ${sample}/build/merged.bin test_binaries/$(basename $sample).bin
+            for test in ${{ steps.build_prep.outputs.test_list }}; do
+              idf.py -DGOLIOTH_HIL_TEST=$test build && \
+                mv build/merged.bin ../../../../test_binaries/${test}.bin || \
+                EXITCODE=$?
             done
+            exit $EXITCODE
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.hil_board }}-sample-esp-idf
+          name: ${{ inputs.hil_board }}-esp-idf
           path: test_binaries/*
 
   test:
-    name: esp-idf-${{ inputs.hil_board }}-sample-test
+    name: esp-idf-${{ inputs.hil_board }}-test
     needs: build
     runs-on:
       - is_active
@@ -95,48 +97,77 @@ jobs:
             pytest \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \
-            git+https://github.com/golioth/python-golioth-tools@v0.6.3
+            git+https://github.com/golioth/python-golioth-tools@v0.6.4
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.hil_board }}-sample-esp-idf
+          name: ${{ inputs.hil_board }}-esp-idf
           path: .
       - name: Run test
         shell: bash
         env:
           hil_board: ${{ inputs.hil_board }}
         run: |
+          rm -rf summary
+          mkdir summary
           rm -rf allure-reports
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
-          for sample in $(find examples/esp_idf -type d -name pytest -exec dirname "{}" \;)
+          for test in $(ls tests/hil/tests)
           do
-            pytest --rootdir . $sample                                          \
+            pytest --rootdir . tests/hil/tests/$test                            \
               --board ${{ inputs.hil_board }}_espidf                            \
               --port ${!PORT_VAR}                                               \
-              --fw-image $(basename $sample).bin                                \
+              --fw-image ${test}.bin                                            \
               --api-url ${{ inputs.api-url }}                                   \
               --api-key ${{ secrets[inputs.api-key-id] }}                       \
               --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
               --mask-secrets                                                    \
               --timeout=600                                                     \
+              --junitxml=summary/hil-espidf-${{ inputs.hil_board }}-${test}.xml \
               --alluredir=allure-reports                                        \
-              --platform=esp-idf                                                \
+              --platform esp-idf                                                \
               --runner-name ${{ runner.name }}                                  \
-              --custom-suitename=sample                                         \
               || EXITCODE=$?
           done
           exit $EXITCODE
+
+      - name: Prepare summary
+        if: always()
+        shell: bash
+        run: |
+          if ! command -v sudo; then
+            # Self-hosted runner docker images don't have sudo installed
+            mkdir -p -m 777 /tmp && apt update && apt install -y xml-twig-tools
+          else
+            sudo apt install -y xml-twig-tools
+          fi
+
+          xml_grep \
+            --pretty_print indented \
+            --wrap testsuites \
+            --descr '' \
+            --cond "testsuite" \
+            summary/*.xml \
+            > combined.xml
+          mv combined.xml summary/hil-espidf-${{ inputs.hil_board }}.xml
+
+      - name: Safe upload CI report summary
+        uses: ./.github/actions/safe-upload-artifacts
+        if: always()
+        with:
+          name: ci-summary-hil-espidf-${{ inputs.hil_board }}
+          path: summary/hil-espidf-${{ inputs.hil_board }}.xml
 
       - name: Safe upload Allure reports
         if: always()
         uses: ./.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}
-          name: allure-reports-samples-espidf-${{ inputs.hil_board }}
+          name: allure-reports-hil-espidf-${{ inputs.hil_board }}
           path: allure-reports
 
       - name: Erase flash

--- a/.github/workflows/hil-integration-linux.yml
+++ b/.github/workflows/hil-integration-linux.yml
@@ -1,4 +1,4 @@
-name: Linux "Hardware-in-the-Loop" Tests
+name: "HIL: Linux Integration"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/hil-integration-nsim.yml
+++ b/.github/workflows/hil-integration-nsim.yml
@@ -1,4 +1,4 @@
-name: Zephyr Hardware-in-the-Loop Tests
+name: "HIL: nsim Integration"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -1,4 +1,4 @@
-name: Zephyr Hardware-in-the-Loop Tests
+name: "HIL: Zephyr Integration"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -1,4 +1,4 @@
-name: ESP-IDF Hardware-in-the-Loop Tests
+name: "HIL: ESP-IDF Samples"
 
 on:
   workflow_dispatch:
@@ -38,7 +38,7 @@ on:
 
 jobs:
   build:
-    name: esp-idf-${{ inputs.hil_board }}-build
+    name: esp-idf-${{ inputs.hil_board }}-sample-build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository and Submodules
@@ -48,33 +48,31 @@ jobs:
       - name: Prep for build
         id: build_prep
         run: |
-          echo CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\" \
-            >> tests/hil/platform/esp-idf/sdkconfig.defaults
-
           rm -rf test_binaries
           mkdir test_binaries
-          echo test_list=$(ls tests/hil/tests) >> "$GITHUB_OUTPUT"
-      - name: Build Test Firmware
+          echo sample_list=$(find examples/esp_idf -type d -name pytest -exec dirname "{}" \;) \
+            >> "$GITHUB_OUTPUT"
+      - name: Build Samples
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: v5.3
           target: ${{ inputs.idf_target }}
-          path: 'tests/hil/platform/esp-idf'
           command: |
-            for test in ${{ steps.build_prep.outputs.test_list }}; do
-              idf.py -DGOLIOTH_HIL_TEST=$test build && \
-                mv build/merged.bin ../../../../test_binaries/${test}.bin || \
-                EXITCODE=$?
+            for sample in ${{ steps.build_prep.outputs.sample_list }};
+            do
+              echo CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\" \
+                >> ${sample}/sdkconfig.defaults && \
+              idf.py -C $sample build && \
+              mv ${sample}/build/merged.bin test_binaries/$(basename $sample).bin
             done
-            exit $EXITCODE
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.hil_board }}-esp-idf
+          name: ${{ inputs.hil_board }}-sample-esp-idf
           path: test_binaries/*
 
   test:
-    name: esp-idf-${{ inputs.hil_board }}-test
+    name: esp-idf-${{ inputs.hil_board }}-sample-test
     needs: build
     runs-on:
       - is_active
@@ -97,77 +95,48 @@ jobs:
             pytest \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \
-            git+https://github.com/golioth/python-golioth-tools@v0.6.4
+            git+https://github.com/golioth/python-golioth-tools@v0.6.3
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.hil_board }}-esp-idf
+          name: ${{ inputs.hil_board }}-sample-esp-idf
           path: .
       - name: Run test
         shell: bash
         env:
           hil_board: ${{ inputs.hil_board }}
         run: |
-          rm -rf summary
-          mkdir summary
           rm -rf allure-reports
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT
-          for test in $(ls tests/hil/tests)
+          for sample in $(find examples/esp_idf -type d -name pytest -exec dirname "{}" \;)
           do
-            pytest --rootdir . tests/hil/tests/$test                            \
+            pytest --rootdir . $sample                                          \
               --board ${{ inputs.hil_board }}_espidf                            \
               --port ${!PORT_VAR}                                               \
-              --fw-image ${test}.bin                                            \
+              --fw-image $(basename $sample).bin                                \
               --api-url ${{ inputs.api-url }}                                   \
               --api-key ${{ secrets[inputs.api-key-id] }}                       \
               --wifi-ssid ${{ secrets[format('{0}_WIFI_SSID', runner.name)] }}  \
               --wifi-psk ${{ secrets[format('{0}_WIFI_PSK', runner.name)] }}    \
               --mask-secrets                                                    \
               --timeout=600                                                     \
-              --junitxml=summary/hil-espidf-${{ inputs.hil_board }}-${test}.xml \
               --alluredir=allure-reports                                        \
-              --platform esp-idf                                                \
+              --platform=esp-idf                                                \
               --runner-name ${{ runner.name }}                                  \
+              --custom-suitename=sample                                         \
               || EXITCODE=$?
           done
           exit $EXITCODE
-
-      - name: Prepare summary
-        if: always()
-        shell: bash
-        run: |
-          if ! command -v sudo; then
-            # Self-hosted runner docker images don't have sudo installed
-            mkdir -p -m 777 /tmp && apt update && apt install -y xml-twig-tools
-          else
-            sudo apt install -y xml-twig-tools
-          fi
-
-          xml_grep \
-            --pretty_print indented \
-            --wrap testsuites \
-            --descr '' \
-            --cond "testsuite" \
-            summary/*.xml \
-            > combined.xml
-          mv combined.xml summary/hil-espidf-${{ inputs.hil_board }}.xml
-
-      - name: Safe upload CI report summary
-        uses: ./.github/actions/safe-upload-artifacts
-        if: always()
-        with:
-          name: ci-summary-hil-espidf-${{ inputs.hil_board }}
-          path: summary/hil-espidf-${{ inputs.hil_board }}.xml
 
       - name: Safe upload Allure reports
         if: always()
         uses: ./.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}
-          name: allure-reports-hil-espidf-${{ inputs.hil_board }}
+          name: allure-reports-samples-espidf-${{ inputs.hil_board }}
           path: allure-reports
 
       - name: Erase flash

--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -1,4 +1,4 @@
-name: Zephyr Samples Test Native_sim
+name: "HIL: nsim Samples"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -1,4 +1,4 @@
-name: Zephyr Sample Tests
+name: "HIL: Zephyr Samples"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/report-allure-publish.yml
+++ b/.github/workflows/report-allure-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Allure Reports to GitHub Pages
+name: "Report: Publish Allure"
 
 on:
   workflow_call:

--- a/.github/workflows/report-summary-publish.yml
+++ b/.github/workflows/report-summary-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Summary of all test to Checks section
+name: "Report: Publish Summary"
 
 on:
   workflow_call:

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: "Test: Comprehensive"
 
 on:
   workflow_dispatch:
@@ -137,7 +137,7 @@ jobs:
             west_board: rak5010/nrf52840
             manifest: .ci-west-zephyr.yml
             binary_name: zephyr.hex
-    uses: ./.github/workflows/hil_test_zephyr.yml
+    uses: ./.github/workflows/hil-integration-zephyr.yml
     with:
       hil_board: ${{ matrix.hil_board }}
       west_board: ${{ matrix.west_board }}
@@ -162,7 +162,7 @@ jobs:
             west_board: native_sim
           - platform: native_sim_64
             west_board: native_sim/native/64
-    uses: ./.github/workflows/hil_test_zephyr_nsim.yml
+    uses: ./.github/workflows/hil-integration-nsim.yml
     with:
       api-url: ${{ inputs.api-url }}
       api-key-id: ${{ inputs.api-key-id }}
@@ -183,7 +183,7 @@ jobs:
             idf_target: esp32
           - hil_board: esp32c3_devkitm
             idf_target: esp32c3
-    uses: ./.github/workflows/hil_test_esp-idf.yml
+    uses: ./.github/workflows/hil-integration-esp-idf.yml
     with:
       hil_board: ${{ matrix.hil_board }}
       idf_target: ${{ matrix.idf_target }}
@@ -194,7 +194,7 @@ jobs:
 
   hil_test_linux:
     if: ${{ inputs.workflow == 'all' || inputs.workflow == 'linux_integration' }}
-    uses: ./.github/workflows/hil_test_linux.yml
+    uses: ./.github/workflows/hil-integration-linux.yml
     with:
       api-url: ${{ inputs.api-url }}
       api-key-id: ${{ inputs.api-key-id }}
@@ -251,7 +251,7 @@ jobs:
             west_board: qemu_x86
             manifest: .ci-west-zephyr.yml
             run_tests: false
-    uses: ./.github/workflows/hil_sample_zephyr.yml
+    uses: ./.github/workflows/hil-sample-zephyr.yml
     with:
       hil_board: ${{ matrix.hil_board }}
       west_board: ${{ matrix.west_board }}
@@ -274,7 +274,7 @@ jobs:
             platform: native_sim_32
           - west_board: native_sim/native/64
             platform: native_sim_64
-    uses: ./.github/workflows/hil_sample_zephyr_nsim.yml
+    uses: ./.github/workflows/hil-sample-nsim.yml
     with:
       api-url: ${{ inputs.api-url }}
       api-key-id: ${{ inputs.api-key-id }}
@@ -414,7 +414,7 @@ jobs:
             idf_target: esp32
           - hil_board: esp32c3_devkitm
             idf_target: esp32c3
-    uses: ./.github/workflows/hil_sample_esp-idf.yml
+    uses: ./.github/workflows/hil-sample-esp-idf.yml
     with:
       hil_board: ${{ matrix.hil_board }}
       idf_target: ${{ matrix.idf_target }}
@@ -433,7 +433,7 @@ jobs:
       - hil_test_zephyr
       - hil_test_zephyr_nsim
     if: ${{ !cancelled() }}
-    uses: ./.github/workflows/reports-allure-publish.yml
+    uses: ./.github/workflows/report-allure-publish.yml
     secrets: inherit
     with:
       allure_branch: ${{ inputs.allure_branch }}
@@ -448,4 +448,4 @@ jobs:
       - hil_test_zephyr
       - hil_test_zephyr_nsim
     if: always()
-    uses: ./.github/workflows/reports-summary-publish.yml
+    uses: ./.github/workflows/report-summary-publish.yml

--- a/.github/workflows/test-recurring.yml
+++ b/.github/workflows/test-recurring.yml
@@ -1,4 +1,4 @@
-name: Run Recurring HIL Tests
+name: "Test: Recurring"
 
 on:
   schedule:
@@ -18,7 +18,7 @@ jobs:
             west_board: native_sim
           - platform: native_sim_64
             west_board: native_sim/native/64
-    uses: ./.github/workflows/hil_test_zephyr_nsim.yml
+    uses: ./.github/workflows/hil-integration-nsim.yml
     with:
       api-url: "https://api.golioth.io"
       api-key-id: "PROD_CI_PROJECT_API_KEY"
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
 
   hil_test_linux:
-    uses: ./.github/workflows/hil_test_linux.yml
+    uses: ./.github/workflows/hil-integration-linux.yml
     with:
       api-url: "https://api.golioth.io"
       api-key-id: "PROD_CI_PROJECT_API_KEY"
@@ -45,7 +45,7 @@ jobs:
             platform: native_sim_32
           - west_board: native_sim/native/64
             platform: native_sim_64
-    uses: ./.github/workflows/hil_sample_zephyr_nsim.yml
+    uses: ./.github/workflows/hil-sample-nsim.yml
     with:
       api-url: "https://api.golioth.io"
       api-key-id: "PROD_CI_PROJECT_API_KEY"
@@ -60,7 +60,7 @@ jobs:
       - hil_test_linux
       - hil_test_zephyr_nsim
     if: ${{ !cancelled() }}
-    uses: ./.github/workflows/reports-allure-publish.yml
+    uses: ./.github/workflows/report-allure-publish.yml
     secrets: inherit
     with:
       allure_branch: recurring
@@ -71,4 +71,4 @@ jobs:
       - hil_test_linux
       - hil_test_zephyr_nsim
     if: always()
-    uses: ./.github/workflows/reports-summary-publish.yml
+    uses: ./.github/workflows/report-summary-publish.yml

--- a/.github/workflows/trigger-push-and-schedule.yml
+++ b/.github/workflows/trigger-push-and-schedule.yml
@@ -1,4 +1,4 @@
-name: Tests Trigger (push and schedule)
+name: "Trigger: Push and Schedule"
 
 on:
   push:
@@ -15,5 +15,5 @@ concurrency:
 
 jobs:
   tests:
-    uses: ./.github/workflows/tests.yml
+    uses: ./.github/workflows/test-comprehensive.yml
     secrets: inherit


### PR DESCRIPTION
Rename and retitle all tests for better organization. This delivers a more uniform list on the GitHub Actions page, and groups workflow files by functionality.

- Use categories as prefix: ci, doc, hil, report, test, trigger
- Normalize on '-' instead of '_' in filenames
- Replace 'test' in filenames with 'integration' to differentiate from 'sample'