### PR TITLE
Update ESP-IDF to v5.4

### DIFF
--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build Test Firmware
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: v5.3
+          esp_idf_version: v5.4
           target: ${{ inputs.idf_target }}
           path: 'tests/hil/platform/esp-idf'
           command: |

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build Samples
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: v5.3
+          esp_idf_version: v5.4
           target: ${{ inputs.idf_target }}
           command: |
             for sample in ${{ steps.build_prep.outputs.sample_list }};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] unreleased
+
+### Highlights:
+
+- ESP-IDF port updated to ESP-IDF v5.4
+
 ## [0.16.0] 2024-11-25
 
 ### Breaking Changes:

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ each of the samples is also continously verified on target.
 
 | Board                | Platform                 |
 | ---                  | ---                      |
-| ESP32-S3-DevKitC-1   | ESP-IDF (v5.3.0)         |
-| ESP32-C3-DevKitM-1   | ESP-IDF (v5.3.0)         |
-| ESP32-DevKitC-WROVER | ESP-IDF (v5.3.0)         |
+| ESP32-S3-DevKitC-1   | ESP-IDF (v5.4.0)         |
+| ESP32-C3-DevKitM-1   | ESP-IDF (v5.4.0)         |
+| ESP32-DevKitC-WROVER | ESP-IDF (v5.4.0)         |
 | ESP32-DevKitC-WROVER | Zephyr (v4.0.0)          |
 | nRF52840 DK + ESP32  | Zephyr (v4.0.0)          |
 | MIMXRT1024-EVK       | Zephyr (v4.0.0)          |

--- a/include/golioth/golioth_sys.h
+++ b/include/golioth/golioth_sys.h
@@ -201,16 +201,45 @@ void golioth_sys_client_disconnected(void *client);
 #include <stdio.h>
 #include "golioth_debug.h"
 
+#ifndef LOG_COLOR_RED
 #define LOG_COLOR_RED "31"
+#endif
+
+#ifndef LOG_COLOR_GREEN
 #define LOG_COLOR_GREEN "32"
+#endif
+
+#ifndef LOG_COLOR_BROWN
 #define LOG_COLOR_BROWN "33"
+#endif
+
+#ifndef LOG_COLOR
 #define LOG_COLOR(COLOR) "\033[0;" COLOR "m"
+#endif
+
+#ifndef LOG_RESET_COLOR
 #define LOG_RESET_COLOR "\033[0m"
+#endif
+
+#ifndef LOG_COLOR_E
 #define LOG_COLOR_E LOG_COLOR(LOG_COLOR_RED)
+#endif
+
+#ifndef LOG_COLOR_W
 #define LOG_COLOR_W LOG_COLOR(LOG_COLOR_BROWN)
+#endif
+
+#ifndef LOG_COLOR_I
 #define LOG_COLOR_I LOG_COLOR(LOG_COLOR_GREEN)
+#endif
+
+#ifndef LOG_COLOR_D
 #define LOG_COLOR_D
+#endif
+
+#ifndef LOG_COLOR_V
 #define LOG_COLOR_V
+#endif
 
 #ifndef GLTH_LOGX
 #define GLTH_LOGX(COLOR, LEVEL, LEVEL_STR, TAG, ...)                       \

--- a/port/esp_idf/libcoap/include/coap_config_posix.h
+++ b/port/esp_idf/libcoap/include/coap_config_posix.h
@@ -40,9 +40,12 @@ struct in6_pktinfo {
     struct in6_addr ipi6_addr; /* src/dst IPv6 address */
     unsigned int ipi6_ifindex; /* send/recv interface index */
 };
+
+#ifndef IN6_IS_ADDR_V4MAPPED
 #define IN6_IS_ADDR_V4MAPPED(a) \
     ((((__const uint32_t*)(a))[0] == 0) && (((__const uint32_t*)(a))[1] == 0) \
      && (((__const uint32_t*)(a))[2] == htonl(0xffff)))
+#endif
 
 /* As not defined, just need to define is as something innocuous */
 #define IPV6_PKTINFO IPV6_CHECKSUM


### PR DESCRIPTION
SDK Changes Due to this Update:
- Guard LOG_COLOR* defines with #ifndef
    - Espressif changed the defines so they no longer exactly match those in the Golioth SDK. They also turned off log    color by default, citing that `idf.py monitor` now handles colorization.
- Guard IN6_IS_ADDR_V4MAPPED(a) with #ifndef
    - The macro was compared between the header in the Golioth Firmware SDK and the one in the esp-lwip repo and found to be functionally equivalent.

Resolves https://github.com/golioth/firmware-issue-tracker/issues/734
