### PR TITLE
CI: Clean up auto-generated main packages

### DIFF
--- a/.github/workflows/doc-firebase-doxygen-main.yml
+++ b/.github/workflows/doc-firebase-doxygen-main.yml
@@ -11,7 +11,8 @@ jobs:
       - name: Install Doxygen
         run: |
           sudo apt install wget graphviz
-          wget https://www.doxygen.nl/files/doxygen-1.10.0.linux.bin.tar.gz
+          wget \
+            https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz
           tar -xvf doxygen-1.10.0.linux.bin.tar.gz
           cd doxygen-1.10.0
           sudo make install

--- a/.github/workflows/doc-firebase-doxygen-pr.yml
+++ b/.github/workflows/doc-firebase-doxygen-pr.yml
@@ -8,7 +8,8 @@ jobs:
       - name: Install Doxygen
         run: |
           sudo apt install wget graphviz
-          wget https://www.doxygen.nl/files/doxygen-1.10.0.linux.bin.tar.gz
+          wget \
+            https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz
           tar -xvf doxygen-1.10.0.linux.bin.tar.gz
           cd doxygen-1.10.0
           sudo make install

--- a/scripts/ci/clean_ci_project
+++ b/scripts/ci/clean_ci_project
@@ -104,9 +104,9 @@ class OrphanCleaner:
                                 project: Project | None,
                                 delta: timedelta | None = None) -> int:
         if not (project and self.certificates):
-            return -1;
+            return -1
 
-        removal_count = 0;
+        removal_count = 0
         print("Processing Certificates:")
         for c in self.certificates:
             id = await self.remove_expired_ids(c, project.certificates.delete, delta)
@@ -119,9 +119,9 @@ class OrphanCleaner:
         if not (project and self.cohorts):
             if self.verbose:
                 print("No cohorts found.")
-            return -1;
+            return -1
 
-        removal_count = 0;
+        removal_count = 0
         print("Processing Cohorts:")
         for c in self.cohorts:
             id = await self.remove_expired_ids(c, project.cohorts.delete, delta)
@@ -134,9 +134,9 @@ class OrphanCleaner:
         if not (project and self.devices):
             if self.verbose:
                 print("No devices found.")
-            return -1;
+            return -1
 
-        removal_count = 0;
+        removal_count = 0
         print("Processing Devices:")
         for d in self.devices:
             id = await self.remove_expired_ids(d, project.delete_device_by_id, delta)
@@ -149,9 +149,9 @@ class OrphanCleaner:
         if not (project and self.releases):
             if self.verbose:
                 print("No releases found.")
-            return -1;
+            return -1
 
-        removal_count = 0;
+        removal_count = 0
         print("Processing Releases:")
         for r in self.releases:
             id = await self.remove_expired_ids(r, project.releases.delete, delta)
@@ -164,9 +164,9 @@ class OrphanCleaner:
         if not (project and self.tags):
             if self.verbose:
                 print("No tags found.")
-            return -1;
+            return -1
 
-        removal_count = 0;
+        removal_count = 0
         print("Processing Tags:")
         for t in self.tags:
             id = await self.remove_expired_ids(t, project.tags.delete, delta)
@@ -180,7 +180,7 @@ async def main(api_url: str, api_key: str, days_old: int, verbose: bool) -> int:
     await oc.fetch_all_project_info()
     if not oc.project:
         print("Unable to initialize project.")
-        return -1;
+        return -1
 
     print("\nStarting removal process.")
     print(f"  Org: {oc.project.organization}")

--- a/scripts/ci/clean_ci_project
+++ b/scripts/ci/clean_ci_project
@@ -6,8 +6,9 @@ __license__ = "Apache-2.0"
 
 import argparse, sys
 
-from golioth import Client, Project, Device, Certificate, Cohort, Release, Tag
+from golioth import Client, Project, Artifact, Device, Certificate, Cohort, Release, Tag
 import asyncio
+import re
 
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Any, Awaitable
@@ -21,9 +22,11 @@ class OrphanCleaner:
         self.client = Client(api_url, api_key)
         self.project = None
 
+        self.artifacts = None
         self.certificates = None
         self.cohorts = None
         self.devices = None
+        self.releases = None
         self.tags = None
 
         self.default_delta = default_delta or EXPIRY_AGE
@@ -36,6 +39,7 @@ class OrphanCleaner:
                 print("No project found")
             return
 
+        self.artifacts = await self.project.artifacts.get_all()
         self.devices = await self.project.get_devices()
         self.certificates = await self.project.certificates.get_all()
         self.cohorts = await self.project.cohorts.get_all()
@@ -53,7 +57,7 @@ class OrphanCleaner:
         return datetime.now(timezone.utc) - created_dt
 
     async def remove_expired_ids(self,
-                                 member: Certificate | Cohort | Device | Release | Tag,
+                                 member: Artifact | Certificate | Cohort | Device | Release | Tag,
                                  remove: RemFunc,
                                  delta: timedelta | None = None) -> str | None:
             age = self.get_age(member.info['createdAt'])
@@ -65,6 +69,36 @@ class OrphanCleaner:
                 except:
                     print(f"Unable to remove: {member.id}")
                     return None
+
+    async def cull_artifacts(self,
+                             project: Project | None,
+                             delta: timedelta | None = None) -> int:
+        if not (project and self.artifacts):
+            if self.verbose:
+                print("No artifacts found.")
+            return -1
+
+        # Pouch CI generated artifacts: 2.0.0-generated-<16 alnum>-<16 hex>
+        # Pouch CI generated artifacts: 2.0.0-generated-<16 alnum>
+        LEAKED_MAIN_RE = re.compile(r"^2\.0\.0-generated-[A-Za-z0-9]{16}(?:-[0-9A-Fa-f]{16})?$")
+
+        removal_count = 0
+        print("Processing Artifacts:")
+        for artifact in self.artifacts:
+            if artifact.package != "main":
+                continue
+            if not LEAKED_MAIN_RE.match(artifact.version):
+                continue
+
+            try:
+                id = await self.remove_expired_ids(artifact, project.artifacts.delete, delta)
+                if id:
+                    print(f"Deleted leaked artifact: {artifact}")
+                    removal_count += 1
+            except Exception as err:
+                print(f"Failed deleting artifact {artifact.id}: {err}")
+        print("Complete.\n")
+        return removal_count
 
     async def cull_certificates(self,
                                 project: Project | None,
@@ -165,6 +199,10 @@ async def main(api_url: str, api_key: str, days_old: int, verbose: bool) -> int:
     if oc.cohorts:
         cohorts_count = await oc.cull_cohorts(oc.project, timedelta(days=days_old))
 
+    artifact_count = 0
+    if oc.artifacts:
+        artifact_count = await oc.cull_artifacts(oc.project, timedelta(days=days_old))
+
     tag_count = 0
     if oc.tags:
         tag_count = await oc.cull_tags(oc.project, timedelta(days=days_old))
@@ -176,6 +214,7 @@ async def main(api_url: str, api_key: str, days_old: int, verbose: bool) -> int:
     print(f"Devices removed: {device_count}")
     print(f"Releases removed: {release_count}")
     print(f"Cohorts removed: {cohorts_count}")
+    print(f"Artifacts removed: {artifact_count}")
     print(f"Tags removed: {tag_count}")
     print(f"Certificates removed: {certificate_count}")
 


### PR DESCRIPTION
Clean up auto-generated `main` packages with a known version string pattern that have been orphaned by a CI run.

I've already run this a few times to clean up about 21 pages of orphaned artifacts. Adding this to the workflow will keep any future leaks cleaned up on a nightly basis.

This resolves the failing recurring OTA test which were cause by the REST API returning a limited number of `main` artifacts that didn't include the CI target artifacts do to the number of orphaned packages in the project.