### PR TITLE
tests: settings: delay after connection for log flush

### DIFF
--- a/tests/hil/tests/settings/test.c
+++ b/tests/hil/tests/settings/test.c
@@ -128,6 +128,12 @@ void hil_test_entry(const struct golioth_client_config *config)
 
     struct golioth_settings *settings = perform_settings_registration(client);
 
+    /* Allow log buffer to clear then notify test script of registration complete */
+
+    golioth_sys_msleep(5 * 1000);
+
+    GLTH_LOGI(TAG, "Settings registration complete");
+
     while (1)
     {
         if (golioth_sys_sem_take(cancel_all_sem, 0))

--- a/tests/hil/tests/settings/test_settings.py
+++ b/tests/hil/tests/settings/test_settings.py
@@ -38,8 +38,8 @@ async def setup(project, board, device):
     golioth_cred = (await device.credentials.list())[0]
     await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
-    # Confirm connection to Golioth
-    assert None != await board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+    # Wait for settings registration
+    assert None != await board.wait_for_regex_in_line('Settings registration complete', timeout_s=30)
 
 async def assert_settings_error(device, key, error):
     await device.refresh()


### PR DESCRIPTION
When registering settings during the HIL test, we get a flood of log messages. On some platforms this can overwhelm the log buffer and lead to dropped messages. If one of those dropped messages is the connection message that the test scripts wait for, the test will fail.

Now, we add a small delay after registering the settings to give time for the log buffer to flush, and then send a new "settings registration complete" message for the test script to key off of. This ensures the test script receives the message, and increases the stability of the test.

Resolves golioth/firmware-issue-tracker#737