### PR TITLE
ci: bump all Golioth Docker images to newest

### DIFF
--- a/.github/workflows/ci-coverity.yml
+++ b/.github/workflows/ci-coverity.yml
@@ -10,7 +10,7 @@ jobs:
   coverity:
     runs-on: ubuntu-24.04
     # yamllint disable-line rule:line-length
-    container: golioth/golioth-coverity-base:bda7b71@sha256:fa0cbe0e64a8b3a81a0899e2e57284e661e5ddeef7dac500a22be035c5b21361
+    container: golioth/golioth-coverity-base:ee62f47-sdk-0.17.4@sha256:a301b19ff552b8ec3db88a0bc452186bbee9d15ce6ef4d430530d6b52af9a11a
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/hil-integration-esp-idf.yml
+++ b/.github/workflows/hil-integration-esp-idf.yml
@@ -131,7 +131,7 @@ jobs:
 
     container:
       # yamllint disable-line rule:line-length
-      image: golioth/golioth-hil-base:bda7b71@sha256:9eb8fcac14e734196c5cb29074221c5c3983cc59d8408bcfb4b0c8028a20b142
+      image: golioth/golioth-hil-base:ee62f47@sha256:8b314f3e9207302350d3ca84ca9d28c8a75aebb307eaeae5a742399400dbca57
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil-integration-nsim.yml
+++ b/.github/workflows/hil-integration-nsim.yml
@@ -67,7 +67,7 @@ jobs:
     needs: matrix
     container:
       # yamllint disable-line rule:line-length
-      image: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
+      image: golioth/golioth-zephyr-base:ee62f47-sdk-0.17.4@sha256:a8561b8de5a23f9eb28101734d672e0582328add515ce4b4788428cd126e6e2b
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     name: zephyr-${{ inputs.platform }}-${{ matrix.test }}-test-nsim

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -90,7 +90,7 @@ jobs:
   build:
     name: zephyr-${{ inputs.hil_board }}-build (${{ matrix.test }})
     # yamllint disable-line rule:line-length
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
+    container: golioth/golioth-zephyr-base:ee62f47-sdk-0.17.4@sha256:a8561b8de5a23f9eb28101734d672e0582328add515ce4b4788428cd126e6e2b
     needs: matrix
     strategy:
       fail-fast: false
@@ -194,7 +194,7 @@ jobs:
 
     container:
       # yamllint disable-line rule:line-length
-      image: golioth/golioth-hil-base:bda7b71@sha256:9eb8fcac14e734196c5cb29074221c5c3983cc59d8408bcfb4b0c8028a20b142
+      image: golioth/golioth-hil-base:ee62f47@sha256:8b314f3e9207302350d3ca84ca9d28c8a75aebb307eaeae5a742399400dbca57
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil-sample-esp-idf.yml
+++ b/.github/workflows/hil-sample-esp-idf.yml
@@ -199,7 +199,7 @@ jobs:
 
     container:
       # yamllint disable-line rule:line-length
-      image: golioth/golioth-hil-base:bda7b71@sha256:9eb8fcac14e734196c5cb29074221c5c3983cc59d8408bcfb4b0c8028a20b142
+      image: golioth/golioth-hil-base:ee62f47@sha256:8b314f3e9207302350d3ca84ca9d28c8a75aebb307eaeae5a742399400dbca57
       volumes:
         - /dev:/dev
         - /home/golioth/credentials:/opt/credentials

--- a/.github/workflows/hil-sample-nsim.yml
+++ b/.github/workflows/hil-sample-nsim.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       # yamllint disable-line rule:line-length
-      image: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
+      image: golioth/golioth-zephyr-base:ee62f47-sdk-0.17.4@sha256:a8561b8de5a23f9eb28101734d672e0582328add515ce4b4788428cd126e6e2b
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
       EXTRA_TWISTER_ARGS: ${{ github.event_name == 'pull_request' && '-e nightly' || '' }}

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -87,7 +87,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.matrix.outputs.sample_list) }}
     # yamllint disable-line rule:line-length
-    container: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
+    container: golioth/golioth-zephyr-base:ee62f47-sdk-0.17.4@sha256:a8561b8de5a23f9eb28101734d672e0582328add515ce4b4788428cd126e6e2b
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     runs-on: ubuntu-24.04
@@ -180,7 +180,7 @@ jobs:
 
     container:
       # yamllint disable-line rule:line-length
-      image: golioth/golioth-twister-base:bda7b71@sha256:e2df86f4fc795fd159dc984f1e7bc345983b26efee1090dd9793028c5ff7430d
+      image: golioth/golioth-twister-base:ee62f47-sdk-0.17.4@sha256:435173aace95071ae278f863d14756b27a526f8e2642d0ec916de2f8c5332a34
       env:
         ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
       volumes:

--- a/.github/workflows/misc-locate-twister-samples.yml
+++ b/.github/workflows/misc-locate-twister-samples.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       # yamllint disable-line rule:line-length
-      image: golioth/golioth-zephyr-base:0.17.4-SDK-v0@sha256:4b734cfd4784affb0df6a8d631db267d97bcec7fbfa67783ee85153592acb388
+      image: golioth/golioth-zephyr-base:ee62f47-sdk-0.17.4@sha256:a8561b8de5a23f9eb28101734d672e0582328add515ce4b4788428cd126e6e2b
 
     outputs:
       sample_list: ${{ steps.locate-samples.outputs.sample_list }}


### PR DESCRIPTION
There is nothing special with new versions, it is just a regular bump.