### PR TITLE
port: add gateway service to Linux and ESP-IDF

### DIFF
--- a/port/esp_idf/components/golioth_sdk/CMakeLists.txt
+++ b/port/esp_idf/components/golioth_sdk/CMakeLists.txt
@@ -31,6 +31,7 @@ idf_component_register(
         "${sdk_src}/golioth_status.c"
         "${sdk_src}/coap_client.c"
         "${sdk_src}/coap_client_libcoap.c"
+        "${sdk_src}/gateway.c"
         "${sdk_src}/log.c"
         "${sdk_src}/lightdb_state.c"
         "${sdk_src}/location.c"

--- a/port/linux/golioth_sdk/CMakeLists.txt
+++ b/port/linux/golioth_sdk/CMakeLists.txt
@@ -24,6 +24,7 @@ set(sdk_srcs
     "${sdk_src}/golioth_status.c"
     "${sdk_src}/coap_client.c"
     "${sdk_src}/coap_client_libcoap.c"
+    "${sdk_src}/gateway.c"
     "${sdk_src}/log.c"
     "${sdk_src}/lightdb_state.c"
     "${sdk_src}/location.c"


### PR DESCRIPTION
This allows for testing the Gateway service on these platforms, even if we're not building gateways on them. This is useful for testing how libcoap performs with some of the changes we're making to the client to support gatewawy work.