### PR TITLE
blockwise: handle errors when requesting next block

### DIFF
--- a/src/coap_blockwise.c
+++ b/src/coap_blockwise.c
@@ -426,7 +426,13 @@ static void on_block_rcvd(struct golioth_client *client,
     else
     {
         ctx->block_idx++;
-        download_single_block(client, ctx);
+        status = download_single_block(client, ctx);
+        if (GOLIOTH_OK != status)
+        {
+            ctx->end_cb(status, NULL, path, ctx->block_idx, ctx->callback_arg);
+
+            golioth_sys_free(ctx);
+        }
     }
 }
 


### PR DESCRIPTION
Fix a bug where requesting the next block could silently fail. Now, if we fail to submit a request for a block, we end the download and alert the application.

Fixes golioth/firmware-issue-tracker#803