### PR TITLE
west: drop self/west-commands

### DIFF
--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -7,4 +7,3 @@ manifest:
 
   self:
     path: modules/lib/golioth-firmware-sdk
-    west-commands: scripts/west-commands.yml

--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -8,4 +8,3 @@ manifest:
 
   self:
     path: modules/lib/golioth-firmware-sdk
-    west-commands: scripts/west-commands.yml


### PR DESCRIPTION
There are no custom commands anymore, so drop that entry from west manifests.

This is a followup to commit 88ff1db76bd4 ("scripts: drop downstream 'west patch' command").