### PR TITLE
workflows: update ModusToolbox to v3.3

### DIFF
--- a/.github/workflows/ci-lint-build.yml
+++ b/.github/workflows/ci-lint-build.yml
@@ -100,9 +100,9 @@ jobs:
   modus_toolbox_build:
     runs-on: ubuntu-22.04
     env:
-      MTB_VERSION: 2.4.0.5972
-      MTB_TOOLS_VERSION: 2.4
-      MTB_DOWNLOAD_ID: 1x_YeXR4XSjaf-NZimKxQ8MIyDGo72yHt
+      MTB_VERSION: 3.3.0.16857
+      MTB_TOOLS_VERSION: 3.3
+      MTB_DOWNLOAD_ID: ${{ secrets.MTB_DOWNLOAD_ID }}
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
@@ -113,22 +113,26 @@ jobs:
         with:
           python-version: 3.x
           architecture: 'x64'
-      - name: Download and install ModusToolbox 2.4
+      - name: Download and install ModusToolbox 3.3
         shell: bash
         run: |
           pip install click gdown==5.1.0 cryptography==41.0.7 intelhex cbor
-          gdown $MTB_DOWNLOAD_ID -O /tmp/ModusToolbox_$MTB_VERSION-linux-install.tar.gz
-          tar -C $HOME -zxf /tmp/ModusToolbox_$MTB_VERSION-linux-install.tar.gz
-          rm /tmp/ModusToolbox_$MTB_VERSION-linux-install.tar.gz
-          $HOME/ModusToolbox/tools_$MTB_TOOLS_VERSION/modus-shell/postinstall
+          sudo apt update && sudo apt install -y  \
+                          libxcb-xinerama0        \
+                          libxcb-icccm4           \
+                          libxcb-image0           \
+                          libxcb-keysyms1         \
+                          libxcb-render-util0     \
+                          libxkbcommon-x11-0      \
+                          libopengl0              \
+                          libegl1
+          gdown $MTB_DOWNLOAD_ID -O /tmp/modustoolbox_${MTB_VERSION}_Linux_x64.deb
+          sudo dpkg -i /tmp/modustoolbox_${MTB_VERSION}_Linux_x64.deb
+          rm /tmp/modustoolbox_${MTB_VERSION}_Linux_x64.deb
       - name: Build MTB golioth_basics project
         shell: bash
         run: |
-          # Ref:
-          # https://community.infineon.com/t5/ModusToolbox-General/ModusToolbox-Project-Creator-and-Library-Manager-report-no-Internet-connection/td-p/347593
-          export CyRemoteManifestOverride=\
-          https://github.com/cypresssemiconductorco/mtb-super-manifest/raw/v2.X/mtb-super-manifest-fv2.xml
-          export CY_TOOLS_PATHS=$HOME/ModusToolbox/tools_$MTB_TOOLS_VERSION
+          export CY_TOOLS_PATHS=/opt/Tools/ModusToolbox/tools_$MTB_TOOLS_VERSION
 
           cd examples/modus_toolbox/golioth_basics/golioth_app
           cp source/credentials.inc.template source/credentials.inc


### PR DESCRIPTION
Upgrade build test from ModusToolbox 2.4 to 3.3 to resolve upstream change that prevented `make getlibs` from downloading libraries.