### PR TITLE
ci: zephyr_integration: avoid collision in test report artifacts

### DIFF
--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -290,7 +290,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: summary
-          pattern: ci-individual-hil-zephyr-*
+          pattern: ci-individual-hil-zephyr-${{ inputs.hil_board }}-*
           merge-multiple: true
 
       - name: Prepare CI report summary


### PR DESCRIPTION
When creating the report summary, we were downloading the test results for all boards, instead of just the one we're testing. This caused results to be recorded multiple times, and for boards which completed testing later to include results from boards which completed testing earlier.

In this screenshot you can see how the ESP32 Zephyr integration test includes results for many more runs than it should:
<img width="645" alt="Screenshot 2025-01-03 at 5 51 27 PM" src="https://github.com/user-attachments/assets/166b5fbc-4318-47a2-aa39-28621a6e23b9" />
