### PR TITLE
bump NCS to 2.9.0

### DIFF
--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -1,7 +1,7 @@
 manifest:
   projects:
     - name: nrf
-      revision: v2.8.0
+      revision: v2.9.0
       url: http://github.com/nrfconnect/sdk-nrf
       import: true
 


### PR DESCRIPTION
This is the latest NCS stable release.