### PR TITLE
ci: ensure summary step runs after failures

### DIFF
--- a/.github/workflows/hil-integration-linux.yml
+++ b/.github/workflows/hil-integration-linux.yml
@@ -136,6 +136,7 @@ jobs:
     name: linux-hil-tests-summary
     runs-on: ubuntu-24.04
     needs: hil
+    if: success() || failure()
 
     steps:
       - name: Checkout repository
@@ -147,7 +148,6 @@ jobs:
           pattern: ci-hil-linux-*
 
       - name: Prepare summary
-        if: always()
         shell: bash
         run: |
           if ! command -v sudo; then
@@ -165,7 +165,6 @@ jobs:
 
       - name: Safe upload CI report summary
         uses: ./.github/actions/safe-upload-artifacts
-        if: always()
         with:
           name: ci-summary-hil-linux
           path: hil-linux.xml

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -284,6 +284,7 @@ jobs:
     name: zephyr-${{ inputs.hil_board }}-summary
     runs-on: ubuntu-24.04
     needs: test
+    if: success() || failure()
 
     steps:
       - name: Collect JUnit reports
@@ -294,7 +295,6 @@ jobs:
           merge-multiple: true
 
       - name: Prepare CI report summary
-        if: always()
         shell: bash
         run: |
           sudo apt install -y xml-twig-tools
@@ -309,7 +309,6 @@ jobs:
 
       - name: Upload CI report summary
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: ci-summary-hil-zephyr-${{ inputs.hil_board }}
           path: summary/hil-zephyr-${{ inputs.hil_board }}.xml


### PR DESCRIPTION
When we split the test job into a matrix of jobs, the summary steps were moved to their own job. This job needs to be run after both success and failures of the test jobs to ensure that the summary reflects any test failures.