### PR TITLE
Fix zephyr timer reset

### DIFF
--- a/port/zephyr/golioth_sys_zephyr.c
+++ b/port/zephyr/golioth_sys_zephyr.c
@@ -175,18 +175,18 @@ bool golioth_sys_timer_start(golioth_sys_timer_t gtimer)
 {
     struct golioth_timer *timer = gtimer;
 
-    k_work_schedule(&timer->work, K_MSEC(timer->config.expiration_ms));
+    int ret = k_work_schedule(&timer->work, K_MSEC(timer->config.expiration_ms));
 
-    return true;
+    return ret > 0;
 }
 
 bool golioth_sys_timer_reset(golioth_sys_timer_t gtimer)
 {
     struct golioth_timer *timer = gtimer;
 
-    k_work_cancel_delayable(&timer->work);
+    int ret = k_work_reschedule(&timer->work, K_MSEC(timer->config.expiration_ms));
 
-    return golioth_sys_timer_start(timer);
+    return ret >= 0;
 }
 
 void golioth_sys_timer_destroy(golioth_sys_timer_t gtimer)

--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -1064,7 +1064,7 @@ static enum golioth_status coap_io_loop_once(struct golioth_client *client,
 
     if (time_spent_waiting_ms >= timeout_ms)
     {
-        GLTH_LOGE(TAG, "Timeout: never got a response from the server");
+        GLTH_LOGE(TAG, "Receive timeout");
 
         if (coap_session_get_state(session) == COAP_SESSION_STATE_HANDSHAKE)
         {

--- a/tests/hil/tests/connection/test.c
+++ b/tests/hil/tests/connection/test.c
@@ -54,6 +54,10 @@ void hil_test_entry(const struct golioth_client_config *config)
 
     golioth_sys_sem_take(_connected_sem, GOLIOTH_SYS_WAIT_FOREVER);
 
+    /* Ensure keepalive timer is running */
+
+    golioth_sys_msleep(60 * 1000);
+
     /* Pause to ensure logs are show */
     golioth_sys_msleep(1 * 1000);
 }

--- a/tests/hil/tests/connection/test_connection.py
+++ b/tests/hil/tests/connection/test_connection.py
@@ -1,4 +1,5 @@
 import pytest
+import trio
 
 pytestmark = pytest.mark.anyio
 
@@ -19,3 +20,6 @@ async def test_connect(board, device):
     assert None != await board.wait_for_regex_in_line('Destroying client', timeout_s=15)
     assert None != await board.wait_for_regex_in_line('Starting client', timeout_s=120)
     assert None != await board.wait_for_regex_in_line('Golioth CoAP client connected', timeout_s=120)
+
+    with pytest.raises(trio.TooSlowError):
+        await board.wait_for_regex_in_line('Receive timeout', timeout_s=60)


### PR DESCRIPTION
Cancelling a scheduled work item is not immediate, and scheduling
an already scheduled work item has no effect. So the previous
strategy of resetting timers by first cancelling and then
immediately scheduling them fails.

Instead we use the k_work_reschedule() API, which works on
both scheduled and scheduled work items.

Additionally, we now properly supply return values for timer
functions.

Fixes golioth/firmware-issue-tracker#805