### PR TITLE
location: twister+pytest test for native_sim and playback data

### DIFF
--- a/examples/zephyr/location/pytest/conftest.py
+++ b/examples/zephyr/location/pytest/conftest.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+@pytest.fixture(scope='session')
+def anyio_backend():
+    return 'trio'

--- a/examples/zephyr/location/pytest/test_sample.py
+++ b/examples/zephyr/location/pytest/test_sample.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import namedtuple
+import re
+
+from twister_harness.device.device_adapter import DeviceAdapter
+from twister_harness.helpers.shell import Shell
+
+import pytest
+
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_location(shell: Shell, dut: DeviceAdapter, device):
+    # Set Golioth credential
+
+    golioth_cred = (await device.credentials.list())[0]
+    shell.exec_command(f"settings set golioth/psk-id {golioth_cred.identity}")
+    shell.exec_command(f"settings set golioth/psk {golioth_cred.key}")
+
+    # Wait for Golioth connection
+
+    dut.readlines_until(regex=".*Golioth CoAP client connected", timeout=90.0)
+
+    # Verify position
+
+    pattern = re.compile(r".* (?P<lon>\d+\.\d+) (?P<lat>\d+\.\d+) \((?P<acc>\d+)\)")
+    Position = namedtuple('Position', ('lon', 'lat', 'acc'))
+
+    positions = []
+    for _ in range(3):
+        lines = dut.readlines_until(regex=pattern, timeout=30.0)
+        m = pattern.search(lines[-1])
+        pos = Position(*[float(m[p]) for p in ['lon', 'lat', 'acc']])
+        positions.append(pos)
+
+    for pos in positions:
+        assert pos.lon == pytest.approx(50.663974800, 1e-3)
+        assert pos.lat == pytest.approx(17.942322850, 1e-3)
+        assert pos.acc < 2000

--- a/examples/zephyr/location/sample.yaml
+++ b/examples/zephyr/location/sample.yaml
@@ -2,13 +2,13 @@ sample:
   description: Location example
   name: location
 common:
-  build_only: true
   tags:
     - golioth
     - location
     - socket
 tests:
   sample.golioth.location:
+    build_only: true
     platform_allow:
       - esp32_devkitc_wrover/esp32/procpu
       - native_sim
@@ -16,14 +16,32 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-  sample.golioth.location.wifi_only:
+  sample.golioth.location.playback:
+    timeout: 100
+    harness: pytest
+    extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
     extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+      - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+  sample.golioth.location.playback.wifi:
+    harness: pytest
+    extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+      - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
       - CONFIG_GOLIOTH_CELLULAR_PLAYBACK=n
     platform_allow:
       - native_sim
       - native_sim/native/64
-  sample.golioth.location.cellular_only:
+  sample.golioth.location.playback.cellular:
+    harness: pytest
+    extra_args: EXTRA_CONF_FILE="../common/runtime_settings.conf"
     extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+      - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
       - CONFIG_GOLIOTH_WIFI_PLAYBACK=n
     platform_allow:
       - native_sim


### PR DESCRIPTION
There are 3 runtime tests:
 * cellular + wifi
 * cellular only
 * wifi

all executed using `native_sim` platform and playback data.

Supersedes: #725