### PR TITLE
Clean atomics in zephyr client

### DIFF
--- a/src/coap_client_zephyr.c
+++ b/src/coap_client_zephyr.c
@@ -32,7 +32,7 @@ LOG_TAG_DEFINE(golioth_coap_client_zephyr);
 
 enum
 {
-    FLAG_STOP_CLIENT,
+    CLIENT_FLAG_STOP,
 };
 
 #define RECV_TIMEOUT (CONFIG_GOLIOTH_COAP_CLIENT_RX_TIMEOUT_SEC * 1000)
@@ -45,7 +45,7 @@ enum pollfd_type
     NUM_POLLFDS,
 };
 
-static atomic_t flags;
+static atomic_t client_flags;
 
 static uint8_t rx_buffer[CONFIG_GOLIOTH_COAP_CLIENT_RX_BUF_SIZE];
 
@@ -1312,7 +1312,7 @@ static void golioth_coap_client_thread(void *arg)
 
             if (event_occurred)
             {
-                bool stop_request = atomic_test_and_clear_bit(&flags, FLAG_STOP_CLIENT);
+                bool stop_request = atomic_test_and_clear_bit(&client_flags, CLIENT_FLAG_STOP);
                 bool receive_timeout = (recv_expiry <= k_uptime_get());
 
                 /*
@@ -1641,7 +1641,7 @@ enum golioth_status golioth_client_start(struct golioth_client *client)
     {
         return GOLIOTH_ERR_NULL;
     }
-    atomic_clear_bit(&flags, FLAG_STOP_CLIENT);
+    atomic_clear_bit(&client_flags, CLIENT_FLAG_STOP);
     k_sem_give(&client->run_sem);
     return GOLIOTH_OK;
 }
@@ -1657,7 +1657,7 @@ enum golioth_status golioth_client_stop(struct golioth_client *client)
 
     k_sem_take(&client->run_sem, K_NO_WAIT);
 
-    atomic_set_bit(&flags, FLAG_STOP_CLIENT);
+    atomic_set_bit(&client_flags, CLIENT_FLAG_STOP);
 
     golioth_client_wakeup(client);
 


### PR DESCRIPTION
- Rename the static `flags` variable (used for stopping the client) to `client_flags` to disambiguate it from the local `flags` variable used in various functions for socket flags.
- Zephyr's atomic functions expect an array of `atomic_t`, but we were passing a pointer to a single `atomic_t`, which worked in practice because the number of flags was less than the size of `atomic_t`, but this triggered an issue in Coverity for potential out-of-bounds memory access. Instead, use Zephyr's `ATOMIC_DEFINE()` macro to define the `client_flags` variable, as recommended.

https://scan8.scan.coverity.com/#/project-view/62270/15696?selectedIssue=544162