### PR TITLE
CI: disable codecov and remove badge from readme

### DIFF
--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -378,6 +378,7 @@ jobs:
           path: coverage/*
 
       - name: Upload results to Codecov
+        if: false
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Golioth Firmware SDK
 
-[![codecov](https://codecov.io/github/golioth/golioth-firmware-sdk/graph/badge.svg?token=IQSG01ZIOP)](https://codecov.io/github/golioth/golioth-firmware-sdk)
-
 A software development kit for connecting embedded devices to the
 [Golioth](https://golioth.io) IoT cloud.
 


### PR DESCRIPTION
We have not been actively using the codecov features and the GitHub application that leverages them has not been installed for several months. This PR disables uploading to the service and may be re-enabled when we need them.