### PR TITLE
west: ci-ncs: drop qcbor

### DIFF
--- a/.ci-west-ncs.yml
+++ b/.ci-west-ncs.yml
@@ -13,7 +13,6 @@ manifest:
         - nrf
         - nrfxlib
         - oberon-psa-crypto
-        - qcbor
         - segger
         - tinycrypt
         - trusted-firmware-m


### PR DESCRIPTION
We no longer use qcbor, having replaced it with zcbor.