### PR TITLE
ota: add manifest get command

### DIFF
--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -142,6 +142,18 @@ enum golioth_status golioth_ota_observe_manifest_async(struct golioth_client *cl
                                                        golioth_get_cb_fn callback,
                                                        void *arg);
 
+/// Get the OTA manifest asynchronously
+///
+/// This function will enqueue a request and return immediately without waiting for a response from
+/// the server. The callback will be invoked when the manifest is received from the Golioth server.
+///
+/// @param client The client handle from @ref golioth_client_create
+/// @param callback Callback function to register
+/// @param arg Optional argument, forwarded directly to the callback when invoked. Can be NULL.
+enum golioth_status golioth_ota_get_manifest_async(struct golioth_client *client,
+                                                   golioth_get_cb_fn callback,
+                                                   void *arg);
+
 /// Callback for OTA download component request
 ///
 /// Will be called repeatedly, once for each block received from the server.

--- a/port/linux/golioth_sys_linux.c
+++ b/port/linux/golioth_sys_linux.c
@@ -392,7 +392,13 @@ golioth_sys_sha256_t golioth_sys_sha256_create(void)
     }
 
     EVP_MD *md = EVP_MD_fetch(NULL, "SHA2-256", NULL);
-    EVP_DigestInit_ex2(mdctx, md, NULL);
+    int rc = EVP_DigestInit_ex2(mdctx, md, NULL);
+    if (1 != rc)
+    {
+        GLTH_LOGE(TAG, "Failed to initialize: %i", rc);
+        golioth_sys_sha256_destroy(mdctx);
+        return NULL;
+    };
 
     return (golioth_sys_sha256_t) mdctx;
 }
@@ -418,8 +424,8 @@ enum golioth_status golioth_sys_sha256_update(golioth_sys_sha256_t sha_ctx,
     }
 
     EVP_MD_CTX *mdctx = sha_ctx;
-    int err = EVP_DigestUpdate(mdctx, input, len);
-    if (err)
+    int rc = EVP_DigestUpdate(mdctx, input, len);
+    if (1 != rc)
     {
         return GOLIOTH_ERR_FAIL;
     }
@@ -435,8 +441,8 @@ enum golioth_status golioth_sys_sha256_finish(golioth_sys_sha256_t sha_ctx, uint
     }
 
     EVP_MD_CTX *mdctx = sha_ctx;
-    int err = EVP_DigestFinal_ex(mdctx, output, NULL);
-    if (err)
+    int rc = EVP_DigestFinal_ex(mdctx, output, NULL);
+    if (1 != rc)
     {
         return GOLIOTH_ERR_FAIL;
     }

--- a/src/ota.c
+++ b/src/ota.c
@@ -100,6 +100,24 @@ enum golioth_status golioth_ota_observe_manifest_async(struct golioth_client *cl
                                        arg);
 }
 
+enum golioth_status golioth_ota_get_manifest_async(struct golioth_client *client,
+                                                   golioth_get_cb_fn callback,
+                                                   void *arg)
+{
+    uint8_t token[GOLIOTH_COAP_TOKEN_LEN];
+    golioth_coap_next_token(token);
+
+    return golioth_coap_client_get(client,
+                                   token,
+                                   "",
+                                   GOLIOTH_OTA_MANIFEST_PATH,
+                                   GOLIOTH_CONTENT_TYPE_CBOR,
+                                   callback,
+                                   arg,
+                                   false,
+                                   GOLIOTH_SYS_WAIT_FOREVER);
+}
+
 enum golioth_status golioth_ota_report_state_sync(struct golioth_client *client,
                                                   enum golioth_ota_state state,
                                                   enum golioth_ota_reason reason,

--- a/tests/hil/tests/ota/test_ota.py
+++ b/tests/hil/tests/ota/test_ota.py
@@ -156,6 +156,9 @@ async def test_multiple_artifacts(artifacts, board, project, releases):
 
     await verify_component_values(board, artifacts["multi_artifact"].info)
 
+    # Test manifest get
+    assert None != await board.wait_for_regex_in_line('Manifest get SHA matches stored SHA', timeout_s=30)
+
 async def test_block_operations(board, project, releases):
     await project.releases.rollout_set(releases["test_blocks"].id, True)
     assert None != await board.wait_for_regex_in_line(f"golioth_ota_size_to_nblocks: {TEST_BLOCK_CNT + 1}", timeout_s=12)


### PR DESCRIPTION
add `golioth_ota_get_manifest_async()` as an alternative to registering an observation for OTA manifest updates.

add test for `golioth_ota_get_manifest_async()`

resolves https://github.com/golioth/firmware-issue-tracker/issues/787