### PR TITLE
ci: bump Docker images to latest

### DIFF
--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:2df1570
+      image: golioth/golioth-hil-base:89df175
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -165,7 +165,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:2df1570
+      image: golioth/golioth-hil-base:89df175
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -136,7 +136,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:2df1570
+      image: golioth/golioth-hil-base:89df175
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -169,7 +169,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-twister-base:2ddffa5
+      image: golioth/golioth-twister-base:89df175
       env:
         ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.0
       volumes:


### PR DESCRIPTION
Latest Docker images come with Python 3.13 instead of Python 3.11. There is
also venv already setup, so that installed packages do not conflict with
system packages.