### PR TITLE
blockwise: include transfer context struct by value

### DIFF
--- a/src/coap_blockwise.c
+++ b/src/coap_blockwise.c
@@ -77,7 +77,7 @@ static void blockwise_transfer_init(struct blockwise_transfer *ctx,
 // Function to free the blockwise_transfer structure
 static void blockwise_transfer_free(struct blockwise_transfer *ctx)
 {
-    free(ctx);
+    golioth_sys_free(ctx);
 }
 
 /* Blockwise Uploads related functions */


### PR DESCRIPTION
The post_block and get_block contexts had been including a reference to a transfer context struct that is allocated separately. We can remove an allocation and simplify error handling by including the full struct as a member rather than including a pointer.

This also fixes a structurally dead code report from Coverity (that was also actually a memory leak).

https://scan8.scan.coverity.com/#/project-view/62270/15696?selectedIssue=553971