### PR TITLE
Implement multi-block upload

### DIFF
--- a/include/golioth/client.h
+++ b/include/golioth/client.h
@@ -163,6 +163,21 @@ typedef void (*golioth_get_cb_fn)(struct golioth_client *client,
                                   size_t payload_size,
                                   void *arg);
 
+/// Callback function type for blockwise uploads that also returns the blocksize in szx format
+///
+/// @param client The client handle from the original request.
+/// @param status Golioth status code.
+/// @param coap_rsp_code CoAP response code received from Golioth. Can be NULL.
+/// @param path The path from the original request
+/// @param block_size The block size from the server in bytes
+/// @param arg User argument, copied from the original request. Can be NULL.
+typedef void (*golioth_set_block_cb_fn)(struct golioth_client *client,
+                                        enum golioth_status status,
+                                        const struct golioth_coap_rsp_code *coap_rsp_code,
+                                        const char *path,
+                                        size_t block_size,
+                                        void *arg);
+
 /// Callback for blockwise get requests
 ///
 /// Will be called repeatedly, once for each block received from the server, on timeout (i.e.

--- a/include/golioth/stream.h
+++ b/include/golioth/stream.h
@@ -112,6 +112,57 @@ enum golioth_status golioth_stream_set_blockwise_sync(struct golioth_client *cli
                                                       stream_read_block_cb cb,
                                                       void *arg);
 
+/// Create a multipart blockwise upload context
+///
+/// Creates the context and returns a pointer to it. This context is used to associate all blocks of
+/// a multipart upload together. A new context is needed at the start of each multipart blockwise
+/// upload operation.
+///
+/// @param client The client handle from @ref golioth_client_create
+/// @param path The path in stream to set (e.g. "my_obj")
+/// @param content_type The content type of the object (e.g. JSON or CBOR)
+struct blockwise_transfer *golioth_stream_blockwise_start(struct golioth_client *client,
+                                                          const char *path,
+                                                          enum golioth_content_type content_type);
+
+/// Destroy a multi-block upload context
+///
+/// Free the memory allocated for a given multi-block upload context.
+///
+/// @param ctx Block upload context to be destroyed
+void golioth_stream_blockwise_finish(struct blockwise_transfer *ctx);
+
+/// Set an object in stream at a particular path by sending each block asynchronously
+///
+/// Call this function for each block. For each call you must increment the \p block_idx, adjust the
+/// \p block_buffer pointer and update the \p data_len. On the final block, set \p is_last to true.
+/// Block size is determined by the value of CONFIG_GOLIOTH_BLOCKWISE_DOWNLOAD_MAX_BLOCK_SIZE.
+///
+/// Create a new \p ctx by calling \ref golioth_stream_blockwise_start. The same \p ctx must be
+/// used for all blocks in a related upload. Generate a new \p ctx for each new upload operation.
+/// Free the context memory by calling \ref golioth_stream_blockwise_finish.
+///
+/// An optional callback and callback argument may be supplied. The callback will be called after
+/// the block is uploaded to provide access to status and CoAP response codes.
+///
+/// @param ctx Block upload context used for all blocks in a related upload operation
+/// @param block_idx The index of the block being sent
+/// @param block_buffer The buffer where the data for this block is located
+/// @param data_len The actual length of data (in bytes) for this block. This should be equal to
+///        CONFIG_GOLIOTH_BLOCKWISE_DOWNLOAD_MAX_BLOCK_SIZE for all blocks except for the final
+///        block, which may be shorter
+/// @param is_last Set this to true if this is the last block in the upload
+/// @param callback A callback that will be called after each block is sent (can be NULL)
+/// @param callback_arg An optional user provided argument that will be passed to \p callback (can
+///        be NULL)
+enum golioth_status golioth_stream_blockwise_set_block_async(struct blockwise_transfer *ctx,
+                                                             uint32_t block_idx,
+                                                             const uint8_t *block_buffer,
+                                                             size_t data_len,
+                                                             bool is_last,
+                                                             golioth_set_block_cb_fn callback,
+                                                             void *callback_arg);
+
 /// @}
 
 #ifdef __cplusplus

--- a/src/coap_blockwise.c
+++ b/src/coap_blockwise.c
@@ -137,7 +137,7 @@ static void on_block_sent(struct golioth_client *client,
                           enum golioth_status status,
                           const struct golioth_coap_rsp_code *coap_rsp_code,
                           const char *path,
-                          size_t block_szx,
+                          size_t block_size,
                           void *arg)
 {
     assert(arg);
@@ -145,7 +145,7 @@ static void on_block_sent(struct golioth_client *client,
     ctx->status = status;
     ctx->coap_rsp_code.code_class = coap_rsp_code->code_class;
     ctx->coap_rsp_code.code_detail = coap_rsp_code->code_detail;
-    ctx->negotiated_blocksize_szx = block_szx;
+    ctx->negotiated_blocksize_szx = BLOCKSIZE_TO_SZX(block_size);
 
     golioth_sys_sem_give(ctx->sem);
 }

--- a/src/coap_blockwise.c
+++ b/src/coap_blockwise.c
@@ -22,24 +22,15 @@ _Static_assert(BLOCKSIZE_TO_SZX(CONFIG_GOLIOTH_BLOCKWISE_UPLOAD_MAX_BLOCK_SIZE) 
 
 struct blockwise_transfer
 {
-    bool is_last;
+    struct golioth_client *client;
     enum golioth_content_type content_type;
     golioth_sys_sem_t sem;
     uint8_t token[GOLIOTH_COAP_TOKEN_LEN];
-    uint32_t block_idx;
-    /* Negotiated block size */
-    size_t block_size;
     const char *path_prefix;
     const char *path;
-    uint8_t *block_buffer;
-    union
-    {
-        read_block_cb read_cb;
-        write_block_cb write_cb;
-    } callback;
+
     enum golioth_status status;
     struct golioth_coap_rsp_code coap_rsp_code;
-    void *callback_arg;
 };
 
 struct post_block_ctx
@@ -48,89 +39,62 @@ struct post_block_ctx
     struct golioth_coap_rsp_code coap_rsp_code;
     golioth_sys_sem_t sem;
     size_t negotiated_blocksize_szx;
+
+    bool is_last;
+    size_t block_size;
+    uint32_t block_idx;
+    uint8_t *block_buffer;
+    read_block_cb read_cb;
+    void *callback_arg;
+
+    struct blockwise_transfer *transfer_ctx;
 };
 
 struct get_block_ctx
 {
-    uint8_t *buffer;
     size_t rcvd_bytes;
     enum golioth_status status;
     struct golioth_coap_rsp_code coap_rsp_code;
     golioth_sys_sem_t sem;
     bool is_last;
+
+    size_t block_size;
+    uint32_t block_idx;
+    uint8_t *block_buffer;
+    write_block_cb write_cb;
+    void *callback_arg;
+
+    struct blockwise_transfer *transfer_ctx;
 };
 
-/* Blockwise Uploads related functions */
-
-static void blockwise_upload_free(struct blockwise_transfer *ctx)
+// Function to initialize the blockwise_transfer structure
+static struct blockwise_transfer *blockwise_transfer_init(struct golioth_client *client,
+                                                          const char *path_prefix,
+                                                          const char *path,
+                                                          enum golioth_content_type content_type)
 {
-    if (!ctx)
-    {
-        return;
-    }
-
-    golioth_sys_sem_destroy(ctx->sem);
-    free(ctx->block_buffer);
-}
-
-// Function to initialize the blockwise_transfer structure for uploads
-struct blockwise_transfer *blockwise_upload_init(const char *path_prefix,
-                                                 const char *path,
-                                                 enum golioth_content_type content_type,
-                                                 size_t block_buffer_size)
-{
-    if (strlen(path) > CONFIG_GOLIOTH_COAP_MAX_PATH_LEN)
-    {
-        GLTH_LOGE(TAG, "Path too long: %zu > %zu", strlen(path), CONFIG_GOLIOTH_COAP_MAX_PATH_LEN);
-        return NULL;
-    }
-
     struct blockwise_transfer *ctx = golioth_sys_malloc(sizeof(struct blockwise_transfer));
     if (NULL == ctx)
     {
-        goto finish;
+        return NULL;
     }
 
-    if (block_buffer_size)
-    {
-        ctx->block_buffer = golioth_sys_malloc(block_buffer_size);
-        if (NULL == ctx->block_buffer)
-        {
-            goto finish_with_ctx;
-        }
-    }
-    else
-    {
-        ctx->block_buffer = NULL;
-    }
-
-    ctx->sem = golioth_sys_sem_create(1, 0);
-    if (NULL == ctx->sem)
-    {
-        goto finish_with_buff;
-    }
-
-    ctx->is_last = false;
+    ctx->client = client;
     ctx->path_prefix = path_prefix;
     ctx->path = path;
     ctx->content_type = content_type;
-    ctx->block_size = CONFIG_GOLIOTH_BLOCKWISE_DOWNLOAD_MAX_BLOCK_SIZE;
-    ctx->block_idx = 0;
-    ctx->callback_arg = NULL;
-    ctx->callback.read_cb = NULL; /* sets all union members to NULL */
     golioth_coap_next_token(ctx->token);
 
     return ctx;
-
-finish_with_buff:
-    free(ctx->block_buffer);
-
-finish_with_ctx:
-    free(ctx);
-
-finish:
-    return NULL;
 }
+
+// Function to free the blockwise_transfer structure
+static void blockwise_transfer_free(struct blockwise_transfer *ctx)
+{
+    free(ctx);
+}
+
+/* Blockwise Uploads related functions */
 
 // Blockwise upload's internal callback function that the COAP client calls
 static void on_block_sent(struct golioth_client *client,
@@ -152,17 +116,17 @@ static void on_block_sent(struct golioth_client *client,
 
 // Function to call the application's read block callback for obtaining
 // blockwise upload data
-static enum golioth_status call_read_block_callback(struct blockwise_transfer *ctx,
+static enum golioth_status call_read_block_callback(struct post_block_ctx *ctx,
                                                     size_t *block_buffer_len)
 {
     /* Do not allow user callback to directly change ctx->block_size value */
     size_t block_size = ctx->block_size;
 
-    enum golioth_status status = ctx->callback.read_cb(ctx->block_idx,
-                                                       ctx->block_buffer,
-                                                       &block_size,
-                                                       &ctx->is_last,
-                                                       ctx->callback_arg);
+    enum golioth_status status = ctx->read_cb(ctx->block_idx,
+                                              ctx->block_buffer,
+                                              &block_size,
+                                              &ctx->is_last,
+                                              ctx->callback_arg);
     if (status != GOLIOTH_OK)
     {
         return status;
@@ -191,48 +155,42 @@ static int recalculate_next_block_idx(int from_idx, size_t from_larger_szx, size
 
 // Function to upload a single block
 static enum golioth_status upload_single_block(struct golioth_client *client,
-                                               struct blockwise_transfer *ctx,
+                                               struct post_block_ctx *ctx,
                                                size_t block_size)
 {
     assert(block_size > 0 && block_size <= ctx->block_size);
 
-    struct post_block_ctx arg = {
-        .status = GOLIOTH_ERR_FAIL,
-        .sem = ctx->sem,
-        .negotiated_blocksize_szx = BLOCKSIZE_TO_SZX(ctx->block_size),
-    };
-
     enum golioth_status err = golioth_coap_client_set_block(client,
-                                                            ctx->token,
-                                                            ctx->path_prefix,
-                                                            ctx->path,
+                                                            ctx->transfer_ctx->token,
+                                                            ctx->transfer_ctx->path_prefix,
+                                                            ctx->transfer_ctx->path,
                                                             ctx->is_last,
-                                                            ctx->content_type,
+                                                            ctx->transfer_ctx->content_type,
                                                             ctx->block_idx,
-                                                            arg.negotiated_blocksize_szx,
+                                                            ctx->negotiated_blocksize_szx,
                                                             ctx->block_buffer,
                                                             block_size,
                                                             on_block_sent,
-                                                            &arg,
+                                                            ctx,
                                                             false,
                                                             GOLIOTH_SYS_WAIT_FOREVER);
     if (GOLIOTH_OK == err)
     {
         golioth_sys_sem_take(ctx->sem, GOLIOTH_SYS_WAIT_FOREVER);
-        err = arg.status;
+        err = ctx->status;
 
-        if (arg.negotiated_blocksize_szx < BLOCKSIZE_TO_SZX(ctx->block_size))
+        if (ctx->negotiated_blocksize_szx < BLOCKSIZE_TO_SZX(ctx->block_size))
         {
             /* Recalculate index so what was sent is now based on the new block_size */
             int next_block_idx = recalculate_next_block_idx(ctx->block_idx,
                                                             BLOCKSIZE_TO_SZX(ctx->block_size),
-                                                            arg.negotiated_blocksize_szx);
+                                                            ctx->negotiated_blocksize_szx);
 
             /* Subtract 1 to indicate the block we just sent; inc happens after return */
             ctx->block_idx = next_block_idx - 1;
 
             /* Store the new blocksize for future blocks */
-            ctx->block_size = SZX_TO_BLOCKSIZE(arg.negotiated_blocksize_szx);
+            ctx->block_size = SZX_TO_BLOCKSIZE(ctx->negotiated_blocksize_szx);
         }
     }
 
@@ -241,7 +199,7 @@ static enum golioth_status upload_single_block(struct golioth_client *client,
 
 // Function to manage blockwise upload and handle errors
 static enum golioth_status process_blockwise_uploads(struct golioth_client *client,
-                                                     struct blockwise_transfer *ctx)
+                                                     struct post_block_ctx *ctx)
 {
     size_t block_buffer_len = ctx->block_size;
     enum golioth_status status = call_read_block_callback(ctx, &block_buffer_len);
@@ -266,25 +224,46 @@ enum golioth_status golioth_blockwise_post(struct golioth_client *client,
                                            void *callback_arg)
 {
     enum golioth_status status = GOLIOTH_ERR_FAIL;
-    if (!client || !path || !read_cb)
+    if (NULL == client || NULL == path || NULL == read_cb)
     {
         return status;
     }
 
-    struct blockwise_transfer *ctx =
-        blockwise_upload_init(path_prefix,
-                              path,
-                              content_type,
-                              CONFIG_GOLIOTH_BLOCKWISE_UPLOAD_MAX_BLOCK_SIZE);
-    if (!ctx)
+    status = GOLIOTH_ERR_MEM_ALLOC;
+
+    struct post_block_ctx *ctx = golioth_sys_malloc(sizeof(struct post_block_ctx));
+    if (NULL == ctx)
     {
-        return GOLIOTH_ERR_MEM_ALLOC;
+        goto finish;
     }
 
-    ctx->callback.read_cb = read_cb;
-    ctx->callback_arg = callback_arg;
+    ctx->block_buffer = golioth_sys_malloc(CONFIG_GOLIOTH_BLOCKWISE_UPLOAD_MAX_BLOCK_SIZE);
+    if (NULL == ctx->block_buffer)
+    {
+        goto finish_with_post_block_ctx;
+    }
 
-    while (!ctx->is_last)
+    ctx->transfer_ctx = blockwise_transfer_init(client, path_prefix, path, content_type);
+    if (NULL == ctx->transfer_ctx)
+    {
+        goto finish_with_block_buffer;
+    }
+
+    ctx->sem = golioth_sys_sem_create(1, 0);
+    if (NULL == ctx->sem)
+    {
+        goto finish_with_transfer_ctx;
+    }
+
+    ctx->status = GOLIOTH_ERR_FAIL, ctx->is_last = false;
+    ctx->block_size = CONFIG_GOLIOTH_BLOCKWISE_UPLOAD_MAX_BLOCK_SIZE;
+    ctx->block_idx = 0;
+    ctx->read_cb = read_cb;
+    ctx->callback_arg = callback_arg;
+    ctx->negotiated_blocksize_szx =
+        BLOCKSIZE_TO_SZX(CONFIG_GOLIOTH_BLOCKWISE_UPLOAD_MAX_BLOCK_SIZE);
+
+    while (false == ctx->is_last)
     {
         if ((status = process_blockwise_uploads(client, ctx)) != GOLIOTH_OK)
         {
@@ -312,46 +291,34 @@ enum golioth_status golioth_blockwise_post(struct golioth_client *client,
     }
 
     /* Upload complete, clean up allocated resources */
-    blockwise_upload_free(ctx);
+    golioth_sys_sem_destroy(ctx->sem);
 
+finish_with_transfer_ctx:
+    blockwise_transfer_free(ctx->transfer_ctx);
+
+finish_with_block_buffer:
+    free(ctx->block_buffer);
+
+finish_with_post_block_ctx:
+    free(ctx);
+
+finish:
     return status;
 }
 
 
 /* Blockwise Downloads related functions */
 
-// Function to initialize the blockwise_transfer structure for downloads
-static void blockwise_download_init(struct blockwise_transfer *ctx,
-                                    uint8_t *data_buf,
-                                    const char *path_prefix,
-                                    const char *path,
-                                    enum golioth_content_type content_type,
-                                    write_block_cb cb,
-                                    void *callback_arg)
-{
-    ctx->is_last = false;
-    ctx->path_prefix = path_prefix;
-    ctx->path = path;
-    ctx->content_type = content_type;
-    ctx->block_size = CONFIG_GOLIOTH_BLOCKWISE_DOWNLOAD_MAX_BLOCK_SIZE;
-    ctx->block_idx = 0;
-    ctx->block_buffer = data_buf;
-    ctx->callback_arg = callback_arg;
-    ctx->callback.write_cb = cb;
-    golioth_coap_next_token(ctx->token);
-}
-
 // Function to call the application's write block callback after a successful
 // blockwise download
-static enum golioth_status call_write_block_callback(struct blockwise_transfer *ctx,
-                                                     size_t rcvd_bytes)
+static enum golioth_status call_write_block_callback(struct get_block_ctx *ctx)
 {
-    enum golioth_status status = ctx->callback.write_cb(ctx->block_idx,
-                                                        ctx->block_buffer,
-                                                        rcvd_bytes,
-                                                        ctx->is_last,
-                                                        ctx->block_size,
-                                                        ctx->callback_arg);
+    enum golioth_status status = ctx->write_cb(ctx->block_idx,
+                                               ctx->block_buffer,
+                                               ctx->rcvd_bytes,
+                                               ctx->is_last,
+                                               ctx->block_size,
+                                               ctx->callback_arg);
 
     if (GOLIOTH_OK == status)
     {
@@ -376,12 +343,12 @@ static void on_block_rcvd(struct golioth_client *client,
     assert(arg);
     assert(payload_size <= CONFIG_GOLIOTH_BLOCKWISE_DOWNLOAD_MAX_BLOCK_SIZE);
     struct get_block_ctx *ctx = arg;
-    assert(ctx->buffer);
+    assert(ctx->block_buffer);
 
     // copy blockwise download values returned by COAP client into ctx
     ctx->status = status;
     ctx->is_last = is_last;
-    memcpy(ctx->buffer, payload, payload_size);
+    memcpy(ctx->block_buffer, payload, payload_size);
     ctx->rcvd_bytes = payload_size;
 
     golioth_sys_sem_give(ctx->sem);
@@ -389,36 +356,27 @@ static void on_block_rcvd(struct golioth_client *client,
 
 // Function to download a single block
 static enum golioth_status download_single_block(struct golioth_client *client,
-                                                 struct blockwise_transfer *ctx,
-                                                 size_t *rcvd_bytes)
+                                                 struct get_block_ctx *ctx)
 {
-    struct get_block_ctx arg = {
-        .is_last = false,
-        .status = GOLIOTH_ERR_FAIL,
-        .buffer = ctx->block_buffer,
-        .rcvd_bytes = 0,
-        .sem = ctx->sem,
-    };
+    ctx->status = GOLIOTH_ERR_FAIL;
+    ctx->is_last = false;
+    ctx->rcvd_bytes = 0;
 
     enum golioth_status err = golioth_coap_client_get_block(client,
-                                                            ctx->token,
-                                                            ctx->path_prefix,
-                                                            ctx->path,
-                                                            ctx->content_type,
+                                                            ctx->transfer_ctx->token,
+                                                            ctx->transfer_ctx->path_prefix,
+                                                            ctx->transfer_ctx->path,
+                                                            ctx->transfer_ctx->content_type,
                                                             ctx->block_idx,
                                                             ctx->block_size,
                                                             on_block_rcvd,
-                                                            &arg,
+                                                            ctx,
                                                             false,
                                                             GOLIOTH_SYS_WAIT_FOREVER);
     if (GOLIOTH_OK == err)
     {
         golioth_sys_sem_take(ctx->sem, GOLIOTH_SYS_WAIT_FOREVER);
-        err = arg.status;
-
-        // TODO: These don't need to be stored in the ctx struct
-        ctx->is_last = arg.is_last;
-        *rcvd_bytes = arg.rcvd_bytes;
+        err = ctx->status;
     }
 
     return err;
@@ -426,14 +384,13 @@ static enum golioth_status download_single_block(struct golioth_client *client,
 
 // Function to manage blockwise downloads and handle errors
 static enum golioth_status process_blockwise_downloads(struct golioth_client *client,
-                                                       struct blockwise_transfer *ctx)
+                                                       struct get_block_ctx *ctx)
 {
-    size_t rcvd_bytes = 0;
-    enum golioth_status status = download_single_block(client, ctx, &rcvd_bytes);
+    enum golioth_status status = download_single_block(client, ctx);
 
     if (status == GOLIOTH_OK)
     {
-        status = call_write_block_callback(ctx, rcvd_bytes);
+        status = call_write_block_callback(ctx);
     }
 
     return status;
@@ -448,37 +405,51 @@ enum golioth_status golioth_blockwise_get(struct golioth_client *client,
                                           void *callback_arg)
 {
     enum golioth_status status = GOLIOTH_ERR_FAIL;
-    if (!client || !path || !cb)
+    if (NULL == client || NULL == path || NULL == cb)
     {
         return GOLIOTH_ERR_NULL;
     }
 
-    struct blockwise_transfer *ctx = malloc(sizeof(struct blockwise_transfer));
-    if (!ctx)
+    status = GOLIOTH_ERR_MEM_ALLOC;
+
+    struct get_block_ctx *ctx = malloc(sizeof(struct get_block_ctx));
+    if (NULL == ctx)
     {
-        status = GOLIOTH_ERR_MEM_ALLOC;
         goto finish;
     }
 
-    uint8_t *data_buff = malloc(CONFIG_GOLIOTH_BLOCKWISE_DOWNLOAD_MAX_BLOCK_SIZE);
-    if (!data_buff)
+    ctx->block_buffer = malloc(CONFIG_GOLIOTH_BLOCKWISE_DOWNLOAD_MAX_BLOCK_SIZE);
+    if (NULL == ctx->block_buffer)
     {
-        status = GOLIOTH_ERR_MEM_ALLOC;
         goto finish_with_ctx;
     }
 
-    blockwise_download_init(ctx, data_buff, path_prefix, path, content_type, cb, callback_arg);
+    ctx->transfer_ctx = blockwise_transfer_init(client, path_prefix, path, content_type);
+    if (NULL == ctx->transfer_ctx)
+    {
+        goto finish_with_block_buffer;
+    }
+
+    ctx->sem = golioth_sys_sem_create(1, 0);
+    if (NULL == ctx->sem)
+    {
+        goto finish_with_transfer_ctx;
+    }
+
+    ctx->status = GOLIOTH_ERR_FAIL;
+    ctx->rcvd_bytes = 0;
+    ctx->is_last = false;
+    ctx->block_size = CONFIG_GOLIOTH_BLOCKWISE_DOWNLOAD_MAX_BLOCK_SIZE;
+    ctx->write_cb = cb;
+    ctx->callback_arg = callback_arg;
 
     if (block_idx)
     {
         ctx->block_idx = *block_idx;
     }
-
-    ctx->sem = golioth_sys_sem_create(1, 0);
-    if (!ctx->sem)
+    else
     {
-        status = GOLIOTH_ERR_MEM_ALLOC;
-        goto finish_with_buff;
+        ctx->block_idx = 0;
     }
 
 
@@ -499,8 +470,11 @@ enum golioth_status golioth_blockwise_get(struct golioth_client *client,
 
     golioth_sys_sem_destroy(ctx->sem);
 
-finish_with_buff:
-    free(data_buff);
+finish_with_transfer_ctx:
+    blockwise_transfer_free(ctx->transfer_ctx);
+
+finish_with_block_buffer:
+    free(ctx->block_buffer);
 
 finish_with_ctx:
     free(ctx);

--- a/src/coap_blockwise.h
+++ b/src/coap_blockwise.h
@@ -11,6 +11,8 @@
 #include <golioth/client.h>
 #include <golioth/golioth_status.h>
 
+struct blockwise_transfer;
+
 /* Blockwise Upload */
 typedef enum golioth_status (*read_block_cb)(uint32_t block_idx,
                                              uint8_t *block_buffer,
@@ -25,6 +27,24 @@ enum golioth_status golioth_blockwise_post(struct golioth_client *client,
                                            read_block_cb cb,
                                            golioth_set_cb_fn callback,
                                            void *callback_arg);
+
+/* Blockwise Multi-Part Upload */
+struct blockwise_transfer *golioth_blockwise_upload_start(struct golioth_client *client,
+                                                          const char *path_prefix,
+                                                          const char *path,
+                                                          enum golioth_content_type content_type);
+
+void golioth_blockwise_upload_finish(struct blockwise_transfer *ctx);
+
+enum golioth_status golioth_blockwise_upload_block(struct blockwise_transfer *ctx,
+                                                   uint32_t block_idx,
+                                                   const uint8_t *block_buffer,
+                                                   size_t block_len,
+                                                   bool is_last,
+                                                   golioth_set_block_cb_fn set_cb,
+                                                   void *callback_arg,
+                                                   bool is_synchronous,
+                                                   int32_t timeout_s);
 
 /* Blockwise Download */
 typedef enum golioth_status (*write_block_cb)(uint32_t block_idx,

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -34,13 +34,13 @@
 /// @param status Golioth status code.
 /// @param coap_rsp_code CoAP response code received from Golioth. Can be NULL.
 /// @param path The path from the original request
-/// @param block_szx The block size from the server in coap SZX format
+/// @param block_size The block size from the server in bytes
 /// @param arg User argument, copied from the original request. Can be NULL.
 typedef void (*golioth_set_block_cb_fn)(struct golioth_client *client,
                                         enum golioth_status status,
                                         const struct golioth_coap_rsp_code *coap_rsp_code,
                                         const char *path,
-                                        size_t block_szx,
+                                        size_t block_size,
                                         void *arg);
 
 struct golioth_coap_post_params

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -28,21 +28,6 @@
 
 #define SZX_TO_BLOCKSIZE(szx) ((size_t) (1 << (szx + 4)))
 
-/// Callback function type for blockwise uploads that also returns the blocksize in szx format
-///
-/// @param client The client handle from the original request.
-/// @param status Golioth status code.
-/// @param coap_rsp_code CoAP response code received from Golioth. Can be NULL.
-/// @param path The path from the original request
-/// @param block_size The block size from the server in bytes
-/// @param arg User argument, copied from the original request. Can be NULL.
-typedef void (*golioth_set_block_cb_fn)(struct golioth_client *client,
-                                        enum golioth_status status,
-                                        const struct golioth_coap_rsp_code *coap_rsp_code,
-                                        const char *path,
-                                        size_t block_size,
-                                        void *arg);
-
 struct golioth_coap_post_params
 {
     enum golioth_content_type content_type;

--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -249,7 +249,7 @@ static coap_response_t coap_response_handler(coap_session_t *session,
                                              status,
                                              &coap_rsp_code,
                                              req->path,
-                                             server_requested_szx,
+                                             SZX_TO_BLOCKSIZE(server_requested_szx),
                                              req->post_block.arg);
                 }
             }

--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -286,7 +286,7 @@ static int golioth_coap_cb(struct golioth_req_rsp *rsp)
                                          rsp->status,
                                          golioth_ptr_to_rsp_code(rsp),
                                          req->path,
-                                         req->post_block.block_szx,
+                                         SZX_TO_BLOCKSIZE(req->post_block.block_szx),
                                          req->post_block.arg);
             }
             break;

--- a/src/stream.c
+++ b/src/stream.c
@@ -73,5 +73,36 @@ enum golioth_status golioth_stream_set_blockwise_sync(struct golioth_client *cli
                                   arg);
 }
 
+struct blockwise_transfer *golioth_stream_blockwise_start(struct golioth_client *client,
+                                                          const char *path,
+                                                          enum golioth_content_type content_type)
+{
+    return golioth_blockwise_upload_start(client, GOLIOTH_STREAM_PATH_PREFIX, path, content_type);
+}
+
+void golioth_stream_blockwise_finish(struct blockwise_transfer *ctx)
+{
+    return golioth_blockwise_upload_finish(ctx);
+}
+
+enum golioth_status golioth_stream_blockwise_set_block_async(struct blockwise_transfer *ctx,
+                                                             uint32_t block_idx,
+                                                             const uint8_t *block_buffer,
+                                                             size_t data_len,
+                                                             bool is_last,
+                                                             golioth_set_block_cb_fn callback,
+                                                             void *callback_arg)
+{
+    return golioth_blockwise_upload_block(ctx,
+                                          block_idx,
+                                          block_buffer,
+                                          data_len,
+                                          is_last,
+                                          callback,
+                                          callback_arg,
+                                          false,
+                                          GOLIOTH_SYS_WAIT_FOREVER);
+}
+
 
 #endif  // CONFIG_GOLIOTH_STREAM


### PR DESCRIPTION
Multi-block upload implements a blockwise upload using repeated API calls:
1. Create a context
2. Call the multi-block set API once for each block in the upload
3. Destroy the context