### PR TITLE
fw_update: fix log message on hash mismatch

### DIFF
--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -302,7 +302,7 @@ static enum golioth_status fw_verify_component_hash(
     else
     {
         GLTH_LOGE(TAG,
-                  "Firmware download failed; Recieved %u bytes but sha256 doesn't match",
+                  "Firmware download failed; Received %u bytes but sha256 doesn't match",
                   ctx->bytes_downloaded);
 
         GLTH_LOG_BUFFER_HEXDUMP(TAG,


### PR DESCRIPTION
Fixes small misspelling in log message when downloaded image hash does not match the hash in the manifest.