### PR TITLE
examples: zephyr: location: add note about private access

### DIFF
--- a/examples/zephyr/location/README.md
+++ b/examples/zephyr/location/README.md
@@ -1,5 +1,11 @@
 # Golioth location demo
 
+> [!IMPORTANT]
+> Using [Golioth
+> Location](https://docs.golioth.io/application-services/location/)
+> requires enrolling in the [private access
+> program](https://blog.golioth.io/golioth-location-private-access/).
+
 ## Overview
 
 This sample demonstrates how to connect to Golioth and get location


### PR DESCRIPTION
Adds a note indicating that enrolling in the location private access program is required.