### PR TITLE
tests/hil: zephyr: support running with twister

### DIFF
--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -129,7 +129,7 @@ jobs:
               --timeout=600                                                     \
               --junitxml=summary/hil-espidf-${{ inputs.hil_board }}-${test}.xml \
               --alluredir=allure-reports                                        \
-              --platform esp-idf                                                \
+              --allure-platform esp-idf                                         \
               --runner-name ${{ runner.name }}                                  \
               || EXITCODE=$?
           done

--- a/.github/workflows/hil-integration-linux.yml
+++ b/.github/workflows/hil-integration-linux.yml
@@ -102,7 +102,7 @@ jobs:
             --timeout=600                               \
             --junitxml=summary/hil-linux-${test}.xml    \
             --alluredir=allure-reports                  \
-            --platform linux
+            --allure-platform linux
 
       - name: Capture coverage
         if: success() || failure()

--- a/.github/workflows/hil-integration-nsim.yml
+++ b/.github/workflows/hil-integration-nsim.yml
@@ -130,7 +130,7 @@ jobs:
             --timeout=600                                                               \
             --junitxml=summary/hil-zephyr-${{ inputs.platform }}-${{ matrix.test }}.xml \
             --alluredir=allure-reports                                                  \
-            --platform=zephyr                                                           \
+            --allure-platform=zephyr                                                    \
             --allure-board=${{ inputs.platform }}
 
       - name: Capture coverage

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -210,7 +210,7 @@ jobs:
             --timeout=600                                                                \
             --junitxml=summary/hil-zephyr-${{ inputs.hil_board }}-${{ matrix.test }}.xml \
             --alluredir=allure-reports                                                   \
-            --platform zephyr                                                            \
+            --allure-platform zephyr                                                     \
             --runner-name ${{ runner.name }}
 
       - name: Safe upload CI report summary

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -182,7 +182,7 @@ jobs:
               --mask-secrets                                                    \
               --timeout=600                                                     \
               --alluredir=allure-reports                                        \
-              --platform=esp-idf                                                \
+              --allure-platform=esp-idf                                         \
               --runner-name ${{ runner.name }}                                  \
               --custom-suitename=sample                                         \
               || EXITCODE=$?

--- a/tests/hil/platform/zephyr/testcase.yaml
+++ b/tests/hil/platform/zephyr/testcase.yaml
@@ -1,0 +1,58 @@
+common:
+  harness: pytest
+  tags:
+    - golioth
+    - socket
+    - goliothd
+  platform_allow:
+    - esp32_devkitc_wrover/esp32/procpu
+    - frdm_rw612
+    - native_sim
+    - native_sim/native/64
+    - nrf52840dk/nrf52840
+    - nrf9160dk/nrf9160/ns
+    - rak5010/nrf52840
+  timeout: 600
+tests:
+  golioth.hil.connection:
+    harness_config:
+      pytest_dut_scope: module
+      pytest_root:
+        - ../../tests/connection
+    extra_args:
+      - GOLIOTH_HIL_TEST=connection
+  golioth.hil.lightdb:
+    harness_config:
+      pytest_dut_scope: module
+      pytest_root:
+        - ../../tests/lightdb
+    extra_args:
+      - GOLIOTH_HIL_TEST=lightdb
+  golioth.hil.ota:
+    harness_config:
+      pytest_dut_scope: module
+      pytest_root:
+        - ../../tests/ota
+    extra_args:
+      - GOLIOTH_HIL_TEST=ota
+  golioth.hil.rpc:
+    harness_config:
+      pytest_dut_scope: module
+      pytest_root:
+        - ../../tests/rpc
+    extra_args:
+      - GOLIOTH_HIL_TEST=rpc
+  golioth.hil.settings:
+    harness_config:
+      pytest_dut_scope: module
+      pytest_root:
+        - ../../tests/settings
+    extra_args:
+      - GOLIOTH_HIL_TEST=settings
+  golioth.hil.stream:
+    harness_config:
+      pytest_dut_scope: module
+      pytest_root:
+        - ../../tests/stream
+    extra_args:
+      - GOLIOTH_HIL_TEST=stream

--- a/tests/hil/scripts/pytest-hil/pytest_hil/plugin.py
+++ b/tests/hil/scripts/pytest-hil/pytest_hil/plugin.py
@@ -11,8 +11,8 @@ from pytest_hil.linuxboard import LinuxBoard
 from pytest_hil.native_sim import NativeSimBoard
 
 def pytest_addoption(parser):
-    parser.addoption("--platform", type=str,
-            help="Platform name (eg: esp-idf, linux, zephyr)")
+    parser.addoption("--allure-platform", type=str,
+            help="Allure platform name (eg: esp-idf, linux, zephyr)")
     parser.addoption("--runner-name", type=str,
             help="Self-hosted runner name (eg: sams_orange_pi, mikes_testbench)")
     parser.addoption("--board", type=str,
@@ -36,8 +36,8 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="session")
-def platform_name(request):
-    return request.config.getoption("--platform")
+def allure_platform_name(request):
+    return request.config.getoption("--allure-platform")
 
 @pytest.fixture(scope="session")
 def runner_name(request):
@@ -112,14 +112,14 @@ async def board(board_name, port, baud, wifi_ssid, wifi_psk, fw_image, serial_nu
 @pytest.hookimpl(wrapper=True)
 def pytest_runtest_setup(item):
     board_name = item.config.getoption("--allure-board") or item.config.getoption("--board")
-    platform_name = item.config.getoption("--platform")
+    allure_platform_name = item.config.getoption("--allure-platform")
     suitename = item.config.getoption("--custom-suitename") or "hil"
 
     allure.dynamic.tag(board_name)
-    allure.dynamic.tag(platform_name)
+    allure.dynamic.tag(allure_platform_name)
     allure.dynamic.parameter("board_name", board_name)
-    allure.dynamic.parameter("platform_name", platform_name)
-    allure.dynamic.parent_suite(f"{suitename}.{platform_name}.{board_name}")
+    allure.dynamic.parameter("platform_name", allure_platform_name)
+    allure.dynamic.parent_suite(f"{suitename}.{allure_platform_name}.{board_name}")
 
     if runner_name is not None:
         allure.dynamic.tag(item.config.getoption("--runner-name"))

--- a/tests/hil/scripts/pytest-hil/pytest_hil/plugin.py
+++ b/tests/hil/scripts/pytest-hil/pytest_hil/plugin.py
@@ -83,7 +83,25 @@ def wifi_psk(request):
     return request.config.getoption("--wifi-psk")
 
 @pytest.fixture(scope="module")
-async def board(board_name, port, baud, wifi_ssid, wifi_psk, fw_image, serial_number, bmp_port):
+async def board(request, baud, wifi_ssid, wifi_psk):
+    if request.config.getoption('twister_harness', None):
+        dut = request.getfixturevalue("dut")
+        dut.disconnect()
+
+        board_name = dut.device_config.platform \
+            .split("/", maxsplit=1)[0] \
+            .split("@", maxsplit=1)[0]
+        port = dut.device_config.serial
+        fw_image = None
+        serial_number = None
+        bmp_port = None
+    else:
+        board_name = request.getfixturevalue("board_name")
+        port = request.getfixturevalue("port")
+        fw_image = request.getfixturevalue("fw_image")
+        serial_number = request.getfixturevalue("serial_number")
+        bmp_port = request.getfixturevalue("bmp_port")
+
     if (board_name.lower() == "esp32s3_devkitc_espidf" or
         board_name.lower() == "esp32c3_devkitm_espidf" or
         board_name.lower() == "esp32_devkitc_wrover_espidf"):


### PR DESCRIPTION
It is very inconvenient to run all tests by hand, as this involves
multi-step process:
 * build firmware
 * run pytest script with following parameters passed by hand:
   * fw_image
   * board_name (derived from build command, but not the same)
   * serial port
   * serial number (for flashing)

Most of above steps are already automated with twister and pytest harness.
Support running existing pytest tests from within twister. As a result it
is possible to run single command to build, test and reuse
hardware-map.yaml (with serial port, serial number, etc.) defined for
Zephyr samples testing purposes.