### PR TITLE
examples: zephyr: cert_provisioning: override LFS partition before boot

### DIFF
--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -117,14 +117,40 @@ jobs:
         run: |
           export EXTRA_BUILD_ARGS=-x=CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"
 
+          # Build
           zephyr/scripts/twister                                                \
                 -v                                                              \
                 --overflow-as-errors                                            \
                 --platform ${{ inputs.west_board }}                             \
                 -T modules/lib/golioth-firmware-sdk/examples/zephyr             \
-                --prep-artifacts-for-testing                                    \
-                --package-artifacts test_artifacts_${{ inputs.hil_board }}.tar  \
+                --build-only                                                    \
                 $EXTRA_BUILD_ARGS
+
+          # Save lfs.hex, which otherwise is cleaned up by twister with
+          # --prep-artifacts-for-testing
+          extra_files=$(find twister-out -name lfs.hex)
+
+          if [ "$extra_files" != "" ]; then
+              tar -cf extra_files.tar $extra_files
+          fi
+
+          # Reuse build directory and cleanup artifacts for testing
+          zephyr/scripts/twister                                                \
+                -n                                                              \
+                -v                                                              \
+                --overflow-as-errors                                            \
+                --platform ${{ inputs.west_board }}                             \
+                -T modules/lib/golioth-firmware-sdk/examples/zephyr             \
+                --prep-artifacts-for-testing                                    \
+                $EXTRA_BUILD_ARGS
+
+          # Re-add lfx.hex files
+          if [ "$extra_files" != "" ]; then
+              tar -xf extra_files.tar
+          fi
+
+          # Package for testing
+          tar -cjf test_artifacts_${{ inputs.hil_board }}.tar twister-out
 
       - name: Save artifacts
         if: success() || failure()

--- a/examples/zephyr/certificate_provisioning/CMakeLists.txt
+++ b/examples/zephyr/certificate_provisioning/CMakeLists.txt
@@ -6,3 +6,15 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cert_provisioning)
 
 target_sources(app PRIVATE src/main.c)
+
+add_custom_command(
+    OUTPUT ${ZEPHYR_BINARY_DIR}/lfs.hex
+    COMMAND ${PYTHON_EXECUTABLE}
+      ${CMAKE_CURRENT_SOURCE_DIR}/generate-lfs-image.py
+      --build-dir ${APPLICATION_BINARY_DIR}
+)
+
+add_custom_target(
+    lfs ALL
+    DEPENDS ${ZEPHYR_BINARY_DIR}/lfs.hex
+)

--- a/examples/zephyr/certificate_provisioning/generate-lfs-image.py
+++ b/examples/zephyr/certificate_provisioning/generate-lfs-image.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import logging
+from pathlib import Path
+import pickle
+import sys
+
+import click
+from intelhex import bin2hex
+import west.configuration
+
+WEST_TOPDIR = Path(west.configuration.west_dir()).parent
+
+sys.path.insert(0, str(WEST_TOPDIR / 'zephyr' / 'scripts' / 'dts' / 'python-devicetree' / 'src'))
+sys.path.insert(0, str(WEST_TOPDIR / 'zephyr' / 'scripts' / 'west_commands'))
+
+from devicetree.edtlib import Node
+from runners.core import BuildConfiguration
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def lfs_partition(build_dir: Path) -> Node:
+    edt_pickle = build_dir / 'zephyr' / 'edt.pickle'
+    with open(edt_pickle, 'rb') as f:
+        edt = pickle.load(f)
+
+    fstab = edt.label2node["lfs1"]
+
+    return fstab.props["partition"].val
+
+
+@click.command()
+@click.option("--build-dir", help="Zephyr build directory",
+              type=click.Path(file_okay=False, path_type=Path))
+def main(build_dir):
+    build_conf = BuildConfiguration(str(build_dir))
+
+    if "CONFIG_FLASH_BASE_ADDRESS" in build_conf:
+        flash_base = build_conf["CONFIG_FLASH_BASE_ADDRESS"]
+    else:
+        flash_base = 0
+
+    part = lfs_partition(build_dir)
+    flash = part.parent.parent
+    block_size = flash.props["erase-block-size"].val
+
+    LOGGER.info("Block size: %s", block_size)
+    LOGGER.info("LFS flash offset: %s", hex(flash_base))
+    LOGGER.info("LFS partition offset: %s", hex(part.regs[0].addr))
+
+    # Override first 2 blocks to make sure LittleFS is reformatted
+    with open(build_dir / "lfs.bin", "wb") as fh:
+        fh.write(b"\xff" * block_size * 2)
+
+    # Generate HEX file from BIN
+    offset = flash_base + part.regs[0].addr
+    bin2hex(str(build_dir / "lfs.bin"),
+            str(build_dir / "lfs.hex"),
+            offset)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/zephyr/certificate_provisioning/pytest/test_sample.py
+++ b/examples/zephyr/certificate_provisioning/pytest/test_sample.py
@@ -1,11 +1,11 @@
 import logging
 from pathlib import Path
 import subprocess
-import datetime
-import logging
-from time import sleep
 
 import pytest
+from twister_harness.device.device_adapter import DeviceAdapter
+from twister_harness.device.hardware_adapter import HardwareAdapter
+from twister_harness.device.utils import log_command
 import west.configuration
 
 WEST_TOPDIR = Path(west.configuration.west_dir()).parent
@@ -22,7 +22,25 @@ def subprocess_logger(result, log_msg):
     if result.stderr:
         LOGGER.error(f'{log_msg} stderr: {result.stderr}')
 
-async def test_cert_provisioning(request, shell,
+@pytest.fixture
+def lfs_flash_empty(device_object: DeviceAdapter, request):
+    if not isinstance(device_object, HardwareAdapter):
+        return
+
+    build_dir = Path(request.config.option.build_dir)
+
+    LOGGER.info("Flashing LFS image")
+    device_object.generate_command()
+    command = device_object.command + ["--hex-file", str(build_dir / "lfs.hex")]
+    log_command(LOGGER, "Flashing LFS command", command, level=logging.DEBUG)
+    result = subprocess.run(command,
+                            capture_output=True, text=True,
+                            cwd=request.config.option.build_dir,
+                            check=False)
+    subprocess_logger(result, 'LFS flash')
+    assert result.returncode == 0
+
+async def test_cert_provisioning(lfs_flash_empty, request, shell,
                                  project, device_name,
                                  mcumgr_conn_args, certificate_cred,
                                  wifi_ssid, wifi_psk):


### PR DESCRIPTION
Make sure to reformat LittleFS partition by overriding first 2 (erase)
blocks of the partition.