### PR TITLE
ci: remove 'twister-out' before extracting new artifacts

### DIFF
--- a/.ci-west-ncs.yml
+++ b/.ci-west-ncs.yml
@@ -14,7 +14,6 @@ manifest:
         - nrfxlib
         - oberon-psa-crypto
         - segger
-        - tinycrypt
         - trusted-firmware-m
         - zcbor
         - zephyr

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -214,7 +214,9 @@ jobs:
           name: test_artifacts_${{ inputs.hil_board }}
           path: .
       - name: Extract artifacts
-        run: tar -xvf test_artifacts_${{ inputs.hil_board }}.tar
+        run: |
+          rm -rf twister-out
+          tar -xvf test_artifacts_${{ inputs.hil_board }}.tar
       - name: Run test
         shell: bash
         env:

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -235,6 +235,7 @@ jobs:
             manifest: .ci-west-ncs.yml
             extra_twister_args: >-
               --west-flash="--dev-id=${!SNR_VAR}"
+              --west-runner nrfjprog
             run_tests: true
 
           - hil_board: nucleo_h563zi

--- a/examples/zephyr/certificate_provisioning/generate-lfs-image.py
+++ b/examples/zephyr/certificate_provisioning/generate-lfs-image.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 import pickle
 import sys
+import yaml
 
 import click
 from intelhex import bin2hex
@@ -44,18 +45,26 @@ def main(build_dir):
 
     part = lfs_partition(build_dir)
     flash = part.parent.parent
+    part_addr = part.regs[0].addr
     block_size = flash.props["erase-block-size"].val
+
+    if "CONFIG_PARTITION_MANAGER_ENABLED" in build_conf:
+        # Special case for NCS Partition Manager
+        partitions_yml_path = build_dir.parent / "partitions.yml"
+        partitions = yaml.load(partitions_yml_path.read_text(), Loader=yaml.Loader)
+        lfs_info = partitions["littlefs_storage"]
+        part_addr = lfs_info["address"]
 
     LOGGER.info("Block size: %s", block_size)
     LOGGER.info("LFS flash offset: %s", hex(flash_base))
-    LOGGER.info("LFS partition offset: %s", hex(part.regs[0].addr))
+    LOGGER.info("LFS partition offset: %s", hex(part_addr))
 
     # Override first 2 blocks to make sure LittleFS is reformatted
     with open(build_dir / "lfs.bin", "wb") as fh:
         fh.write(b"\xff" * block_size * 2)
 
     # Generate HEX file from BIN
-    offset = flash_base + part.regs[0].addr
+    offset = flash_base + part_addr
     bin2hex(str(build_dir / "lfs.bin"),
             str(build_dir / "lfs.hex"),
             offset)

--- a/examples/zephyr/certificate_provisioning/pytest/test_sample.py
+++ b/examples/zephyr/certificate_provisioning/pytest/test_sample.py
@@ -6,6 +6,7 @@ import pytest
 from twister_harness.device.device_adapter import DeviceAdapter
 from twister_harness.device.hardware_adapter import HardwareAdapter
 from twister_harness.device.utils import log_command
+from twister_harness.helpers.domains_helper import get_default_domain_name
 import west.configuration
 
 WEST_TOPDIR = Path(west.configuration.west_dir()).parent
@@ -28,6 +29,9 @@ def lfs_flash_empty(device_object: DeviceAdapter, request):
         return
 
     build_dir = Path(request.config.option.build_dir)
+    domains = build_dir / 'domains.yaml'
+    if domains.exists():
+        build_dir = build_dir / get_default_domain_name(domains)
 
     LOGGER.info("Flashing LFS image")
     device_object.generate_command()
@@ -35,7 +39,7 @@ def lfs_flash_empty(device_object: DeviceAdapter, request):
     log_command(LOGGER, "Flashing LFS command", command, level=logging.DEBUG)
     result = subprocess.run(command,
                             capture_output=True, text=True,
-                            cwd=request.config.option.build_dir,
+                            cwd=str(build_dir),
                             check=False)
     subprocess_logger(result, 'LFS flash')
     assert result.returncode == 0

--- a/examples/zephyr/fw_update/pytest/conftest.py
+++ b/examples/zephyr/fw_update/pytest/conftest.py
@@ -15,7 +15,8 @@ async def fw_info():
 
 @pytest.fixture(scope="module")
 async def blueprint_id(project, request):
-    bp_name = request.config.option.platform.replace('/','_')
+    bp_name = '_'.join([x.split('@')[0] for x in
+                        request.config.option.platform.split('/')])
     yield await project.blueprints.get_id(bp_name)
 
 

--- a/examples/zephyr/hello_nrf91_offloaded/pytest/conftest.py
+++ b/examples/zephyr/hello_nrf91_offloaded/pytest/conftest.py
@@ -4,6 +4,8 @@ import sys
 import west.configuration
 import pytest
 
+from twister_harness.helpers.domains_helper import get_default_domain_name
+
 WEST_TOPDIR = Path(west.configuration.west_dir()).parent
 sys.path.insert(0, str(WEST_TOPDIR / 'zephyr' / 'scripts' / 'west_commands'))
 from runners.core import BuildConfiguration
@@ -14,4 +16,7 @@ def anyio_backend():
 
 @pytest.fixture(scope='session')
 def build_conf(request):
-    return BuildConfiguration(request.config.option.build_dir)
+    build_dir = Path(request.config.option.build_dir)
+    domains = build_dir / 'domains.yaml'
+    app_build_dir = build_dir / get_default_domain_name(domains)
+    return BuildConfiguration(str(app_build_dir))

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -1,7 +1,7 @@
 manifest:
   projects:
     - name: nrf
-      revision: v2.9.0
+      revision: v3.0.1
       url: http://github.com/nrfconnect/sdk-nrf
       import: true
 


### PR DESCRIPTION
In some cases there are still old artifacts on the filesystem on
self-hosted runners. They are no harm for testing, but they do occupy space
and they are archived as artifacts after HIL testing finishes.

Make sure that 'twister-out' is removed before extracting new artifacts.
This reduces confusion when inspecting failed jobs.