### PR TITLE
CI: add option to skip test on PR

### DIFF
--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -27,6 +27,10 @@ on:
       coap_gateway_url:
         required: true
         type: string
+      skip_tests_on_pr:
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       hil_board:
@@ -53,6 +57,10 @@ on:
       coap_gateway_url:
         required: true
         type: string
+      skip_tests_on_pr:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   matrix:
@@ -170,6 +178,7 @@ jobs:
 
   test:
     name: zephyr-${{ inputs.hil_board }}-test (${{ matrix.test }})
+    if: ${{ !(inputs.skip_tests_on_pr && github.event_name == 'pull_request') }}
     needs:
       - matrix
       - build

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -32,6 +32,10 @@ on:
       coap_gateway_url:
         required: true
         type: string
+      skip_tests_on_pr:
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       hil_board:
@@ -62,6 +66,10 @@ on:
       coap_gateway_url:
         required: true
         type: string
+      skip_tests_on_pr:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   matrix:
@@ -154,7 +162,9 @@ jobs:
 
   test:
     name: zephyr-${{ inputs.hil_board }}-twister-run (${{ matrix.name }})
-    if: ${{ inputs.run_tests && !cancelled() }}
+    if: >-
+      ${{ inputs.run_tests && !cancelled()
+      && !(inputs.skip_tests_on_pr && github.event_name == 'pull_request') }}
     needs:
       - matrix
       - build

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -147,6 +147,7 @@ jobs:
       api-url: ${{ inputs.api-url }}
       api-key-id: ${{ inputs.api-key-id }}
       coap_gateway_url: ${{ inputs.coap_gateway_url }}
+      skip_tests_on_pr: ${{ matrix.skip_tests_on_pr || false }}
     secrets: inherit
 
   hil_test_zephyr_nsim:
@@ -264,6 +265,7 @@ jobs:
       api-url: ${{ inputs.api-url }}
       api-key-id: ${{ inputs.api-key-id }}
       coap_gateway_url: ${{ inputs.coap_gateway_url }}
+      skip_tests_on_pr: ${{ matrix.skip_tests_on_pr || false }}
     secrets: inherit
 
   hil_sample_zephyr_nsim:

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -137,6 +137,7 @@ jobs:
             west_board: rak5010/nrf52840
             manifest: .ci-west-zephyr.yml
             binary_name: zephyr/zephyr.hex
+            skip_tests_on_pr: true
     uses: ./.github/workflows/hil-integration-zephyr.yml
     with:
       hil_board: ${{ matrix.hil_board }}
@@ -254,6 +255,7 @@ jobs:
               --west-flash=--gdb=/usr/bin/gdb
               --west-runner blackmagicprobe
             run_tests: true
+            skip_tests_on_pr: true
     uses: ./.github/workflows/hil-sample-zephyr.yml
     with:
       hil_board: ${{ matrix.hil_board }}


### PR DESCRIPTION
Introduces the option to skip HIL test on pull_request, but continue to run build and to run the test on nightly and on merge to main. This option can help alleviate bottlenecks in the self-hosted runner availability. To that end, this option has been enabled for the rak5010 board.