### PR TITLE
ci: increase twister verbosity with single -v flag

### DIFF
--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           rm -rf allure-reports
           zephyr/scripts/twister                                                    \
+              -v                                                                    \
               --platform ${{ inputs.west_board }}                                   \
               -T modules/lib/golioth-firmware-sdk/examples/zephyr                   \
               -C --coverage-basedir modules/lib/golioth-firmware-sdk                \

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -118,6 +118,7 @@ jobs:
           export EXTRA_BUILD_ARGS=-x=CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"
 
           zephyr/scripts/twister                                                \
+                -v                                                              \
                 --overflow-as-errors                                            \
                 --platform ${{ inputs.west_board }}                             \
                 -T modules/lib/golioth-firmware-sdk/examples/zephyr             \
@@ -201,6 +202,7 @@ jobs:
           PORT_VAR=CI_${hil_board^^}_PORT
           SNR_VAR=CI_${hil_board^^}_SNR
           zephyr/scripts/twister                                                                  \
+                -v                                                                                \
                 -p ${{ inputs.west_board }}                                                       \
                 -T modules/lib/golioth-firmware-sdk/examples/zephyr                               \
                 --device-testing                                                                  \
@@ -214,8 +216,7 @@ jobs:
                 --pytest-args="--mask-secrets"                                                    \
                 --pytest-args="--alluredir=allure-reports"                                        \
                 --pytest-args="--runner-name=${{ runner.name }}"                                  \
-                --pytest-args="--hil-board=${{ inputs.hil_board }}"                               \
-                -v
+                --pytest-args="--hil-board=${{ inputs.hil_board }}"
 
       - name: Safe upload twister artifacts
         if: success() || failure()


### PR DESCRIPTION
This changes following report:

```
INFO    - Total complete:    1/   4   25%  built (not run):    1, filtered:    0, failed:    0, error:    0
INFO    - Total complete:    2/   4   50%  built (not run):    1, filtered:    0, failed:    0, error:    0
INFO    - Total complete:    3/   4   75%  built (not run):    1, filtered:    0, failed:    0, error:    0
INFO    - Total complete:    4/   4  100%  built (not run):    1, filtered:    0, failed:    0, error:    0
INFO    - 4 test scenarios (4 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
INFO    - 3 of 4 executed test configurations passed (75.00%), 1 built (not run), 0 failed, 0 errored, with no warnings in 49.12 seconds.
INFO    - 3 of 3 executed test cases passed (100.00%) on 1 out of total 860 platforms (0.12%).
INFO    - 1 selected test cases not executed: 1 not run (built only).
INFO    - 3 test configurations executed on platforms, 1 test configurations were only built.
```

to:

```
INFO    - 1/4 native_sim/native/64      sample.golioth.location                            NOT RUN (build)
INFO    - 2/4 native_sim/native/64      sample.golioth.location.playback.wifi              PASSED (native 12.659s)
INFO    - 3/4 native_sim/native/64      sample.golioth.location.playback.cellular          PASSED (native 27.586s)
INFO    - 4/4 native_sim/native/64      sample.golioth.location.playback                   PASSED (native 37.606s)

INFO    - 4 test scenarios (4 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
INFO    - 3 of 4 executed test configurations passed (75.00%), 1 built (not run), 0 failed, 0 errored, with no warnings in 49.04 seconds.
INFO    - 3 of 3 executed test cases passed (100.00%) on 1 out of total 860 platforms (0.12%).
INFO    - 1 selected test cases not executed: 1 not run (built only).
INFO    - 3 test configurations executed on platforms, 1 test configurations were only built.
```