### PR TITLE
port: fix memory leak in SHA256

### DIFF
--- a/port/esp_idf/golioth_sys_espidf.c
+++ b/port/esp_idf/golioth_sys_espidf.c
@@ -23,13 +23,7 @@ golioth_sys_sha256_t golioth_sys_sha256_create(void)
 
 void golioth_sys_sha256_destroy(golioth_sys_sha256_t sha_ctx)
 {
-    if (!sha_ctx)
-    {
-        return;
-    }
-
-    mbedtls_sha256_context *hash = sha_ctx;
-    mbedtls_sha256_free(hash);
+    golioth_sys_free(sha_ctx);
 }
 
 enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,

--- a/port/modus_toolbox/golioth_sys_modus_toolbox.c
+++ b/port/modus_toolbox/golioth_sys_modus_toolbox.c
@@ -23,13 +23,7 @@ golioth_sys_sha256_t golioth_sys_sha256_create(void)
 
 void golioth_sys_sha256_destroy(golioth_sys_sha256_t sha_ctx)
 {
-    if (!sha_ctx)
-    {
-        return;
-    }
-
-    mbedtls_sha256_context *hash = sha_ctx;
-    mbedtls_sha256_free(hash);
+    golioth_sys_free(sha_ctx);
 }
 
 enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,

--- a/port/zephyr/golioth_sys_zephyr.c
+++ b/port/zephyr/golioth_sys_zephyr.c
@@ -307,13 +307,7 @@ golioth_sys_sha256_t golioth_sys_sha256_create(void)
 
 void golioth_sys_sha256_destroy(golioth_sys_sha256_t sha_ctx)
 {
-    if (!sha_ctx)
-    {
-        return;
-    }
-
-    mbedtls_sha256_context *hash = sha_ctx;
-    mbedtls_sha256_free(hash);
+    golioth_sys_free(sha_ctx);
 }
 
 enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,


### PR DESCRIPTION
`mbedtls_sha256_free()` [does not](https://github.com/Mbed-TLS/mbedtls/blob/107ea89daaefb9867ea9121002fbbdf926780e98/library/sha256.c#L230-L237) free memory, it only zeroes out the SHA context struct.