### PR TITLE
ci: don't store artifacts while cancelling workflows

### DIFF
--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -136,7 +136,7 @@ jobs:
           exit $EXITCODE
 
       - name: Prepare summary
-        if: always()
+        if: success() || failure()
         shell: bash
         run: |
           if ! command -v sudo; then
@@ -157,13 +157,13 @@ jobs:
 
       - name: Safe upload CI report summary
         uses: ./.github/actions/safe-upload-artifacts
-        if: always()
+        if: success() || failure()
         with:
           name: ci-summary-hil-espidf-${{ inputs.hil_board }}
           path: summary/hil-espidf-${{ inputs.hil_board }}.xml
 
       - name: Safe upload Allure reports
-        if: always()
+        if: success() || failure()
         uses: ./.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}

--- a/.github/workflows/hil-integration-linux.yml
+++ b/.github/workflows/hil-integration-linux.yml
@@ -123,13 +123,13 @@ jobs:
 
       - name: Safe upload CI report summary
         uses: ./.github/actions/safe-upload-artifacts
-        if: always()
+        if: success() || failure()
         with:
           name: ci-hil-linux-${{ matrix.test }}
           path: summary/hil-linux-*.xml
 
       - name: Safe upload Allure reports
-        if: always()
+        if: success() || failure()
         uses: ./.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}

--- a/.github/workflows/hil-integration-nsim.yml
+++ b/.github/workflows/hil-integration-nsim.yml
@@ -180,7 +180,7 @@ jobs:
           pattern: ci-individual-hil-zephyr-*
 
       - name: Prepare CI report summary
-        if: always()
+        if: success() || failure()
         run: |
           sudo apt install -y xml-twig-tools
 
@@ -195,7 +195,7 @@ jobs:
 
       - name: Upload CI report summary
         uses: actions/upload-artifact@v4
-        if: always()
+        if: success() || failure()
         with:
           name: ci-summary-hil-zephyr-${{ inputs.platform }}
           path: hil-zephyr-*.xml

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -215,13 +215,13 @@ jobs:
 
       - name: Safe upload CI report summary
         uses: ./.github/actions/safe-upload-artifacts
-        if: always()
+        if: success() || failure()
         with:
           name: ci-individual-hil-zephyr-${{ inputs.hil_board }}-${{ matrix.test }}
           path: summary/*.xml
 
       - name: Safe upload Allure reports
-        if: always()
+        if: success() || failure()
         uses: ./.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -190,7 +190,7 @@ jobs:
           exit $EXITCODE
 
       - name: Safe upload Allure reports
-        if: always()
+        if: success() || failure()
         uses: ./.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}

--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -90,7 +90,7 @@ jobs:
               --pytest-args="--hil-board=${{ inputs.platform }}"
 
       - name: Safe upload twister artifacts
-        if: always()
+        if: success() || failure()
         uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}
@@ -105,13 +105,13 @@ jobs:
 
       - name: Safe upload CI report summary
         uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
-        if: always()
+        if: success() || failure()
         with:
           name: ci-individual-samples-zephyr-${{ inputs.platform }}
           path: twister-out/twister_suite_report.xml
 
       - name: Safe upload Allure reports
-        if: always()
+        if: success() || failure()
         uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}
@@ -131,7 +131,7 @@ jobs:
           pattern: ci-individual-samples-zephyr-*
 
       - name: Prepare CI report summary
-        if: always()
+        if: success() || failure()
         run: |
           sudo apt install -y xml-twig-tools
 
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload CI report summary
         uses: actions/upload-artifact@v4
-        if: always()
+        if: success() || failure()
         with:
           name: ci-summary-samples-zephyr-${{ inputs.platform }}
           path: samples-zephyr-*.xml

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -127,7 +127,7 @@ jobs:
                 $EXTRA_BUILD_ARGS
 
       - name: Save artifacts
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: test_artifacts_${{ inputs.hil_board }}
@@ -220,7 +220,7 @@ jobs:
                 -v
 
       - name: Safe upload twister artifacts
-        if: always()
+        if: success() || failure()
         uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}
@@ -233,7 +233,7 @@ jobs:
             twister-out/*.json
 
       - name: Prepare CI report summary
-        if: always()
+        if: success() || failure()
         run: |
           rm -rf summary
           mkdir summary
@@ -241,13 +241,13 @@ jobs:
 
       - name: Safe upload CI report summary
         uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
-        if: always()
+        if: success() || failure()
         with:
           name: ci-summary-samples-zephyr-${{ inputs.hil_board }}
           path: summary/*
 
       - name: Safe upload Allure reports
-        if: always()
+        if: success() || failure()
         uses: ./modules/lib/golioth-firmware-sdk/.github/actions/safe-upload-artifacts
         with:
           secrets-json: ${{ toJson(secrets) }}

--- a/.github/workflows/report-allure-publish.yml
+++ b/.github/workflows/report-allure-publish.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build Allure report
         uses: simple-elf/allure-report-action@v1.11
-        if: always()
+        if: success() || failure()
         with:
           gh_pages: ${{ env.GHPAGES_LABEL }}
           allure_history: reports/allure-history
@@ -72,7 +72,7 @@ jobs:
                 --delete
 
       - name: Place index.html
-        if: always() && github.ref == 'refs/heads/main'
+        if: (success() || failure()) && github.ref == 'refs/heads/main'
         # Root URL should always point to latest main report
         run: |
           cp reports/allure-history/${{ steps.vars.outputs.allure_subdir}}/index.html \
@@ -80,7 +80,7 @@ jobs:
 
       - name: Publish test report
         uses: peaceiris/actions-gh-pages@v4
-        if: always()
+        if: success() || failure()
         with:
           deploy_key: ${{ secrets.ALLURE_REPORTS_DEPLOY_KEY }}
           external_repository: golioth/allure-reports

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -104,7 +104,7 @@ jobs:
             build
 
       - name: Upload test coverage artifacts
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: unit-test-coverage
@@ -364,7 +364,7 @@ jobs:
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
-        if: always()
+        if: success() || failure()
         with:
           name: coverage-native-sim
           path: coverage/*
@@ -447,5 +447,5 @@ jobs:
       - hil_test_linux
       - hil_test_zephyr
       - hil_test_zephyr_nsim
-    if: always()
+    if: success() || failure()
     uses: ./.github/workflows/report-summary-publish.yml

--- a/.github/workflows/test-recurring.yml
+++ b/.github/workflows/test-recurring.yml
@@ -70,5 +70,5 @@ jobs:
       - hil_sample_zephyr_nsim
       - hil_test_linux
       - hil_test_zephyr_nsim
-    if: always()
+    if: success() || failure()
     uses: ./.github/workflows/report-summary-publish.yml


### PR DESCRIPTION
Prefer `success() || failure()` instead of `always()` for workflow steps related to storing artifacts, and generating and storing test reports. This ensures that those steps won't run when a workflow is cancelled. This will allow runs to be cancelled faster, and also prevents incomplete results from being included in test reports.

Note that the steps for erasing boards and powering down USB hubs are left as `always()` so that we still put the runners into our preferred idle state after cancelling a run.