### PR TITLE
examples: zephyr: common: wifi: remove dead code

### DIFF
--- a/examples/zephyr/common/wifi.c
+++ b/examples/zephyr/common/wifi.c
@@ -432,11 +432,6 @@ static void wifi_event_handle(struct k_work *work)
         return;
     }
 
-    if (new_state == WIFI_STATE_INVALID)
-    {
-        return;
-    }
-
     wifi_state_change(wifi_mgmt, new_state);
 
     if (new_state == old_state)


### PR DESCRIPTION
Fixes https://scan8.scan.coverity.com/#/project-view/62270/15696?selectedIssue=544186