### PR TITLE
workflow: use specific version of allure-report-action

### DIFF
--- a/.github/workflows/report-allure-publish.yml
+++ b/.github/workflows/report-allure-publish.yml
@@ -54,7 +54,7 @@ jobs:
           fi
 
       - name: Build Allure report
-        uses: simple-elf/allure-report-action@v1
+        uses: simple-elf/allure-report-action@v1.11
         if: always()
         with:
           gh_pages: ${{ env.GHPAGES_LABEL }}


### PR DESCRIPTION
Specify most recent minor version of action to ensure the fixes for links back to the workflow associated with a report is available.

## Before

![2025-01-07-105013_3840x1080_scrot](https://github.com/user-attachments/assets/77198bb9-b3e8-4241-a78f-ba07ff112433)

## After

![2025-01-07-105045_3840x1080_scrot](https://github.com/user-attachments/assets/87de35df-9da1-4c7b-9a88-5732de64d233)