### PR TITLE
Add support for the WiFi variant of frdm_rw612

### DIFF
--- a/.github/actions/erase-flash/action.yml
+++ b/.github/actions/erase-flash/action.yml
@@ -1,0 +1,47 @@
+name: Erase flash
+description: Erase flash on the target board after testing
+
+inputs:
+  hil_board:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Erase flash
+      shell: bash
+      env:
+        hil_board: ${{ inputs.hil_board }}
+      run: |
+        source /opt/credentials/runner_env.sh
+        export PATH=$PATH:/opt/SEGGER/JLink
+        SNR_VAR=CI_${hil_board^^}_SNR
+        PORT_VAR=CI_${hil_board^^}_PORT
+        cat <<EOF > erase_frdm_rw612.jlink
+        r
+        h
+        exec EnableEraseAllFlashBanks
+        erase 0x8000000 0x8624000
+        sleep 30
+        r
+        sleep 3
+        q
+        EOF
+
+        if [[ "${hil_board}" == "nrf9160dk" ]] || [[ "${hil_board}" == "nrf52840dk" ]]; then
+          nrfjprog --recover --snr ${!SNR_VAR}
+
+        elif [[ "${hil_board}" == "esp32s3_devkitc" ]]; then
+          esptool.py --port ${!PORT_VAR} erase_flash
+
+        elif [[ "${hil_board}" == "frdm_rw612" ]]; then
+          JLinkExe \
+            -nogui 1 \
+            -if swd \
+            -speed auto \
+            -device RW612 \
+            -CommanderScript erase_frdm_rw612.jlink \
+            -SelectEmuBySN ${!SNR_VAR}
+
+        fi

--- a/.github/workflows/hil-integration-zephyr.yml
+++ b/.github/workflows/hil-integration-zephyr.yml
@@ -255,41 +255,10 @@ jobs:
 
       - name: Erase flash
         if: always()
-        shell: bash
-        env:
+        uses: ./.github/actions/erase-flash
+        with:
           hil_board: ${{ inputs.hil_board }}
-        run: |
-          source /opt/credentials/runner_env.sh
-          export PATH=$PATH:/opt/SEGGER/JLink
-          SNR_VAR=CI_${hil_board^^}_SNR
-          PORT_VAR=CI_${hil_board^^}_PORT
-          cat <<EOF > erase_frdm_rw612.jlink
-          r
-          h
-          exec EnableEraseAllFlashBanks
-          erase 0x8000000 0x8624000
-          sleep 30
-          r
-          sleep 3
-          q
-          EOF
 
-          if [[ "${hil_board}" == "nrf9160dk" ]] || [[ "${hil_board}" == "nrf52840dk" ]]; then
-            nrfjprog --recover --snr ${!SNR_VAR}
-
-          elif [[ "${hil_board}" == "esp32s3_devkitc" ]]; then
-            esptool.py --port ${!PORT_VAR} erase_flash
-
-          elif [[ "${hil_board}" == "frdm_rw612" ]]; then
-            JLinkExe \
-              -nogui 1 \
-              -if swd \
-              -speed auto \
-              -device RW612 \
-              -CommanderScript erase_frdm_rw612.jlink \
-              -SelectEmuBySN ${!SNR_VAR}
-
-          fi
       - name: Power Off USB Hub
         if: always()
         run: python3 /opt/golioth-scripts/usb_hub_power.py off

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -187,6 +187,7 @@ jobs:
       - name: Init and update west
         run: |
           rm -rf zephyr
+          rm -rf twister-out
 
           MANIFEST=${{ inputs.manifest }}
           MANIFEST_TWISTER=${MANIFEST%.yml}-twister.yml
@@ -223,7 +224,6 @@ jobs:
           path: .
       - name: Extract artifacts
         run: |
-          rm -rf twister-out
           tar -xvf test_artifacts_${{ inputs.hil_board }}-${{ matrix.name }}.tar
       - name: Run test
         shell: bash

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Download binary blobs
         if: ${{ inputs.binary_blob }}
         run: |
-          west blobs fetch ${{ inputs.binary_blob }}
+          west blobs fetch ${{ inputs.binary_blob }} --auto-accept
 
       - name: Compile Tests
         run: |

--- a/.github/workflows/hil-sample-zephyr.yml
+++ b/.github/workflows/hil-sample-zephyr.yml
@@ -210,6 +210,12 @@ jobs:
             git+https://github.com/golioth/python-golioth-tools@v0.9.0
       - name: Power On USB Hub
         run: python3 /opt/golioth-scripts/usb_hub_power.py on
+      - name: Erase flash (pre-test)
+        if: ${{ contains(matrix.name, 'fw_update') }}
+        uses: ./modules/lib/golioth-firmware-sdk/.github/actions/erase-flash
+        with:
+          hil_board: ${{ inputs.hil_board }}
+
       - name: Download build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -277,43 +283,12 @@ jobs:
           name: allure-reports-samples-zephyr-${{ inputs.hil_board }}-${{ matrix.name }}
           path: allure-reports
 
-      - name: Erase flash
+      - name: Erase flash (post-test)
         if: always()
-        shell: bash
-        env:
+        uses: ./modules/lib/golioth-firmware-sdk/.github/actions/erase-flash
+        with:
           hil_board: ${{ inputs.hil_board }}
-        run: |
-          source /opt/credentials/runner_env.sh
-          export PATH=$PATH:/opt/SEGGER/JLink
-          SNR_VAR=CI_${hil_board^^}_SNR
-          PORT_VAR=CI_${hil_board^^}_PORT
-          cat <<EOF > erase_frdm_rw612.jlink
-          r
-          h
-          exec EnableEraseAllFlashBanks
-          erase 0x8000000 0x8624000
-          sleep 30
-          r
-          sleep 3
-          q
-          EOF
 
-          if [[ "${hil_board}" == "nrf9160dk" ]] || [[ "${hil_board}" == "nrf52840dk" ]]; then
-            nrfjprog --recover --snr ${!SNR_VAR}
-
-          elif [[ "${hil_board}" == "esp32s3_devkitc" ]]; then
-            esptool.py --port ${!PORT_VAR} erase_flash
-
-          elif [[ "${hil_board}" == "frdm_rw612" ]]; then
-            JLinkExe \
-              -nogui 1 \
-              -if swd \
-              -speed auto \
-              -device RW612 \
-              -CommanderScript erase_frdm_rw612.jlink \
-              -SelectEmuBySN ${!SNR_VAR}
-
-          fi
       - name: Power Off USB Hub
         if: always()
         run: python3 /opt/golioth-scripts/usb_hub_power.py off

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -213,6 +213,7 @@ jobs:
             manifest: .ci-west-zephyr.yml
             extra_twister_args: >-
               --west-flash="--dev-id=${!SNR_VAR}"
+            binary_blob: hal_nxp
             run_tests: true
 
           - hil_board: nrf52840dk

--- a/examples/zephyr/common/net_connect.c
+++ b/examples/zephyr/common/net_connect.c
@@ -60,13 +60,16 @@ void net_connect(void)
         int ret = net_if_up(iface);
         if ((ret < 0) && (ret != -EALREADY))
         {
-            LOG_ERR("Failed to bring up network interface: %d", ret);
+            LOG_ERR("Network link bring up request failed: %d", ret);
             return;
         }
     }
 
     if (IS_ENABLED(CONFIG_GOLIOTH_SAMPLE_DHCP_BIND))
     {
+        LOG_INF("Waiting for link to be up");
+        wait_for_net_event(iface, NET_EVENT_IF_UP);
+
         LOG_INF("Starting DHCP to obtain IP address");
         net_dhcpv4_start(iface);
     }

--- a/examples/zephyr/common/wifi.c
+++ b/examples/zephyr/common/wifi.c
@@ -168,7 +168,7 @@ static void wifi_mgmt_connecting_update(struct wifi_manager_data *wifi_mgmt, boo
     }
 }
 
-static bool wifi_iface_ready(struct wifi_manager_data *wifi_mgmt)
+static bool wifi_iface_get_state(struct wifi_manager_data *wifi_mgmt, enum wifi_iface_state *state)
 {
     struct wifi_iface_status status = {0};
     int err;
@@ -180,14 +180,50 @@ static bool wifi_iface_ready(struct wifi_manager_data *wifi_mgmt)
         return false;
     }
 
-    switch (status.state)
+    *state = status.state;
+    return true;
+}
+
+static bool wifi_iface_ready(struct wifi_manager_data *wifi_mgmt)
+{
+    enum wifi_iface_state state;
+
+    if (!wifi_iface_get_state(wifi_mgmt, &state))
+    {
+        return false;
+    }
+
+    switch (state)
     {
         case WIFI_STATE_INTERFACE_DISABLED:
         case WIFI_STATE_UNKNOWN:
+            LOG_DBG("WiFi iface not ready, state=%d", state);
             return false;
         default:
-            LOG_DBG("WiFi iface not ready, state=%d", status.state);
             return true;
+    }
+}
+
+static bool wifi_connect_in_progress(struct wifi_manager_data *wifi_mgmt)
+{
+    enum wifi_iface_state state;
+
+    if (!wifi_iface_get_state(wifi_mgmt, &state))
+    {
+        return false;
+    }
+
+    switch (state)
+    {
+        case WIFI_STATE_SCANNING:
+        case WIFI_STATE_AUTHENTICATING:
+        case WIFI_STATE_ASSOCIATING:
+        case WIFI_STATE_ASSOCIATED:
+        case WIFI_STATE_4WAY_HANDSHAKE:
+        case WIFI_STATE_GROUP_HANDSHAKE:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -198,6 +234,13 @@ static void wifi_connect(struct wifi_manager_data *wifi_mgmt)
     if (!wifi_iface_ready(wifi_mgmt))
     {
         wifi_event_notify(wifi_mgmt, WIFI_EVENT_DISCONNECTED);
+        return;
+    }
+
+    if (wifi_connect_in_progress(wifi_mgmt))
+    {
+        LOG_DBG("connect already in progress; waiting for it to resolve");
+        wifi_mgmt_connecting_update(wifi_mgmt, true);
         return;
     }
 

--- a/examples/zephyr/fw_update/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/fw_update/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,33 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 examples/zephyr/fw_update \
+#             --sysbuild                                  \
+#             --extra-conf boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+CONFIG_GOLIOTH_SAMPLE_WIFI=y
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_SHELL_STACK_SIZE=2560
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n
+
+CONFIG_ZVFS_POLL_MAX=4

--- a/examples/zephyr/fw_update/pytest/conftest.py
+++ b/examples/zephyr/fw_update/pytest/conftest.py
@@ -1,4 +1,13 @@
 import pytest
+import sys
+import west.configuration
+from pathlib import Path
+from twister_harness.helpers.domains_helper import get_default_domain_name
+
+WEST_TOPDIR = Path(west.configuration.west_dir()).parent
+
+sys.path.insert(0, str(WEST_TOPDIR / 'zephyr' / 'scripts' / 'west_commands'))
+from runners.core import BuildConfiguration
 
 UPDATE_VERSION = '255.8.9'
 
@@ -8,7 +17,14 @@ def anyio_backend():
 
 @pytest.fixture(scope="session")
 async def target_package(request):
-    return request.config.getoption('hil_board')
+    build_dir = Path(request.config.option.build_dir)
+    domains = build_dir / 'domains.yaml'
+    assert domains.exists()
+    app_build_dir = build_dir / get_default_domain_name(domains)
+    build_conf = BuildConfiguration(str(app_build_dir))
+    package_name = build_conf['CONFIG_GOLIOTH_FW_UPDATE_PACKAGE_NAME']
+    assert package_name != ""
+    return package_name
 
 @pytest.fixture(scope="session")
 async def fw_info(target_package):

--- a/examples/zephyr/fw_update/sample.yaml
+++ b/examples/zephyr/fw_update/sample.yaml
@@ -26,3 +26,18 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
+  sample.golioth.fw_update.wifi:
+    harness: pytest
+    sysbuild: true
+    tags:
+      - golioth
+      - socket
+      - goliothd
+    timeout: 720
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+      - CONFIG_GOLIOTH_FW_UPDATE_PACKAGE_NAME="frdm_rw612_wifi"
+    extra_args:
+      - EXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+    platform_allow:
+      - frdm_rw612

--- a/examples/zephyr/hello/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/hello/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,31 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 examples/zephyr/hello --extra-conf boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+CONFIG_GOLIOTH_SAMPLE_WIFI=y
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_SHELL_STACK_SIZE=2560
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n
+
+CONFIG_ZVFS_POLL_MAX=4

--- a/examples/zephyr/hello/sample.yaml
+++ b/examples/zephyr/hello/sample.yaml
@@ -62,6 +62,19 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nucleo_h563zi/stm32h563xx
+  sample.golioth.hello.wifi:
+    harness: pytest
+    tags:
+      - golioth
+      - socket
+      - goliothd
+    timeout: 180
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+    extra_args:
+      - EXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+    platform_allow:
+      - frdm_rw612
   sample.golioth.hello.openthread.buildonly:
     build_only: true
     harness: pytest

--- a/examples/zephyr/lightdb/delete/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/lightdb/delete/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,32 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 examples/zephyr/lightdb/delete \
+#             --extra-conf boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+CONFIG_GOLIOTH_SAMPLE_WIFI=y
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_SHELL_STACK_SIZE=2560
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n
+
+CONFIG_ZVFS_POLL_MAX=4

--- a/examples/zephyr/lightdb/delete/sample.yaml
+++ b/examples/zephyr/lightdb/delete/sample.yaml
@@ -24,3 +24,17 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nucleo_h563zi/stm32h563xx
+  sample.golioth.lightdb_delete.wifi:
+    harness: pytest
+    tags:
+      - golioth
+      - lightdb
+      - socket
+      - goliothd
+    timeout: 180
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+    extra_args:
+      - EXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+    platform_allow:
+      - frdm_rw612

--- a/examples/zephyr/lightdb/get/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/lightdb/get/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,31 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 examples/zephyr/lightdb/get --extra-conf boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+CONFIG_GOLIOTH_SAMPLE_WIFI=y
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_SHELL_STACK_SIZE=2560
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n
+
+CONFIG_ZVFS_POLL_MAX=4

--- a/examples/zephyr/lightdb/get/sample.yaml
+++ b/examples/zephyr/lightdb/get/sample.yaml
@@ -24,3 +24,17 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nucleo_h563zi/stm32h563xx
+  sample.golioth.lightdb_get.wifi:
+    harness: pytest
+    tags:
+      - golioth
+      - lightdb
+      - socket
+      - goliothd
+    timeout: 180
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+    extra_args:
+      - EXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+    platform_allow:
+      - frdm_rw612

--- a/examples/zephyr/lightdb/observe/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/lightdb/observe/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,32 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 examples/zephyr/lightdb/observe \
+#             --extra-conf boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+CONFIG_GOLIOTH_SAMPLE_WIFI=y
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_SHELL_STACK_SIZE=2560
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n
+
+CONFIG_ZVFS_POLL_MAX=4

--- a/examples/zephyr/lightdb/observe/sample.yaml
+++ b/examples/zephyr/lightdb/observe/sample.yaml
@@ -24,3 +24,17 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nucleo_h563zi/stm32h563xx
+  sample.golioth.lightdb_observe.wifi:
+    harness: pytest
+    tags:
+      - golioth
+      - lightdb
+      - socket
+      - goliothd
+    timeout: 180
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+    extra_args:
+      - EXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+    platform_allow:
+      - frdm_rw612

--- a/examples/zephyr/lightdb/set/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/lightdb/set/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,31 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 examples/zephyr/lightdb/set --extra-conf boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+CONFIG_GOLIOTH_SAMPLE_WIFI=y
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_SHELL_STACK_SIZE=2560
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n
+
+CONFIG_ZVFS_POLL_MAX=4

--- a/examples/zephyr/lightdb/set/sample.yaml
+++ b/examples/zephyr/lightdb/set/sample.yaml
@@ -24,3 +24,17 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nucleo_h563zi/stm32h563xx
+  sample.golioth.lightdb_set.wifi:
+    harness: pytest
+    tags:
+      - golioth
+      - lightdb
+      - socket
+      - goliothd
+    timeout: 180
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+    extra_args:
+      - EXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+    platform_allow:
+      - frdm_rw612

--- a/examples/zephyr/logging/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/logging/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,31 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 examples/zephyr/logging --extra-conf boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+CONFIG_GOLIOTH_SAMPLE_WIFI=y
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_SHELL_STACK_SIZE=2560
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n
+
+CONFIG_ZVFS_POLL_MAX=4

--- a/examples/zephyr/logging/sample.yaml
+++ b/examples/zephyr/logging/sample.yaml
@@ -24,3 +24,17 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nucleo_h563zi/stm32h563xx
+  sample.golioth.logging.wifi:
+    harness: pytest
+    tags:
+      - golioth
+      - logger
+      - socket
+      - goliothd
+    timeout: 180
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+    extra_args:
+      - EXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+    platform_allow:
+      - frdm_rw612

--- a/examples/zephyr/rpc/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/rpc/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,31 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 examples/zephyr/rpc --extra-conf boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+CONFIG_GOLIOTH_SAMPLE_WIFI=y
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_SHELL_STACK_SIZE=2560
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n
+
+CONFIG_ZVFS_POLL_MAX=4

--- a/examples/zephyr/rpc/sample.yaml
+++ b/examples/zephyr/rpc/sample.yaml
@@ -23,3 +23,16 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nucleo_h563zi/stm32h563xx
+  sample.golioth.rpc.wifi:
+    harness: pytest
+    tags:
+      - golioth
+      - socket
+      - goliothd
+    timeout: 180
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+    extra_args:
+      - EXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+    platform_allow:
+      - frdm_rw612

--- a/examples/zephyr/settings/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/settings/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,31 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 examples/zephyr/settings --extra-conf boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+CONFIG_GOLIOTH_SAMPLE_WIFI=y
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_SHELL_STACK_SIZE=2560
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n
+
+CONFIG_ZVFS_POLL_MAX=4

--- a/examples/zephyr/settings/sample.yaml
+++ b/examples/zephyr/settings/sample.yaml
@@ -23,3 +23,16 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nucleo_h563zi/stm32h563xx
+  sample.golioth.settings.wifi:
+    harness: pytest
+    tags:
+      - golioth
+      - socket
+      - goliothd
+    timeout: 180
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+    extra_args:
+      - EXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+    platform_allow:
+      - frdm_rw612

--- a/examples/zephyr/stream/boards/frdm_rw612_wifi.conf
+++ b/examples/zephyr/stream/boards/frdm_rw612_wifi.conf
@@ -1,0 +1,31 @@
+# Extra configuration file for using NXP frdm_rw612 with WiFi instead of Ethernet
+#   To use, add as extra conf file:
+#   west build -p -b frdm_rw612 examples/zephyr/stream --extra-conf boards/frdm_rw612_wifi.conf
+#
+CONFIG_WIFI=y
+CONFIG_WIFI_NXP=y
+CONFIG_GOLIOTH_SAMPLE_WIFI=y
+
+# Runtime provisioning for WiFi credentials
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_SHELL_STACK_SIZE=2560
+
+# Wifi Configuration
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_BUF_RX_COUNT=40
+CONFIG_NET_BUF_TX_COUNT=40
+CONFIG_NET_BUF_DATA_SIZE=1744
+
+# Handle WiFi Networks with Multiple DNS Servers
+CONFIG_DNS_RESOLVER_MAX_SERVERS=3
+
+# Disable Ethernet
+CONFIG_ETH_NXP_ENET=n
+CONFIG_PHY_MICROCHIP_KSZ8081=n
+CONFIG_NET_CONFIG_AUTO_INIT=n
+CONFIG_NET_CONFIG_NEED_IPV4=n
+
+CONFIG_ZVFS_POLL_MAX=4

--- a/examples/zephyr/stream/sample.yaml
+++ b/examples/zephyr/stream/sample.yaml
@@ -23,3 +23,16 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nucleo_h563zi/stm32h563xx
+  sample.golioth.stream.wifi:
+    harness: pytest
+    tags:
+      - golioth
+      - socket
+      - goliothd
+    timeout: 180
+    extra_configs:
+      - CONFIG_GOLIOTH_SAMPLE_TWISTER_TEST=y
+    extra_args:
+      - EXTRA_CONF_FILE=boards/frdm_rw612_wifi.conf
+    platform_allow:
+      - frdm_rw612


### PR DESCRIPTION
Add optional conf files for using frdm_rw612 with WiFi (instead of Ethernet). Add tests to all samples for this variant.

This PR also adds an erase step before the fw_update test runs. This is necessary to ensure the mcuboot flags from a previous (failed) run are wiped out before starting a new test.

resolves https://github.com/golioth/firmware-issue-tracker/issues/1038