### PR TITLE
west: drop 'tinycrypt' module

### DIFF
--- a/.ci-west-ncs.yml
+++ b/.ci-west-ncs.yml
@@ -15,7 +15,6 @@ manifest:
         - oberon-psa-crypto
         - qcbor
         - segger
-        - tinycrypt
         - trusted-firmware-m
         - zcbor
         - zephyr

--- a/.ci-west-zephyr.yml
+++ b/.ci-west-zephyr.yml
@@ -14,6 +14,5 @@ manifest:
         - net-tools
         - picolibc
         - segger
-        - tinycrypt
         - zcbor
         - zephyr


### PR DESCRIPTION
Tinycrypt is no longer needed, as there was a switch to other crypto
implementation.