### PR TITLE
zephyr: coap: limit path length based on Zephyr CoAP library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+- Zephyr: The default maximum path length for Golioth APIs has changed
+  from 39 characters to 12 characters and the
+  `CONFIG_GOLIOTH_COAP_MAX_PATH_LEN` symbol can no longer be changed by
+  the user. Update this limit using the following Kconfig symbols
+  supplied by Zephyr's CoAP library:
+
+    ```
+    CONFIG_COAP_EXTENDED_OPTIONS_LEN=y
+    CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE=39
+    ```
+
+### Fixed
+
+- Zephyr: correctly detect path names that are longer than the maximum
+  setting.
+
 ## [0.17.0] 2025-01-23
 
 ### Highlights:

--- a/examples/zephyr/common/Kconfig.defconfig
+++ b/examples/zephyr/common/Kconfig.defconfig
@@ -142,6 +142,12 @@ config SETTINGS
 config SETTINGS_RUNTIME
 	default y
 
+configdefault COAP_EXTENDED_OPTIONS_LEN
+    default y
+
+configdefault COAP_EXTENDED_OPTIONS_LEN_VALUE
+    default 39
+
 if GOLIOTH_SAMPLE_TWISTER_TEST
 
 configdefault GOLIOTH_SAMPLE_NRF91_RESET_LOOP_OVERRIDE

--- a/port/esp_idf/components/golioth_sdk/Kconfig
+++ b/port/esp_idf/components/golioth_sdk/Kconfig
@@ -18,6 +18,13 @@ menu "CoAP"
 
 rsource '../../../../src/Kconfig.coap'
 
+config GOLIOTH_COAP_MAX_PATH_LEN
+    int "Golioth maximum CoAP path length"
+    default 39
+    help
+        Maximum length of a CoAP path (everything after
+        "coaps://coap.golioth.io/").
+
 endmenu # CoAP
 
 menu "Logging"

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -168,6 +168,18 @@ menu "CoAP"
 
 source "${ZEPHYR_GOLIOTH_FIRMWARE_SDK_MODULE_DIR}/src/Kconfig.coap"
 
+config GOLIOTH_COAP_MAX_PATH_LEN
+    int
+    default COAP_EXTENDED_OPTIONS_LEN_VALUE if COAP_EXTENDED_OPTIONS_LEN
+    default 12
+    help
+        Maximum length of a CoAP path (everything after "coaps://coap.golioth.io/"). Increase this
+        value by setting two symbols provided by the Zephyr CoAP library:
+
+          - CONFIG_COAP_EXTENDED_OPTIONS_LEN=y
+          - CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE=39
+
+
 config GOLIOTH_COAP_CLIENT_RX_TIMEOUT_SEC
 	int "Receive timeout (seconds)"
 	default 30

--- a/src/Kconfig.coap
+++ b/src/Kconfig.coap
@@ -136,10 +136,3 @@ config GOLIOTH_COAP_KEEPALIVE_INTERVAL_S
         Can be useful to keep the CoAP session active, and to mitigate
         against NAT and server timeouts.
         Set to 0 to disable.
-
-config GOLIOTH_COAP_MAX_PATH_LEN
-    int "Golioth maximum CoAP path length"
-    default 39
-    help
-        Maximum length of a CoAP path (everything after
-        "coaps://coap.golioth.io/").

--- a/tests/hil/platform/zephyr/prj.conf
+++ b/tests/hil/platform/zephyr/prj.conf
@@ -35,3 +35,7 @@ CONFIG_GOLIOTH_SETTINGS_MAX_RESPONSE_LEN=512
 
 # Double log memory to prevent dropped logs on settings test
 CONFIG_LOG_BUFFER_SIZE=2048
+
+# Increase maximum CoAP path length
+CONFIG_COAP_EXTENDED_OPTIONS_LEN=y
+CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE=39


### PR DESCRIPTION
Make `GOLIOTH_COAP_MAX_PATH_LEN` an automatic setting that cannot be changed by the user and base its default on the Zephyr CoAP setting. This reduces the default from 39 characters down to 12 characters. Users may change this value using the symbols provided by Zephyr CoAP:

- CONFIG_COAP_EXTENDED_OPTIONS_LEN=y
- CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE=39

In Zephyr, the GOLIOTH_COAP_MAX_PATH_LEN symbol defaulted to 39 characters while Zephyr's CoAP library defaulted to 12 characters. Sending a single stream call with a path name >12 worked as expected. However, when sending a blockwise stream using a path name between 13 and 39 characters the Golioth check would pass, the Zephyr library would create the coap packet, but subsequent CoAP operations to prepare the block for upload would result in error. Deferring to the Zephyr symbols resolves the issue.

This change applies only to Zephyr and does not affect other OS ports that use the Golioth Firmware SDK.