### PR TITLE
ci: use 'uv pip install' as a dropin replacement for 'pip install'

### DIFF
--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -91,9 +91,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup Python dependencies
+      - name: Install uv
         run: |
-          pip install \
+          pip install uv
+      - name: Setup Python dependencies
+        shell: bash
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install \
             pytest \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \
@@ -110,6 +116,7 @@ jobs:
         env:
           hil_board: ${{ inputs.hil_board }}
         run: |
+          source .venv/bin/activate
           rm -rf summary
           mkdir summary
           rm -rf allure-reports

--- a/.github/workflows/hil-integration-linux.yml
+++ b/.github/workflows/hil-integration-linux.yml
@@ -73,9 +73,15 @@ jobs:
           cmake -B build -S tests/hil/platform/linux \
             $EXTRA_BUILD_ARGS -DGOLIOTH_HIL_TEST=${{ matrix.test }}
           make -j$(nproc) -C build
-      - name: Setup Python dependencies
+      - name: Install uv
         run: |
-          pip install \
+          pip install uv
+      - name: Setup Python dependencies
+        shell: bash
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install \
             gcovr \
             pytest \
             pytest-timeout \
@@ -87,6 +93,8 @@ jobs:
         env:
           test: ${{ matrix.test }}
         run: |
+          source .venv/bin/activate
+
           rm -rf summary
           mkdir summary
 

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -171,9 +171,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup Python dependencies
+      - name: Install uv
         run: |
-          pip install \
+          pip install uv
+      - name: Setup Python dependencies
+        shell: bash
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install \
             pytest \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \
@@ -190,6 +196,7 @@ jobs:
         env:
           hil_board: ${{ inputs.hil_board }}
         run: |
+          source .venv/bin/activate
           rm -rf summary
           mkdir summary
           rm -rf allure-reports

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -145,9 +145,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup Python dependencies
+      - name: Install uv
         run: |
-          pip install \
+          pip install uv
+      - name: Setup Python dependencies
+        shell: bash
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install \
             pytest \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \
@@ -166,6 +172,7 @@ jobs:
           GOLIOTH_DEVICE_CERT_NAME: ${{ needs.rand_name.outputs.device_name }}
           GOLIOTH_ROOT_CERTIFICATE: "golioth.crt.pem"
         run: |
+          source .venv/bin/activate
           rm -rf allure-reports
           source /opt/credentials/runner_env.sh
           PORT_VAR=CI_${hil_board^^}_PORT


### PR DESCRIPTION
This should have particulary good speed improvement with self-hosted runners on low cost ARM boards.