### PR TITLE
ci: pin github runners to ubuntu 24.04

### DIFF
--- a/.github/workflows/ci-clean-project.yml
+++ b/.github/workflows/ci-clean-project.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check_versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-gitlint.yml
+++ b/.github/workflows/ci-gitlint.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   gitlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     container:
       image: jorisroovers/gitlint:0.19.1

--- a/.github/workflows/ci-lint-build.yml
+++ b/.github/workflows/ci-lint-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
@@ -36,7 +36,7 @@ jobs:
           git clang-format --verbose --extensions c,h --diff --diffstat $BASE
 
   linux_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
           ./build.sh
 
   esp_idf_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
           path: 'examples/esp_idf/certificate_auth'
 
   modus_toolbox_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       MTB_VERSION: 2.4.0.5972
       MTB_TOOLS_VERSION: 2.4

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     container:
       image: kiwicom/pre-commit:3.6.0

--- a/.github/workflows/ci-yamllint.yml
+++ b/.github/workflows/ci-yamllint.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   yamllint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/doc-firebase-doxygen-main.yml
+++ b/.github/workflows/doc-firebase-doxygen-main.yml
@@ -5,7 +5,7 @@ name: "Doc: Doxygen to Firebase (Main)"
       - main
 jobs:
   deploy_doxygen_prod:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Doxygen

--- a/.github/workflows/doc-firebase-doxygen-pr.yml
+++ b/.github/workflows/doc-firebase-doxygen-pr.yml
@@ -2,7 +2,7 @@ name: "Doc: Doxygen to Firebase (PR)"
 on: pull_request
 jobs:
   deploy_doxygen_dev:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Doxygen

--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   build:
     name: esp-idf-${{ inputs.hil_board }}-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository and Submodules
         uses: actions/checkout@v4

--- a/.github/workflows/hil-integration-linux.yml
+++ b/.github/workflows/hil-integration-linux.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   hil-matrix:
     name: linux-hil-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       tests: ${{ steps.output-tests.outputs.tests }}
@@ -51,7 +51,7 @@ jobs:
 
   hil:
     name: linux-hil-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: hil-matrix
 
     strategy:
@@ -134,7 +134,7 @@ jobs:
 
   hil-summary:
     name: linux-hil-tests-summary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: hil
 
     steps:

--- a/.github/workflows/hil-integration-nsim.yml
+++ b/.github/workflows/hil-integration-nsim.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: zephyr-native_sim-matrix-generate
 
     outputs:
@@ -63,7 +63,7 @@ jobs:
             print('tests=' + json.dumps(tests), file=github_output)
 
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: matrix
     container:
       image: golioth/golioth-zephyr-base:0.16.8-SDK-v0
@@ -168,7 +168,7 @@ jobs:
 
   hil_test_zephyr_nsim_summary:
     name: zephyr-${{ inputs.platform }}-test-summary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build_and_test
     if: success() || failure()
 

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -57,7 +57,7 @@ on:
 jobs:
   matrix:
     name: zephyr-${{ inputs.hil_board }}-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       tests: ${{ steps.output-tests.outputs.tests }}
@@ -89,7 +89,7 @@ jobs:
         test: ${{ fromJSON(needs.matrix.outputs.tests) }}
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
@@ -282,7 +282,7 @@ jobs:
 
   summary:
     name: zephyr-${{ inputs.hil_board }}-summary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: test
 
     steps:

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   build:
     name: esp-idf-${{ inputs.hil_board }}-sample-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository and Submodules
         uses: actions/checkout@v4

--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   build_and_test:
     name: zephyr-${{ inputs.west_board }}-twister
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: golioth/golioth-zephyr-base:0.16.8-SDK-v0
     env:
@@ -120,7 +120,7 @@ jobs:
 
   hil_sample_zephyr_nsim_summary:
     name: zephyr-${{ inputs.platform }}-twister-summary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build_and_test
     if: success() || failure()
 

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -69,7 +69,7 @@ jobs:
     container: golioth/golioth-zephyr-base:0.16.8-SDK-v0
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4

--- a/.github/workflows/report-allure-publish.yml
+++ b/.github/workflows/report-allure-publish.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   allure-collect-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency:
       group: publish_allure_to_gh_pages
       cancel-in-progress: false

--- a/.github/workflows/report-summary-publish.yml
+++ b/.github/workflows/report-summary-publish.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-test-summaries:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -74,7 +74,7 @@ on:
 
 jobs:
   unit_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository and submodules
@@ -284,7 +284,7 @@ jobs:
     secrets: inherit
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - hil_sample_zephyr_nsim
       - hil_test_linux


### PR DESCRIPTION
The GitHub Actions cloud runner `ubuntu-latest` images are moving from Ubuntu 22.04 LTS to Ubuntu 24.04 LTS. We should be pinning these anyway, so we'll pin to Ubuntu 24.04 LTS. This also suppresses a warning message in the GitHub UI.

The Modus Toolbox build workflow will remain pinned to Ubuntu 22.04 for now, as it does not build without modification on Ubuntu 24.04. Ubuntu 22.04 is supported for another 2 years.