### PR TITLE
workflows: used older ubuntu for modustoolbox build test

### DIFF
--- a/.github/workflows/ci-lint-build.yml
+++ b/.github/workflows/ci-lint-build.yml
@@ -98,7 +98,7 @@ jobs:
           path: 'examples/esp_idf/certificate_auth'
 
   modus_toolbox_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       MTB_VERSION: 2.4.0.5972
       MTB_TOOLS_VERSION: 2.4


### PR DESCRIPTION
This build test is failing after GitHub changed `ubuntu-latest` to 24.04. Use older version of Ubuntu until the build issue is resolved.