### PR TITLE
ci: bump golioth-hil-base and switch to 'uv pip --system'

### DIFF
--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python dependencies
         run: |
-          pip install \
+          uv pip install --system \
             pytest \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -165,7 +165,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:8e12fd2
+      image: golioth/golioth-hil-base:43132bf
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials
@@ -176,7 +176,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python dependencies
         run: |
-          pip install \
+          uv pip install --system \
             pytest \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -136,7 +136,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:8e12fd2
+      image: golioth/golioth-hil-base:43132bf
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python dependencies
         run: |
-          pip install \
+          uv pip install --system \
             pytest \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \


### PR DESCRIPTION
This image has 'uv' installed, so it should be faster to install
dependencies with 'uv pip'.