### PR TITLE
ci: pin ubuntu version for esp-idf-device-name job

### DIFF
--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -48,7 +48,7 @@ on:
 
 jobs:
   rand_name:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: esp-idf-device-name
 
     outputs:


### PR DESCRIPTION
This job was added after the ubuntu version was pinned for all of the other jobs. Pin the ubuntu version used in GitHub Actions to ensure stability and suppress warnings in the GitHub UI.