### PR TITLE
blockwise: const correctness

### DIFF
--- a/include/golioth/ota.h
+++ b/include/golioth/ota.h
@@ -156,7 +156,7 @@ enum golioth_status golioth_ota_observe_manifest_async(struct golioth_client *cl
 typedef enum golioth_status (*ota_component_block_write_cb)(
     const struct golioth_ota_component *component,
     uint32_t block_idx,
-    uint8_t *block_buffer,
+    const uint8_t *block_buffer,
     size_t block_buffer_len,
     bool is_last,
     size_t negotiated_block_size,

--- a/src/coap_blockwise.h
+++ b/src/coap_blockwise.h
@@ -48,7 +48,7 @@ enum golioth_status golioth_blockwise_upload_block(struct blockwise_transfer *ct
 
 /* Blockwise Download */
 typedef enum golioth_status (*write_block_cb)(uint32_t block_idx,
-                                              uint8_t *block_buffer,
+                                              const uint8_t *block_buffer,
                                               size_t block_buffer_len,
                                               bool is_last,
                                               size_t negotiated_block_size,

--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -58,7 +58,7 @@ static struct fw_update_component_context _component_ctx;
 
 static enum golioth_status fw_write_block_cb(const struct golioth_ota_component *component,
                                              uint32_t block_idx,
-                                             uint8_t *block_buffer,
+                                             const uint8_t *block_buffer,
                                              size_t block_buffer_len,
                                              bool is_last,
                                              size_t negotiated_block_size,

--- a/src/ota.c
+++ b/src/ota.c
@@ -350,7 +350,7 @@ struct ota_component_blockwise_ctx
 };
 
 static enum golioth_status ota_component_write_cb_wrapper(uint32_t block_idx,
-                                                          uint8_t *block_buffer,
+                                                          const uint8_t *block_buffer,
                                                           size_t block_buffer_len,
                                                           bool is_last,
                                                           size_t negotiated_block_size,

--- a/tests/hil/tests/ota/test.c
+++ b/tests/hil/tests/ota/test.c
@@ -192,7 +192,7 @@ static void test_block_ops(void)
 
 enum golioth_status write_artifact_block_cb(const struct golioth_ota_component *component,
                                             uint32_t block_idx,
-                                            uint8_t *block_buffer,
+                                            const uint8_t *block_buffer,
                                             size_t block_buffer_len,
                                             bool is_last,
                                             size_t negotiated_block_size,


### PR DESCRIPTION
Mark payload data as const in block write callbacks.