### PR TITLE
ci: run location tests nightly

### DIFF
--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -45,6 +45,7 @@ jobs:
       image: golioth/golioth-zephyr-base:0.17.0-SDK-v0
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.0
+      EXTRA_TWISTER_ARGS: ${{ github.event_name == 'pull_request' && '-e nightly' || '' }}
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
@@ -81,6 +82,7 @@ jobs:
               -T modules/lib/golioth-firmware-sdk/examples/zephyr                   \
               -C --coverage-basedir modules/lib/golioth-firmware-sdk                \
               --coverage-formats txt                                                \
+              ${EXTRA_TWISTER_ARGS}                                                 \
               -x=CONFIG_GOLIOTH_COAP_HOST_URI=\"${{ inputs.coap_gateway_url }}\"    \
               --pytest-args="--api-url=${{ inputs.api-url }}"                       \
               --pytest-args="--api-key=${{ secrets[inputs.api-key-id] }}"           \

--- a/examples/zephyr/location/sample.yaml
+++ b/examples/zephyr/location/sample.yaml
@@ -21,6 +21,8 @@ tests:
   sample.golioth.location.playback:
     timeout: 100
     harness: pytest
+    tags:
+      - nightly
     extra_configs:
       - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
       - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
@@ -29,6 +31,8 @@ tests:
       - native_sim/native/64
   sample.golioth.location.playback.wifi:
     harness: pytest
+    tags:
+      - nightly
     extra_configs:
       - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
       - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
@@ -38,6 +42,8 @@ tests:
       - native_sim/native/64
   sample.golioth.location.playback.cellular:
     harness: pytest
+    tags:
+      - nightly
     extra_configs:
       - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
       - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y


### PR DESCRIPTION
We are getting rate-limited on location requests, so run the location sample tests nightly instead of on every PR.