### PR TITLE
Fix warnings/errors when GOLIOTH_DEBUG_LOG=n

### DIFF
--- a/port/zephyr/include/golioth_port_config.h
+++ b/port/zephyr/include/golioth_port_config.h
@@ -25,6 +25,15 @@
 
 #define GLTH_LOG_BUFFER_HEXDUMP(tag, buf, size, level) LOG_HEXDUMP_DBG(buf, size, "buffer")
 
+#else /* CONFIG_GOLIOTH_DEBUG_LOG */
+
+#define GLTH_LOGV(TAG, ...)
+#define GLTH_LOGD(TAG, ...)
+#define GLTH_LOGI(TAG, ...)
+#define GLTH_LOGW(TAG, ...)
+#define GLTH_LOGE(TAG, ...)
+#define GLTH_LOG_BUFFER_HEXDUMP(TAG, ...)
+
 #endif
 
 /* Use Zephyr random subsystem, which has support for HW RNGs and HW entropy sources. Seeding is

--- a/src/fw_update.c
+++ b/src/fw_update.c
@@ -524,7 +524,9 @@ static void fw_update_thread(void *arg)
                                             FW_REPORT_COMPONENT_NAME | FW_REPORT_CURRENT_VERSION
                                                 | FW_REPORT_TARGET_VERSION);
 
+#if defined(CONFIG_GOLIOTH_DEBUG_LOG)
         uint64_t start_time_ms = golioth_sys_now_ms();
+#endif
         download_ctx.bytes_downloaded = 0;
         download_ctx.retries = 0;
         download_ctx.sha = golioth_sys_sha256_create();

--- a/src/ota.c
+++ b/src/ota.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdio.h>
 #include <assert.h>
 #include <errno.h>
 #include <string.h>

--- a/src/settings.c
+++ b/src/settings.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdio.h>
 #include <golioth/settings.h>
 #include "golioth_util.h"
 #include "coap_client.h"


### PR DESCRIPTION
Draft for now, I'll add an explanation to the commit message if this ends up getting merged.

With the v0.19.0 release, when `CONFIG_GOLIOTH_DEBUG_LOG=n` (i.e. disable `GLTH_LOGX` debug messages), the build fails with some warnings/errors like:
- `warning: implicit declaration of function 'GLTH_LOGD' [-Wimplicit-function-declaration]`
- `error: 'TAG' undeclared (first use in this function)`.

I think I figured out why this is happening:
1. [Source file](https://github.com/golioth/golioth-firmware-sdk/blob/452785e0fe99d9477f9202e00456262bf227f0fc/src/zephyr_coap_req.c#L7) includes `#include <golioth/golioth_debug.h>`
2. `golioth/golioth_debug.h` includes `#include <golioth/config.h>`
3. `golioth/config.h` includes `#include "golioth_port_config.h"`
4. `golioth_port_config.h` doesn't explicitly define `GLTH_LOG<x>` macros if `CONFIG_GOLIOTH_DEBUG_LOG=n`

50b4a93ac652824d2321188442240b66fd4c990d is essentially the minimal set of changes I had to make to get these warnings/errors to go away for my Zephyr app, but someone who is more familiar with the SDK might have better suggestions on how to fix this.

For example, files that include `golioth/golioth_sys.h` instead of (or in addition to) `golioth/golioth_debug.h` have these defined (so no warnings/errors):

https://github.com/golioth/golioth-firmware-sdk/blob/452785e0fe99d9477f9202e00456262bf227f0fc/include/golioth/golioth_sys.h#L297-L306

I don't know if it makes sense to move the ["Logging" section](https://github.com/golioth/golioth-firmware-sdk/blob/452785e0fe99d9477f9202e00456262bf227f0fc/include/golioth/golioth_sys.h#L195-L306) out of `golioth/golioth_sys.h` and put it into `golioth/golioth_debug.h` instead? Or something else might make more sense? 🤷‍♂️ LMK what you want, happy to make changes.