### PR TITLE
ci: bump actions/{checkout,upload-artifact} to v6

### DIFF
--- a/.github/actions/safe-upload-artifacts/action.yml
+++ b/.github/actions/safe-upload-artifacts/action.yml
@@ -65,7 +65,7 @@ runs:
         done
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/ci-clean-project.yml
+++ b/.github/workflows/ci-clean-project.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci-coverity.yml
+++ b/.github/workflows/ci-coverity.yml
@@ -12,7 +12,7 @@ jobs:
     container: golioth/golioth-coverity-base:bda7b71
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: modules/lib/golioth-firmware-sdk
           submodules: recursive
@@ -55,7 +55,7 @@ jobs:
             --form version="0" \
             --form description="Description" \
             https://scan.coverity.com/builds?project=golioth%2Fgolioth-firmware-sdk
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: coverity_output
           path: golioth-firmware-sdk.tgz

--- a/.github/workflows/ci-gitlint.yml
+++ b/.github/workflows/ci-gitlint.yml
@@ -13,7 +13,7 @@ jobs:
       image: jorisroovers/gitlint:0.19.1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci-lint-build.yml
+++ b/.github/workflows/ci-lint-build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch depth must be greater than the number of commits included in the push in order to
           # compare against commit prior to merge. 15 is chosen as a reasonable default for the
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Setup Python
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Setup Python
@@ -106,7 +106,7 @@ jobs:
       MTB_DOWNLOAD_ID: ${{ secrets.MTB_DOWNLOAD_ID }}
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Setup Python

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
       image: kiwicom/pre-commit:3.6.0
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci-yamllint.yml
+++ b/.github/workflows/ci-yamllint.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run yamllint
         run: |

--- a/.github/workflows/doc-firebase-doxygen-main.yml
+++ b/.github/workflows/doc-firebase-doxygen-main.yml
@@ -7,7 +7,7 @@ jobs:
   deploy_doxygen_prod:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Doxygen
         run: |
           sudo apt install wget graphviz

--- a/.github/workflows/doc-firebase-doxygen-pr.yml
+++ b/.github/workflows/doc-firebase-doxygen-pr.yml
@@ -4,7 +4,7 @@ jobs:
   deploy_doxygen_dev:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Doxygen
         run: |
           sudo apt install wget graphviz

--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare tests matrix
         id: output-tests
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository and Submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -95,7 +95,7 @@ jobs:
               mv build/merged.bin ../../../../test_binaries/${{ matrix.test }}.bin
 
       - name: Save Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.hil_board }}-hil-espidf-${{ matrix.test }}
           path: test_binaries/*
@@ -138,7 +138,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python dependencies
         run: |
@@ -242,7 +242,7 @@ jobs:
           mv combined.xml summary/hil-espidf-${{ inputs.hil_board }}.xml
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ci-summary-hil-espidf-${{ inputs.hil_board }}
           path: summary/hil-espidf-${{ inputs.hil_board }}.xml

--- a/.github/workflows/hil-integration-linux.yml
+++ b/.github/workflows/hil-integration-linux.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare tests matrix
         id: output-tests
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: .
           submodules: 'recursive'
@@ -114,7 +114,7 @@ jobs:
             build
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: success() || failure()
         with:
           name: linux-hil-test-coverage-${{ matrix.test }}
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Collect JUnit reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/hil-integration-nsim.yml
+++ b/.github/workflows/hil-integration-nsim.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare tests matrix
         id: output-tests
@@ -76,7 +76,7 @@ jobs:
         test: ${{ fromJSON(needs.matrix.outputs.tests) }}
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: modules/lib/golioth-firmware-sdk
           submodules: 'recursive'
@@ -208,7 +208,7 @@ jobs:
             > hil-zephyr-${{ inputs.platform }}.xml
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: success() || failure()
         with:
           name: ci-summary-hil-zephyr-${{ inputs.platform }}

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare tests matrix
         id: output-tests
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: modules/lib/golioth-firmware-sdk
           submodules: 'recursive'
@@ -148,7 +148,7 @@ jobs:
             test_binaries/${FW_IMAGE}
 
       - name: Save artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.hil_board }}-hil-zephyr-${{ matrix.test }}
           path: test_binaries/*
@@ -191,7 +191,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python dependencies
         run: |
           uv pip install \
@@ -331,7 +331,7 @@ jobs:
             > summary/hil-zephyr-${{ inputs.hil_board }}.xml
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ci-summary-hil-zephyr-${{ inputs.hil_board }}
           path: summary/hil-zephyr-${{ inputs.hil_board }}.xml

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
 
       - name: Generate device name
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository and Submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -163,7 +163,7 @@ jobs:
               mv ${SAMPLE_DIR}/build/merged.bin test_binaries/${SAMPLE_NAME}.bin
 
       - name: Save Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.hil_board }}-sample-espidf-${{ matrix.name }}
           path: test_binaries/*
@@ -206,7 +206,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python dependencies
         run: |

--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -60,7 +60,7 @@ jobs:
       EXTRA_TWISTER_ARGS: ${{ github.event_name == 'pull_request' && '-e nightly' || '' }}
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: modules/lib/golioth-firmware-sdk
           submodules: 'recursive'
@@ -177,7 +177,7 @@ jobs:
             > samples-zephyr-${{ inputs.platform }}.xml
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: success() || failure()
         with:
           name: ci-summary-samples-zephyr-${{ inputs.platform }}

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: modules/lib/golioth-firmware-sdk
           submodules: 'recursive'
@@ -147,7 +147,7 @@ jobs:
 
       - name: Save artifacts
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test_artifacts_${{ inputs.hil_board }}-${{ matrix.name }}
           path: test_artifacts_${{ inputs.hil_board }}-${{ matrix.name }}.tar
@@ -178,7 +178,7 @@ jobs:
 
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: modules/lib/golioth-firmware-sdk
       - name: Init and update west
@@ -379,7 +379,7 @@ jobs:
           fi
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: success() || failure()
         with:
           name: ci-summary-samples-zephyr-${{ inputs.hil_board }}

--- a/.github/workflows/misc-locate-twister-samples.yml
+++ b/.github/workflows/misc-locate-twister-samples.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: modules/lib/golioth-firmware-sdk
 

--- a/.github/workflows/report-allure-publish.yml
+++ b/.github/workflows/report-allure-publish.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Load Allure report history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         continue-on-error: true
         with:
           repository: golioth/allure-reports
@@ -37,7 +37,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload collected reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: allure-reports-alltest
           path: reports/allure-results

--- a/.github/workflows/report-summary-publish.yml
+++ b/.github/workflows/report-summary-publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Gather summaries
       uses: actions/download-artifact@v4

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload test coverage artifacts
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: unit-test-coverage
           path: coverage.json
@@ -295,7 +295,7 @@ jobs:
     name: coverage
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download HIL Linux coverage artifacts
         uses: actions/download-artifact@v4
@@ -365,7 +365,7 @@ jobs:
           gcovr --txt-summary --xml coverage.xml --html-details coverage/index.html
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: success() || failure()
         with:
           name: coverage-native-sim


### PR DESCRIPTION
This solves "Node.js 20 actions are deprecated." message.