### PR TITLE
examples: replace deprecated datetime.utcnow()

### DIFF
--- a/examples/esp_idf/hello/pytest/test_sample.py
+++ b/examples/esp_idf/hello/pytest/test_sample.py
@@ -17,11 +17,11 @@ async def test_hello(board, device):
     await board.set_golioth_psk_credentials(golioth_cred.identity, golioth_cred.key)
 
     # Record timestamp and wait for fourth hello message
-    start = datetime.datetime.utcnow()
+    start = datetime.datetime.now(datetime.UTC)
     await board.wait_for_regex_in_line('.*Sending hello! 3', timeout_s=90.0)
 
     # Check logs for hello messages
-    end = datetime.datetime.utcnow()
+    end = datetime.datetime.now(datetime.UTC)
     logs = await device.get_logs({'start': start.strftime('%Y-%m-%dT%H:%M:%S.%fZ'), 'end': end.strftime('%Y-%m-%dT%H:%M:%S.%fZ')})
 
     # Test logs received from server

--- a/examples/zephyr/hello/pytest/test_sample.py
+++ b/examples/zephyr/hello/pytest/test_sample.py
@@ -26,12 +26,12 @@ async def test_hello(shell, device, wifi_ssid, wifi_psk):
 
     # Record timestamp and wait for fourth hello message
 
-    start = datetime.datetime.utcnow()
+    start = datetime.datetime.now(datetime.UTC)
     shell._device.readlines_until(regex=".*Sending hello! 3", timeout=110.0)
 
     # Check logs for hello messages
 
-    end = datetime.datetime.utcnow()
+    end = datetime.datetime.now(datetime.UTC)
 
     logs = await device.get_logs({'start': start.strftime('%Y-%m-%dT%H:%M:%S.%fZ'), 'end': end.strftime('%Y-%m-%dT%H:%M:%S.%fZ')})
 

--- a/examples/zephyr/hello_nrf91_offloaded/pytest/test_sample.py
+++ b/examples/zephyr/hello_nrf91_offloaded/pytest/test_sample.py
@@ -35,12 +35,12 @@ async def test_hello(shell, device, build_conf):
 
     # Record timestamp and wait for fourth hello message
 
-    start = datetime.datetime.utcnow()
+    start = datetime.datetime.now(datetime.UTC)
     shell._device.readlines_until(regex=".*Sending hello! 3", timeout=110.0)
 
     # Check logs for hello messages
 
-    end = datetime.datetime.utcnow()
+    end = datetime.datetime.now(datetime.UTC)
 
     logs = await device.get_logs({'start': start.strftime('%Y-%m-%dT%H:%M:%S.%fZ'), 'end': end.strftime('%Y-%m-%dT%H:%M:%S.%fZ')})
 

--- a/examples/zephyr/logging/pytest/test_sample.py
+++ b/examples/zephyr/logging/pytest/test_sample.py
@@ -69,12 +69,12 @@ async def test_logging(shell, device, wifi_ssid, wifi_psk):
 
     # Record timestamp and wait for fourth hello message
 
-    start = datetime.datetime.utcnow()
+    start = datetime.datetime.now(datetime.UTC)
     shell._device.readlines_until(regex=".*Debug info! 2", timeout=90.0)
 
     # Check logs for hello messages
 
-    end = datetime.datetime.utcnow()
+    end = datetime.datetime.now(datetime.UTC)
 
     logs = await device.get_logs({'start': start.strftime('%Y-%m-%dT%H:%M:%S.%fZ'), 'end': end.strftime('%Y-%m-%dT%H:%M:%S.%fZ')})
 


### PR DESCRIPTION
`datetime.utcnow()` is deprecated since Python 3.12.

See https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow