### PR TITLE
CI: use OTA events

### DIFF
--- a/.github/workflows/ci-clean-project.yml
+++ b/.github/workflows/ci-clean-project.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Golioth Python Tools
         run: |
-          pip install git+https://github.com/golioth/python-golioth-tools@v0.8.1
+          pip install git+https://github.com/golioth/python-golioth-tools@v0.9.0
 
       - name: Remove old asset from Prod
         run: |

--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -147,7 +147,7 @@ jobs:
             pytest==8.4.2 \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \
-            git+https://github.com/golioth/python-golioth-tools@v0.8.1
+            git+https://github.com/golioth/python-golioth-tools@v0.9.0
 
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on

--- a/.github/workflows/hil-integration-linux.yml
+++ b/.github/workflows/hil-integration-linux.yml
@@ -80,7 +80,7 @@ jobs:
             pytest==8.4.2 \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \
-            git+https://github.com/golioth/python-golioth-tools@v0.8.1
+            git+https://github.com/golioth/python-golioth-tools@v0.9.0
       - name: Run test
         id: run_test
         shell: bash

--- a/.github/workflows/hil-integration-nsim.yml
+++ b/.github/workflows/hil-integration-nsim.yml
@@ -102,7 +102,7 @@ jobs:
             pytest==8.4.2 \
             pytest-timeout \
             modules/lib/golioth-firmware-sdk/tests/hil/scripts/pytest-hil \
-            git+https://github.com/golioth/python-golioth-tools@v0.8.1
+            git+https://github.com/golioth/python-golioth-tools@v0.9.0
 
       - name: Build test
         run: |

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -209,7 +209,7 @@ jobs:
             pytest==8.4.2 \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \
-            git+https://github.com/golioth/python-golioth-tools@v0.8.1
+            git+https://github.com/golioth/python-golioth-tools@v0.9.0
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -215,7 +215,7 @@ jobs:
             pytest==8.4.2 \
             pytest-timeout \
             tests/hil/scripts/pytest-hil \
-            git+https://github.com/golioth/python-golioth-tools@v0.8.1
+            git+https://github.com/golioth/python-golioth-tools@v0.9.0
 
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on

--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -84,7 +84,7 @@ jobs:
             -r zephyr/scripts/requirements-build-test.txt \
             -r zephyr/scripts/requirements-run-test.txt \
             modules/lib/golioth-firmware-sdk/tests/hil/scripts/pytest-zephyr-samples \
-            git+https://github.com/golioth/python-golioth-tools@v0.8.1 \
+            git+https://github.com/golioth/python-golioth-tools@v0.9.0 \
             asyncclick==8.1.8
 
       - name: Run tests

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -216,7 +216,7 @@ jobs:
             -r zephyr/scripts/requirements-build-test.txt \
             -r zephyr/scripts/requirements-run-test.txt \
             tests/hil/scripts/pytest-zephyr-samples \
-            git+https://github.com/golioth/python-golioth-tools@v0.8.1
+            git+https://github.com/golioth/python-golioth-tools@v0.9.0
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
       - name: Download build

--- a/tests/hil/tests/ota/test.c
+++ b/tests/hil/tests/ota/test.c
@@ -303,14 +303,8 @@ static void test_reason_and_state(void)
         enum golioth_ota_state state = i % GOLIOTH_OTA_STATE_CNT;
         enum golioth_ota_reason reason = i;
         GLTH_LOGI(TAG, "Updating status. Reason: %d State: %d", reason, state);
-        status = golioth_ota_report_state(client,
-                                          state,
-                                          reason,
-                                          "lobster",
-                                          "2.3.4",
-                                          "5.6.7",
-                                          NULL,
-                                          NULL);
+        status =
+            golioth_ota_report_state(client, state, reason, "main", "2.3.4", "5.6.7", NULL, NULL);
 
         if (status != GOLIOTH_OK)
         {
@@ -326,7 +320,7 @@ static void test_reason_and_state(void)
     golioth_sys_msleep(1000);
 
     /* The log of this null test is used as a trigger by pytest and must always be last */
-    status = golioth_ota_report_state(NULL, 0, 0, "lobster", "2.3.4", "5.6.7", NULL, NULL);
+    status = golioth_ota_report_state(NULL, 0, 0, "main", "2.3.4", "5.6.7", NULL, NULL);
     GLTH_LOGE(TAG, "GOLIOTH_ERR_NULL: %d", status);
 }
 

--- a/tests/hil/tests/ota/test_ota.py
+++ b/tests/hil/tests/ota/test_ota.py
@@ -251,3 +251,13 @@ async def test_reason_and_state(board, device, project, artifacts, cohort):
         )
 
         await trio.sleep(1)
+
+    assert len(events) == GOLIOTH_OTA_REASON_CNT
+
+    # API returns newest-first
+    for i, e in enumerate(reversed(events)):
+        assert e.status == i
+        assert e.eventType == golioth_ota_state[i % GOLIOTH_OTA_STATE_CNT]
+        assert e.packageId == "main"
+        assert e.currentVersion == "2.3.4"
+        assert e.targetVersion == "5.6.7"

--- a/tests/hil/tests/ota/test_ota.py
+++ b/tests/hil/tests/ota/test_ota.py
@@ -5,7 +5,7 @@ import trio
 
 LOGGER = logging.getLogger(__name__)
 
-LOG_FETCH_POLLING_LIMIT = datetime.timedelta(seconds=60)
+EVENT_FETCH_POLLING_LIMIT = datetime.timedelta(seconds=60)
 
 UPDATE_PACKAGE = 'main'
 DUMMY_VER_OLDER = '1.2.2'
@@ -118,35 +118,6 @@ async def verify_component_values(board, info):
     assert None is not await board.wait_for_regex_in_line(f'component.size: {b_info["size"]}', timeout_s=2)
     assert None is not await board.wait_for_regex_in_line(f'component.hash: {b_info["digests"]["sha256"]["digest"]}', timeout_s=2)
 
-def verify_dfu_status_logs(logs):
-    # Filter to only the DFU status-report logs emitted by test_reason_and_state.
-    status_logs = [
-        log for log in logs
-        if log.metadata.get('reasonCode') is not None
-        and log.metadata.get('stateCode') is not None
-        and log.metadata.get('package') == 'lobster'
-    ]
-
-    assert len(status_logs) == len(golioth_ota_reason)
-
-    # Filter received logs by reasonCode
-    by_reason = {}
-    for log in status_logs:
-        reason_code = int(log.metadata['reasonCode'])
-        if reason_code in by_reason:
-            raise AssertionError(f"duplicate reasonCode: {reason_code}")
-        by_reason[reason_code] = log
-
-    # Iterate reason codes and check against filtered log messages
-    for i, r in enumerate(golioth_ota_reason):
-        assert i in by_reason, f"missing reasonCode: {i} ({r})"
-        log = by_reason[i]
-        assert int(log.metadata['stateCode']) == i % GOLIOTH_OTA_STATE_CNT
-        assert log.metadata['state'] == golioth_ota_state[i % GOLIOTH_OTA_STATE_CNT]
-        assert log.metadata['package'] == "lobster"
-        assert log.metadata['version'] == "2.3.4"
-        assert log.metadata['target'] == "5.6.7"
-
 ##### Tests #####
 
 async def test_manifest(artifacts, board, project, cohort):
@@ -212,42 +183,31 @@ async def test_reason_and_state(board, device, project, artifacts, cohort):
 
     await board.wait_for_regex_in_line("GOLIOTH_ERR_NULL: 5", timeout_s=6)
 
-    # Pause to ensure logs propagate to cloud
+    # Pause to ensure OTA events propagate to cloud
 
     await trio.sleep(5)
 
-    # Fetch logs
-
-    log_fetch_start = datetime.datetime.now(datetime.UTC)
-    min_required = GOLIOTH_OTA_REASON_CNT
-    last_validation_error = None
+    event_fetch_start = datetime.datetime.now(datetime.UTC)
 
     while True:
         end = datetime.datetime.now(datetime.UTC)
 
-        logs = await device.get_logs(
-            {
-                "start": start.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "end": end.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "module": "golioth_dfu",
-            }
-        )
+        try:
+            events = await project.ota_events.get(
+                deviceId=device.id,
+                startTime=start,
+                endTime=end,
+                limit=GOLIOTH_OTA_REASON_CNT,
+            )
+        except Exception:
+            events = []
 
-        if len(logs) >= min_required:
-            try:
-                verify_dfu_status_logs(logs)
-                break
-            except AssertionError as e:
-                last_validation_error = e
-                if str(e).startswith("duplicate reasonCode:"):
-                    raise
-                min_required = len(logs) + 1
+        if len(events) >= GOLIOTH_OTA_REASON_CNT:
+            break
 
-        elapsed = datetime.datetime.now(datetime.UTC) - log_fetch_start
-        assert LOG_FETCH_POLLING_LIMIT > elapsed, (
-            f"Timed out after {elapsed.total_seconds():.1f}s waiting for "
-            f"{min_required} golioth_dfu logs"
-            + (f". Last validation error: {last_validation_error}" if last_validation_error else "")
+        assert (
+            EVENT_FETCH_POLLING_LIMIT
+            > datetime.datetime.now(datetime.UTC) - event_fetch_start
         )
 
         await trio.sleep(1)


### PR DESCRIPTION
- Use package name `main` instead of `lobster` for OTA state and reason testing
- Update python-golioth-tools to v0.9.0 which implements OTA events support
- Use OTA events for the OTA state and reason test

The package name was necessary because the OTA events system appears to silently drop updates from packages that are not in the current deployment. This is a change from previous behavior that accepted any string for the package name.

resolves: https://github.com/golioth/firmware-issue-tracker/issues/1026