### PR TITLE
CI: Pin all actions and containers and grant write permissions where neccessary

### DIFF
--- a/.github/actions/safe-upload-artifacts/action.yml
+++ b/.github/actions/safe-upload-artifacts/action.yml
@@ -65,7 +65,7 @@ runs:
         done
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/ci-clean-project.yml
+++ b/.github/workflows/ci-clean-project.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11' # >=3.11 for datetime.fromisoformat()
 

--- a/.github/workflows/ci-coverity.yml
+++ b/.github/workflows/ci-coverity.yml
@@ -12,7 +12,7 @@ jobs:
     container: golioth/golioth-coverity-base:bda7b71
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: modules/lib/golioth-firmware-sdk
           submodules: recursive
@@ -55,7 +55,7 @@ jobs:
             --form version="0" \
             --form description="Description" \
             https://scan.coverity.com/builds?project=golioth%2Fgolioth-firmware-sdk
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverity_output
           path: golioth-firmware-sdk.tgz

--- a/.github/workflows/ci-coverity.yml
+++ b/.github/workflows/ci-coverity.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   coverity:
     runs-on: ubuntu-24.04
-    container: golioth/golioth-coverity-base:bda7b71
+    # yamllint disable-line rule:line-length
+    container: golioth/golioth-coverity-base:bda7b71@sha256:fa0cbe0e64a8b3a81a0899e2e57284e661e5ddeef7dac500a22be035c5b21361
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci-gitlint.yml
+++ b/.github/workflows/ci-gitlint.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-24.04
 
     container:
-      image: jorisroovers/gitlint:0.19.1
+      # yamllint disable-line rule:line-length
+      image: jorisroovers/gitlint:0.19.1@sha256:bc451a096ba8ce380c9d9e0e6afdef47e54369b47ca5e1be95fae1b879b8e3b8
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci-gitlint.yml
+++ b/.github/workflows/ci-gitlint.yml
@@ -13,7 +13,7 @@ jobs:
       image: jorisroovers/gitlint:0.19.1
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci-lint-build.yml
+++ b/.github/workflows/ci-lint-build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Fetch depth must be greater than the number of commits included in the push in order to
           # compare against commit prior to merge. 15 is chosen as a reasonable default for the
@@ -40,11 +40,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: 'recursive'
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
           architecture: 'x64'
@@ -69,16 +69,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: 'recursive'
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
           architecture: 'x64'
       - name: Build ESP-IDF cpp project
-        uses: espressif/esp-idf-ci-action@v1
+        uses: espressif/esp-idf-ci-action@e6f5c74232b1ccd4c97ed641f1e48553853f1fd5 # v1.2.0
         with:
           esp_idf_version: v5.3
           target: esp32
@@ -92,7 +92,7 @@ jobs:
           touch certs/client.key.pem
           touch certs/client.crt.pem
       - name: Build ESP-IDF certificate_auth project
-        uses: espressif/esp-idf-ci-action@v1
+        uses: espressif/esp-idf-ci-action@e6f5c74232b1ccd4c97ed641f1e48553853f1fd5 # v1.2.0
         with:
           esp_idf_version: v5.3
           target: esp32
@@ -106,11 +106,11 @@ jobs:
       MTB_DOWNLOAD_ID: ${{ secrets.MTB_DOWNLOAD_ID }}
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: 'recursive'
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
           architecture: 'x64'

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
       image: kiwicom/pre-commit:3.6.0
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-24.04
 
     container:
-      image: kiwicom/pre-commit:3.6.0
+      # yamllint disable-line rule:line-length
+      image: kiwicom/pre-commit:3.6.0@sha256:381a3406aa9e6fedfc386ca0889dd5b8e9b915cbc5490a3ecec272ed7b8a67ed
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci-yamllint.yml
+++ b/.github/workflows/ci-yamllint.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run yamllint
         run: |

--- a/.github/workflows/doc-firebase-doxygen-main.yml
+++ b/.github/workflows/doc-firebase-doxygen-main.yml
@@ -22,7 +22,14 @@ jobs:
         run: |
           cd docs/doxygen
           doxygen
-      - uses: FirebaseExtended/action-hosting-deploy@ac8041b3b04337509168113bf98b95879df22322
+      # Pin the node24 version to workaround regression in firebase-tools:
+      # https://github.com/firebase/firebase-tools/issues/10716#issuecomment-4800040219
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24.18.0'
+      # yamllint disable-line rule:line-length
+      - uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0.11.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GOLIOTH }}'

--- a/.github/workflows/doc-firebase-doxygen-main.yml
+++ b/.github/workflows/doc-firebase-doxygen-main.yml
@@ -1,4 +1,8 @@
 name: "Doc: Doxygen to Firebase (Main)"
+permissions:
+  deployments: write
+  statuses: write
+  checks: write
 'on':
   push:
     branches:

--- a/.github/workflows/doc-firebase-doxygen-main.yml
+++ b/.github/workflows/doc-firebase-doxygen-main.yml
@@ -7,7 +7,7 @@ jobs:
   deploy_doxygen_prod:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Doxygen
         run: |
           sudo apt install wget graphviz

--- a/.github/workflows/doc-firebase-doxygen-pr.yml
+++ b/.github/workflows/doc-firebase-doxygen-pr.yml
@@ -19,8 +19,15 @@ jobs:
         run: |
           cd docs/doxygen
           doxygen
+      # Pin the node24 version to workaround regression in firebase-tools:
+      # https://github.com/firebase/firebase-tools/issues/10716#issuecomment-4800040219
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24.18.0'
       - name: Deploy docs to dev
-        uses: FirebaseExtended/action-hosting-deploy@ac8041b3b04337509168113bf98b95879df22322
+        # yamllint disable-line rule:line-length
+        uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0.11.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GOLIOTH }}'

--- a/.github/workflows/doc-firebase-doxygen-pr.yml
+++ b/.github/workflows/doc-firebase-doxygen-pr.yml
@@ -4,7 +4,7 @@ jobs:
   deploy_doxygen_dev:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Doxygen
         run: |
           sudo apt install wget graphviz

--- a/.github/workflows/doc-firebase-doxygen-pr.yml
+++ b/.github/workflows/doc-firebase-doxygen-pr.yml
@@ -1,4 +1,9 @@
 name: "Doc: Doxygen to Firebase (PR)"
+permissions:
+  deployments: write
+  statuses: write
+  pull-requests: write
+  checks: write
 on: pull_request
 jobs:
   deploy_doxygen_dev:

--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Prepare tests matrix
         id: output-tests
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository and Submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: 'recursive'
 
@@ -85,7 +85,7 @@ jobs:
           mkdir test_binaries
 
       - name: Build Test Firmware
-        uses: espressif/esp-idf-ci-action@v1
+        uses: espressif/esp-idf-ci-action@e6f5c74232b1ccd4c97ed641f1e48553853f1fd5 # v1.2.0
         with:
           esp_idf_version: v5.4.1
           target: ${{ inputs.idf_target }}
@@ -95,7 +95,7 @@ jobs:
               mv build/merged.bin ../../../../test_binaries/${{ matrix.test }}.bin
 
       - name: Save Artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.hil_board }}-hil-espidf-${{ matrix.test }}
           path: test_binaries/*
@@ -138,7 +138,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python dependencies
         run: |
@@ -152,7 +152,7 @@ jobs:
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.hil_board }}-hil-espidf-${{ matrix.test }}
           path: .
@@ -220,7 +220,7 @@ jobs:
 
     steps:
       - name: Collect JUnit reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: summary
           pattern: ci-individual-hil-espidf-${{ inputs.hil_board }}-*
@@ -242,7 +242,7 @@ jobs:
           mv combined.xml summary/hil-espidf-${{ inputs.hil_board }}.xml
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-summary-hil-espidf-${{ inputs.hil_board }}
           path: summary/hil-espidf-${{ inputs.hil_board }}.xml

--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -130,7 +130,8 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:bda7b71
+      # yamllint disable-line rule:line-length
+      image: golioth/golioth-hil-base:bda7b71@sha256:9eb8fcac14e734196c5cb29074221c5c3983cc59d8408bcfb4b0c8028a20b142
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil-integration-linux.yml
+++ b/.github/workflows/hil-integration-linux.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Prepare tests matrix
         id: output-tests
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: .
           submodules: 'recursive'
@@ -114,7 +114,7 @@ jobs:
             build
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
           name: linux-hil-test-coverage-${{ matrix.test }}
@@ -159,10 +159,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Collect JUnit reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ci-hil-linux-*
 

--- a/.github/workflows/hil-integration-nsim.yml
+++ b/.github/workflows/hil-integration-nsim.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Prepare tests matrix
         id: output-tests
@@ -76,7 +76,7 @@ jobs:
         test: ${{ fromJSON(needs.matrix.outputs.tests) }}
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: modules/lib/golioth-firmware-sdk
           submodules: 'recursive'
@@ -189,7 +189,7 @@ jobs:
 
     steps:
       - name: Collect JUnit reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ci-individual-hil-zephyr-*
 
@@ -208,7 +208,7 @@ jobs:
             > hil-zephyr-${{ inputs.platform }}.xml
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
           name: ci-summary-hil-zephyr-${{ inputs.platform }}

--- a/.github/workflows/hil-integration-nsim.yml
+++ b/.github/workflows/hil-integration-nsim.yml
@@ -66,7 +66,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: matrix
     container:
-      image: golioth/golioth-zephyr-base:0.17.4-SDK-v0
+      # yamllint disable-line rule:line-length
+      image: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     name: zephyr-${{ inputs.platform }}-${{ matrix.test }}-test-nsim

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -89,7 +89,8 @@ jobs:
 
   build:
     name: zephyr-${{ inputs.hil_board }}-build (${{ matrix.test }})
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0
+    # yamllint disable-line rule:line-length
+    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
     needs: matrix
     strategy:
       fail-fast: false
@@ -192,7 +193,8 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:bda7b71
+      # yamllint disable-line rule:line-length
+      image: golioth/golioth-hil-base:bda7b71@sha256:9eb8fcac14e734196c5cb29074221c5c3983cc59d8408bcfb4b0c8028a20b142
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Prepare tests matrix
         id: output-tests
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: modules/lib/golioth-firmware-sdk
           submodules: 'recursive'
@@ -156,7 +156,7 @@ jobs:
             test_binaries/${FW_IMAGE}
 
       - name: Save artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.hil_board }}-hil-zephyr-${{ matrix.test }}
           path: test_binaries/*
@@ -200,7 +200,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Python dependencies
         run: |
           uv pip install \
@@ -211,7 +211,7 @@ jobs:
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.hil_board }}-hil-zephyr-${{ matrix.test }}
           path: .
@@ -320,7 +320,7 @@ jobs:
 
     steps:
       - name: Collect JUnit reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: summary
           pattern: ci-individual-hil-zephyr-${{ inputs.hil_board }}-*
@@ -340,7 +340,7 @@ jobs:
             > summary/hil-zephyr-${{ inputs.hil_board }}.xml
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-summary-hil-zephyr-${{ inputs.hil_board }}
           path: summary/hil-zephyr-${{ inputs.hil_board }}.xml

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -198,7 +198,8 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-hil-base:bda7b71
+      # yamllint disable-line rule:line-length
+      image: golioth/golioth-hil-base:bda7b71@sha256:9eb8fcac14e734196c5cb29074221c5c3983cc59d8408bcfb4b0c8028a20b142
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
 
       - name: Generate device name
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository and Submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: 'recursive'
 
@@ -139,7 +139,7 @@ jobs:
           mv *.key.pem examples/esp_idf/certificate_auth/main/certs/client.key.pem
 
       - name: Build Samples
-        uses: espressif/esp-idf-ci-action@v1
+        uses: espressif/esp-idf-ci-action@e6f5c74232b1ccd4c97ed641f1e48553853f1fd5 # v1.2.0
         with:
           esp_idf_version: v5.4.1
           target: ${{ inputs.idf_target }}
@@ -163,7 +163,7 @@ jobs:
               mv ${SAMPLE_DIR}/build/merged.bin test_binaries/${SAMPLE_NAME}.bin
 
       - name: Save Artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.hil_board }}-sample-espidf-${{ matrix.name }}
           path: test_binaries/*
@@ -206,7 +206,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python dependencies
         run: |
@@ -220,7 +220,7 @@ jobs:
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.hil_board }}-sample-espidf-${{ matrix.name }}
           path: .

--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -54,7 +54,8 @@ jobs:
         include: ${{ fromJSON(needs.matrix.outputs.sample_list) }}
     runs-on: ubuntu-24.04
     container:
-      image: golioth/golioth-zephyr-base:0.17.4-SDK-v0
+      # yamllint disable-line rule:line-length
+      image: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
       EXTRA_TWISTER_ARGS: ${{ github.event_name == 'pull_request' && '-e nightly' || '' }}

--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -60,7 +60,7 @@ jobs:
       EXTRA_TWISTER_ARGS: ${{ github.event_name == 'pull_request' && '-e nightly' || '' }}
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: modules/lib/golioth-firmware-sdk
           submodules: 'recursive'
@@ -158,7 +158,7 @@ jobs:
 
     steps:
       - name: Collect JUnit reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ci-individual-samples-zephyr-*
 
@@ -177,7 +177,7 @@ jobs:
             > samples-zephyr-${{ inputs.platform }}.xml
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
           name: ci-summary-samples-zephyr-${{ inputs.platform }}

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -86,7 +86,8 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.matrix.outputs.sample_list) }}
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0
+    # yamllint disable-line rule:line-length
+    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     runs-on: ubuntu-24.04
@@ -178,7 +179,8 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: golioth/golioth-twister-base:bda7b71
+      # yamllint disable-line rule:line-length
+      image: golioth/golioth-twister-base:bda7b71@sha256:e2df86f4fc795fd159dc984f1e7bc345983b26efee1090dd9793028c5ff7430d
       env:
         ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
       volumes:

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: modules/lib/golioth-firmware-sdk
           submodules: 'recursive'
@@ -155,7 +155,7 @@ jobs:
 
       - name: Save artifacts
         if: success() || failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test_artifacts_${{ inputs.hil_board }}-${{ matrix.name }}
           path: test_artifacts_${{ inputs.hil_board }}-${{ matrix.name }}.tar
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: modules/lib/golioth-firmware-sdk
       - name: Init and update west
@@ -218,7 +218,7 @@ jobs:
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test_artifacts_${{ inputs.hil_board }}-${{ matrix.name }}
           path: .
@@ -362,7 +362,7 @@ jobs:
 
     steps:
       - name: Collect JUnit reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ci-individual-samples-zephyr-*
 
@@ -389,7 +389,7 @@ jobs:
           fi
 
       - name: Upload CI report summary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
           name: ci-summary-samples-zephyr-${{ inputs.hil_board }}

--- a/.github/workflows/misc-locate-twister-samples.yml
+++ b/.github/workflows/misc-locate-twister-samples.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: modules/lib/golioth-firmware-sdk
 

--- a/.github/workflows/misc-locate-twister-samples.yml
+++ b/.github/workflows/misc-locate-twister-samples.yml
@@ -17,7 +17,8 @@ jobs:
     name: zephyr-${{ inputs.west_board }}-sample-matrix
     runs-on: ubuntu-24.04
     container:
-      image: golioth/golioth-zephyr-base:0.17.4-SDK-v0
+      # yamllint disable-line rule:line-length
+      image: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
 
     outputs:
       sample_list: ${{ steps.locate-samples.outputs.sample_list }}

--- a/.github/workflows/report-allure-publish.yml
+++ b/.github/workflows/report-allure-publish.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Load Allure report history
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         continue-on-error: true
         with:
           repository: golioth/allure-reports
@@ -30,14 +30,14 @@ jobs:
           ssh-key: ${{ secrets.ALLURE_REPORTS_DEPLOY_KEY }}
 
       - name: Collect individual reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: reports/allure-results
           pattern: allure-reports-*
           merge-multiple: true
 
       - name: Upload collected reports
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: allure-reports-alltest
           path: reports/allure-results
@@ -79,7 +79,7 @@ jobs:
           ${{ env.GHPAGES_LABEL }}/.
 
       - name: Publish test report
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         if: success() || failure()
         with:
           deploy_key: ${{ secrets.ALLURE_REPORTS_DEPLOY_KEY }}

--- a/.github/workflows/report-summary-publish.yml
+++ b/.github/workflows/report-summary-publish.yml
@@ -8,17 +8,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Gather summaries
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: summary
         pattern: ci-summary-*
         merge-multiple: true
 
     - name: Test Report
-      uses: phoenix-actions/test-reporting@v15
+      uses: phoenix-actions/test-reporting@7317eea6e13c47348dd0bb318669485157c518d6 # v16
       if: success() || failure()
       with:
         name: Firmware Test Summary

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: 'recursive'
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload test coverage artifacts
         if: success() || failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unit-test-coverage
           path: coverage.json
@@ -299,31 +299,31 @@ jobs:
     name: coverage
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download HIL Linux coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: linux-hil-test-coverage-*
 
       - name: Download HIL Zephyr coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: native-sim-hil-test-coverage-*
 
       - name: Download Twister coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: twister-run-artifacts-native*
 
       - name: Download Unit Tests coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: unit-test-coverage
           path: unit-test-coverage
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
 
@@ -369,21 +369,21 @@ jobs:
           gcovr --txt-summary --xml coverage.xml --html-details coverage/index.html
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
           name: coverage-native-sim
           path: coverage/*
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           disable_search: true
 
       - name: Coverage report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: coverage.xml
           format: markdown
@@ -403,7 +403,8 @@ jobs:
           cat code-coverage-results.md >> code-coverage-comment.md
 
       - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        # yamllint disable-line rule:line-length
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         if: github.event_name == 'pull_request'
         with:
           path: code-coverage-comment.md

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -297,6 +297,8 @@ jobs:
       - hil_test_zephyr_nsim
       - unit_tests
     name: coverage
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/trigger-push-and-schedule.yml
+++ b/.github/workflows/trigger-push-and-schedule.yml
@@ -9,6 +9,10 @@ on:
     # Run workflow at the start of every day (12 AM UTC)
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
- Upgrade all actions to latest release and pin by sha
- Pin all containers to digest sha (do not change any versions)
- Add write permissions to workflows that require them

The Golioth Org default has changed to only grant read permission. This PR grants write permissions to the workflows that need them.

Relates to: https://github.com/golioth/firmware-issue-tracker/issues/958