### PR TITLE
CI: fix how logs are filtered for the ota_reason_and_state_test

### DIFF
--- a/tests/hil/tests/ota/test_ota.py
+++ b/tests/hil/tests/ota/test_ota.py
@@ -119,15 +119,33 @@ async def verify_component_values(board, info):
     assert None is not await board.wait_for_regex_in_line(f'component.hash: {b_info["digests"]["sha256"]["digest"]}', timeout_s=2)
 
 def verify_dfu_status_logs(logs):
-    assert len(logs) == len(golioth_ota_reason)
+    # Filter to only the DFU status-report logs emitted by test_reason_and_state.
+    status_logs = [
+        log for log in logs
+        if log.metadata.get('reasonCode') is not None
+        and log.metadata.get('stateCode') is not None
+        and log.metadata.get('package') == 'lobster'
+    ]
 
+    assert len(status_logs) == len(golioth_ota_reason)
+
+    # Filter received logs by reasonCode
+    by_reason = {}
+    for log in status_logs:
+        reason_code = int(log.metadata['reasonCode'])
+        if reason_code in by_reason:
+            raise AssertionError(f"duplicate reasonCode: {reason_code}")
+        by_reason[reason_code] = log
+
+    # Iterate reason codes and check against filtered log messages
     for i, r in enumerate(golioth_ota_reason):
-        assert int(logs[i].metadata['reasonCode']) == i
-        assert int(logs[i].metadata['stateCode']) == i % GOLIOTH_OTA_STATE_CNT
-        assert logs[i].metadata['state'] == golioth_ota_state[ i % GOLIOTH_OTA_STATE_CNT ]
-        assert logs[i].metadata['package'] == "lobster"
-        assert logs[i].metadata['version'] == "2.3.4"
-        assert logs[i].metadata['target'] == "5.6.7"
+        assert i in by_reason, f"missing reasonCode: {i} ({r})"
+        log = by_reason[i]
+        assert int(log.metadata['stateCode']) == i % GOLIOTH_OTA_STATE_CNT
+        assert log.metadata['state'] == golioth_ota_state[i % GOLIOTH_OTA_STATE_CNT]
+        assert log.metadata['package'] == "lobster"
+        assert log.metadata['version'] == "2.3.4"
+        assert log.metadata['target'] == "5.6.7"
 
 ##### Tests #####
 
@@ -201,6 +219,8 @@ async def test_reason_and_state(board, device, project, artifacts, cohort):
     # Fetch logs
 
     log_fetch_start = datetime.datetime.now(datetime.UTC)
+    min_required = GOLIOTH_OTA_REASON_CNT
+    last_validation_error = None
 
     while True:
         end = datetime.datetime.now(datetime.UTC)
@@ -213,16 +233,21 @@ async def test_reason_and_state(board, device, project, artifacts, cohort):
             }
         )
 
-        if len(logs) == GOLIOTH_OTA_REASON_CNT:
-            break
+        if len(logs) >= min_required:
+            try:
+                verify_dfu_status_logs(logs)
+                break
+            except AssertionError as e:
+                last_validation_error = e
+                if str(e).startswith("duplicate reasonCode:"):
+                    raise
+                min_required = len(logs) + 1
 
-        assert (
-            LOG_FETCH_POLLING_LIMIT
-            > datetime.datetime.now(datetime.UTC) - log_fetch_start
+        elapsed = datetime.datetime.now(datetime.UTC) - log_fetch_start
+        assert LOG_FETCH_POLLING_LIMIT > elapsed, (
+            f"Timed out after {elapsed.total_seconds():.1f}s waiting for "
+            f"{min_required} golioth_dfu logs"
+            + (f". Last validation error: {last_validation_error}" if last_validation_error else "")
         )
 
         await trio.sleep(1)
-
-    # Test logs received from server
-
-    verify_dfu_status_logs(logs)


### PR DESCRIPTION
stabilize the flaky test by:
- validating based on log message content and not absolute number of logs
  - if validation fails, keep polling for new messages until timeout
- filter received logs by reason code and fail on duplicates