### PR TITLE
Fix undefined reference warnings when debug logging is turned off

### DIFF
--- a/src/lightdb_state.c
+++ b/src/lightdb_state.c
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <assert.h>
+#include <stdio.h>
 #include <string.h>
+
 #include "coap_client.h"
 #include <golioth/lightdb_state.h>
 #include <golioth/payload_utils.h>

--- a/src/ota.c
+++ b/src/ota.c
@@ -5,7 +5,9 @@
  */
 #include <assert.h>
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
+
 #include <zcbor_decode.h>
 #include <zcbor_encode.h>
 #include <golioth/ota.h>

--- a/src/settings.c
+++ b/src/settings.c
@@ -378,18 +378,14 @@ static void on_settings(struct golioth_client *client,
 {
     if (GOLIOTH_OK != status)
     {
-        char coap_code_str[16] = {0};
-        if (coap_rsp_code)
+        GLTH_LOGE(TAG, "Settings error: %d", status);
+        if (GOLIOTH_ERR_COAP_RESPONSE == status)
         {
-            /* Mask class & detail (following RFC 7252) to silence truncation build warning */
-            snprintf(coap_code_str,
-                     sizeof(coap_code_str),
-                     "CoAP: %d.%02d",
-                     (coap_rsp_code->code_class & 0b111),
-                     (coap_rsp_code->code_detail & 0b11111));
+            GLTH_LOGE(TAG,
+                      "CoAP response: %d.%02d",
+                      (coap_rsp_code->code_class & 0b111),
+                      (coap_rsp_code->code_detail & 0b11111));
         }
-
-        GLTH_LOGE(TAG, "Settings callback received status error: %d  %s", status, coap_code_str);
         return;
     }
 


### PR DESCRIPTION
These errors are due to using snprintf() but not directly including stdio.h. In lightdb_state.c and ota.c we now include stdio.h. In settings.c we rework logging to remove the snprintf call, which also recovers some resources when logging is disabled.