### PR TITLE
examples: zephyr: cert_provisioning: use different UDP ports

### DIFF
--- a/examples/zephyr/certificate_provisioning/pytest/conftest.py
+++ b/examples/zephyr/certificate_provisioning/pytest/conftest.py
@@ -25,9 +25,11 @@ def mcumgr_conn_args(request, dut):
         else:
             ip = build_conf['CONFIG_NET_CONFIG_MY_IPV4_ADDR']
 
+        port = build_conf['CONFIG_MCUMGR_TRANSPORT_UDP_PORT']
+
         return [
             "--conntype=udp",
-            f"--connstring={ip}:1337",
+            f"--connstring={ip}:{port}",
         ]
 
     return [

--- a/examples/zephyr/certificate_provisioning/sample.yaml
+++ b/examples/zephyr/certificate_provisioning/sample.yaml
@@ -38,6 +38,7 @@ tests:
       - CONFIG_MBEDTLS_PSA_CRYPTO_C=y
       - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
       - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
+      - arch:posix:CONFIG_MCUMGR_TRANSPORT_UDP_PORT=1347
     platform_allow:
       - frdm_rw612
       - native_sim


### PR DESCRIPTION
Configure different UDP port for second testcase, so that running
certificate_provisioning for native_sim won't run into "unable to bind UDP
port" because of two tests being exeucuted in parallel.