### PR TITLE
coap_client: clean up leftover references to the sync API

### DIFF
--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -155,12 +155,10 @@ struct golioth_coap_request_msg
         struct golioth_coap_observe_params observe;
     };
     /// Time (since boot) in milliseconds when request is no longer valid.
-    /// This is checked when reqeusts are pulled out of the queue and when responses are received.
-    /// Primarily intended to be used for synchronous requests, to avoid blocking forever.
+    /// This is checked when requests are pulled out of the queue and when responses are received.
     uint64_t ageout_ms;
     bool got_response;
     bool got_nack;
-    enum golioth_status *status;
 };
 
 struct golioth_coap_observe_info

--- a/src/coap_client.h
+++ b/src/coap_client.h
@@ -9,10 +9,6 @@
 #include <golioth/config.h>
 #include <golioth/golioth_sys.h>
 
-/// Event group bits for request_complete_event
-#define RESPONSE_RECEIVED_EVENT_BIT (1 << 0)
-#define RESPONSE_TIMEOUT_EVENT_BIT (1 << 1)
-
 #define GOLIOTH_COAP_TOKEN_LEN 8
 
 #define BLOCKSIZE_TO_SZX(blockSize) \

--- a/src/coap_client_libcoap.c
+++ b/src/coap_client_libcoap.c
@@ -109,11 +109,6 @@ static coap_response_t coap_response_handler(coap_session_t *session,
 
     if (req)
     {
-        if (req->status)
-        {
-            *req->status = status;
-        }
-
         if (req->type == GOLIOTH_COAP_REQUEST_EMPTY)
         {
             GLTH_LOGD(TAG,


### PR DESCRIPTION
Clean up a few references that should have been removed when the sync API was removed.