### PR TITLE
ci: switch to 'uv pip' in golioth-zephyr-base image

### DIFF
--- a/.github/workflows/hil-integration-nsim.yml
+++ b/.github/workflows/hil-integration-nsim.yml
@@ -94,7 +94,7 @@ jobs:
           git config --global user.email user@git-scm.com
           git config --global user.name "Git User"
 
-          pip install \
+          uv pip install \
             -r zephyr/scripts/requirements-base.txt \
             -r zephyr/scripts/requirements-build-test.txt \
             -r zephyr/scripts/requirements-run-test.txt \

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -107,13 +107,13 @@ jobs:
 
           west update -o=--depth=1 -n
 
-          pip3 install \
+          uv pip install \
             -r zephyr/scripts/requirements-base.txt \
             -r zephyr/scripts/requirements-build-test.txt \
             -r zephyr/scripts/requirements-run-test.txt
 
           # Needed for TF-M
-          pip3 install \
+          uv pip install \
             cryptography==41.0.7 \
             pyasn1 \
             pyyaml \

--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -65,7 +65,7 @@ jobs:
           git config --global user.email user@git-scm.com
           git config --global user.name "Git User"
 
-          pip3 install \
+          uv pip install \
             -r zephyr/scripts/requirements-base.txt \
             -r zephyr/scripts/requirements-build-test.txt \
             -r zephyr/scripts/requirements-run-test.txt \

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -93,13 +93,13 @@ jobs:
             git config --global user.name "Git User"
           fi
 
-          pip3 install \
+          uv pip install \
             -r zephyr/scripts/requirements-base.txt \
             -r zephyr/scripts/requirements-build-test.txt \
             -r zephyr/scripts/requirements-run-test.txt
 
           # Needed for TF-M
-          pip3 install \
+          uv pip install \
             cryptography==41.0.7 \
             pyasn1 \
             pyyaml \


### PR DESCRIPTION
'uv' is now installed in new image revision. Use it to speed up package
installation. This also improved consistency with other workflows, which
have been migrated to 'uv' before.