### PR TITLE
Fix  memory leak in golioth_ota_download_components()

### DIFF
--- a/src/coap_blockwise.c
+++ b/src/coap_blockwise.c
@@ -293,7 +293,7 @@ enum golioth_status golioth_blockwise_post(struct golioth_client *client,
     golioth_sys_sem_destroy(ctx.sem);
 
 finish_with_block_buffer:
-    free(ctx.block_buffer);
+    golioth_sys_free(ctx.block_buffer);
 
 finish:
     return status;

--- a/src/net_info.c
+++ b/src/net_info.c
@@ -36,7 +36,7 @@ enum golioth_status golioth_net_info_destroy(struct golioth_net_info *info)
         return GOLIOTH_ERR_NULL;
     }
 
-    free(info);
+    golioth_sys_free(info);
     return GOLIOTH_OK;
 }
 

--- a/src/ota.c
+++ b/src/ota.c
@@ -448,6 +448,7 @@ static void ota_component_download_end_cb_wrapper(struct golioth_client *client,
 
     ctx->end_cb(status, coap_rsp_code, ctx->component, block_idx, ctx->arg);
 
+    /* allocated in golioth_ota_download_component(), freed here */
     golioth_sys_free(ctx);
 }
 
@@ -458,22 +459,36 @@ enum golioth_status golioth_ota_download_component(struct golioth_client *client
                                                    ota_component_download_end_cb end_cb,
                                                    void *arg)
 {
+    /* Allocated here, freed in ota_component_download_end_cb_wrapper() (or the err path below) */
     struct ota_component_blockwise_ctx *ctx =
         golioth_sys_malloc(sizeof(struct ota_component_blockwise_ctx));
+
+    if (ctx == NULL)
+    {
+        return GOLIOTH_ERR_MEM_ALLOC;
+    }
+
     ctx->component = component;
     ctx->block_cb = block_cb;
     ctx->end_cb = end_cb;
     ctx->arg = arg;
 
 
-    return golioth_blockwise_get(client,
-                                 "",
-                                 component->uri,
-                                 GOLIOTH_CONTENT_TYPE_OCTET_STREAM,
-                                 block_idx,
-                                 ota_component_write_cb_wrapper,
-                                 ota_component_download_end_cb_wrapper,
-                                 ctx);
+    enum golioth_status status = golioth_blockwise_get(client,
+                                                       "",
+                                                       component->uri,
+                                                       GOLIOTH_CONTENT_TYPE_OCTET_STREAM,
+                                                       block_idx,
+                                                       ota_component_write_cb_wrapper,
+                                                       ota_component_download_end_cb_wrapper,
+                                                       ctx);
+
+    if (GOLIOTH_OK != status)
+    {
+        golioth_sys_free(ctx);
+    }
+
+    return status;
 }
 
 enum golioth_ota_state golioth_ota_get_state(void)

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -265,7 +265,7 @@ enum golioth_status golioth_rpc_deinit(struct golioth_rpc *grpc)
     }
 
     golioth_coap_client_cancel_observations_by_prefix(grpc->client, GOLIOTH_RPC_PATH_PREFIX);
-    free(grpc);
+    golioth_sys_free(grpc);
     return GOLIOTH_OK;
 }
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -504,7 +504,7 @@ enum golioth_status golioth_settings_deinit(struct golioth_settings *settings)
     }
 
     golioth_coap_client_cancel_observations_by_prefix(settings->client, SETTINGS_PATH_PREFIX);
-    free(settings);
+    golioth_sys_free(settings);
     return GOLIOTH_OK;
 }
 

--- a/tests/hil/tests/ota/test.c
+++ b/tests/hil/tests/ota/test.c
@@ -217,7 +217,8 @@ static void on_end(struct golioth_client *client,
     }
 
 finish:
-    free(bytes_cached_p);
+    /* allocated in test_manifest_get(), freed here */
+    golioth_sys_free(bytes_cached_p);
     golioth_sys_sem_give(manifest_get_cb_sem);
 }
 
@@ -274,6 +275,7 @@ static void test_manifest_get(void)
     }
 
 
+    /* Allocated here, freed in on_end() (or in error path below) */
     size_t *bytes_cached_p = (size_t *) golioth_sys_malloc(sizeof(size_t));
     if (NULL == bytes_cached_p)
     {
@@ -287,6 +289,7 @@ static void test_manifest_get(void)
     if (GOLIOTH_OK != err)
     {
         GLTH_LOGE(TAG, "Failed to get manifest: %d", err);
+        golioth_sys_free(bytes_cached_p);
     }
     else
     {


### PR DESCRIPTION
As reported by @rlinus in #919, the failure path in goliioth_ota_download_components() returns without freeing the allocated context. This PR follows his suggested fix to test that status code and free on failure, as well as checking for NULL after the initial malloc.

A review of treewide golioth_sys_malloc() calls was conducted to ensure memory is freed correctly and a similar leak was fixed in the ota HIL test. Instances where free() was called where golioth_sys_free() should have been called were also fixed, which is a correction of the API use but does not result in any changed behavior.

resolves #919 